### PR TITLE
Bug/id generation

### DIFF
--- a/id.go
+++ b/id.go
@@ -3,16 +3,21 @@ package surrealdb
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 )
 
+var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
+var randLock sync.Mutex
+
 func xid(length int) string {
 	// Generate a new seed
-	rand.Seed(time.Now().UnixNano())
 	// Create a random byte slice
 	b := make([]byte, length)
 	// Fill the byte slice with data
-	rand.Read(b) //nolint:gosec
+	randLock.Lock()
+	randSource.Read(b) //nolint:gosec
+	randLock.Unlock()
 	// Return the byte slice as a string
 	return fmt.Sprintf("%x", b)[:length]
 }

--- a/id.go
+++ b/id.go
@@ -7,8 +7,10 @@ import (
 	"time"
 )
 
-var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
-var randSourceLock sync.Mutex
+var (
+	randSource     = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randSourceLock sync.Mutex
+)
 
 func xid(length int) string {
 	// Create a random byte slice

--- a/id.go
+++ b/id.go
@@ -8,16 +8,15 @@ import (
 )
 
 var randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
-var randLock sync.Mutex
+var randSourceLock sync.Mutex
 
 func xid(length int) string {
-	// Generate a new seed
 	// Create a random byte slice
 	b := make([]byte, length)
 	// Fill the byte slice with data
-	randLock.Lock()
-	randSource.Read(b) //nolint:gosec
-	randLock.Unlock()
+	randSourceLock.Lock()
+	randSource.Read(b)
+	randSourceLock.Unlock()
 	// Return the byte slice as a string
 	return fmt.Sprintf("%x", b)[:length]
 }


### PR DESCRIPTION
When testing a with a large amount of concurrent requests for my previous PR I noticed id collisions were very frequent.
I believe this was happening because if 2 ids are generated at the same time they can get the same seed resulting in their IDs being the same. This PR changes the id generation to just set the seed once and use our own random number source instead of the library default.

We need a Mutex here because random sources are not concurrency safe, Internally `rand.Read` also uses a Mutex.

Another solution could be to just not set the seed every time we generate an ID.