### PR TITLE
Remove "skip-go-installation" because it was removed from the action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,5 +24,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          skip-go-installation: true
           args: --timeout=5m


### PR DESCRIPTION
From the compatibility on the action page
> v3.0.0+ requires explicit setup-go installation step prior to using this action: uses: actions/setup-go@v3. The skip-go-installation option has been removed.