### PR TITLE
create WithTimeout func to set timeout

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"reflect"
 
@@ -24,12 +25,21 @@ type DB struct {
 }
 
 // SurrealDBOption is a struct that holds options for the SurrealDB client.
-type SurrealDBOption struct {
+type Option struct {
 	WsOption websocket.Option
 }
 
+func WithTimeout(timeout time.Duration) Option {
+	return Option{
+		WsOption: func(ws *websocket.WebSocket) error {
+			ws.Timeout = timeout
+			return nil
+		},
+	}
+}
+
 // New creates a new SurrealDB client.
-func New(url string, options ...SurrealDBOption) (*DB, error) {
+func New(url string, options ...Option) (*DB, error) {
 	wsOptions := make([]websocket.Option, 0)
 	for _, option := range options {
 		if option.WsOption != nil {

--- a/db.go
+++ b/db.go
@@ -24,7 +24,7 @@ type DB struct {
 	ws *websocket.WebSocket
 }
 
-// SurrealDBOption is a struct that holds options for the SurrealDB client.
+// Option is a struct that holds options for the SurrealDB client.
 type Option struct {
 	WsOption websocket.Option
 }

--- a/db.go
+++ b/db.go
@@ -29,6 +29,7 @@ type Option struct {
 	WsOption websocket.Option
 }
 
+// WithTimeout sets the timeout for requests, default timeout is 30 seconds
 func WithTimeout(timeout time.Duration) Option {
 	return Option{
 		WsOption: func(ws *websocket.WebSocket) error {

--- a/db.go
+++ b/db.go
@@ -39,6 +39,16 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
+// UseWriteCompression enables or disables write compression for internal websocket client
+func UseWriteCompression(useWriteCompression bool) Option {
+	return Option{
+		WsOption: func(ws *websocket.WebSocket) error {
+			ws.Conn.EnableWriteCompression(useWriteCompression)
+			return nil
+		},
+	}
+}
+
 // New creates a new SurrealDB client.
 func New(url string, options ...Option) (*DB, error) {
 	wsOptions := make([]websocket.Option, 0)

--- a/db_test.go
+++ b/db_test.go
@@ -27,7 +27,7 @@ type testUser struct {
 
 // getOptions returns a list of options to be used when creating a new websocket connection
 func getOptions() (options []surrealdb.Option) {
-	options = append(options, surrealdb.WithWriteCompression(true), surrealdb.WithTimeout(20*time.Second))
+	options = append(options, surrealdb.UseWriteCompression(true), surrealdb.WithTimeout(20*time.Second))
 	return
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -15,7 +15,7 @@ import (
 type SurrealDBTestSuite struct {
 	suite.Suite
 	db      *surrealdb.DB
-	options []surrealdb.SurrealDBOption
+	options []surrealdb.Option
 }
 
 // a simple user struct for testing
@@ -27,14 +27,14 @@ type testUser struct {
 }
 
 // getOptions returns a list of options to be used when creating a new websocket connection
-func getOptions() (options []surrealdb.SurrealDBOption) {
-	// Set option to timeout after 20 seconds.
-	optionfunc := func(ws *websocket.WebSocket) error {
-		ws.Timeout = time.Duration(20) * time.Second
-		ws.Conn.EnableWriteCompression(true)
-		return nil
+func getOptions() (options []surrealdb.Option) {
+	optWriteCompression := surrealdb.Option{
+		WsOption: func(ws *websocket.WebSocket) error {
+			ws.Conn.EnableWriteCompression(true)
+			return nil
+		},
 	}
-	options = append(options, surrealdb.SurrealDBOption{WsOption: optionfunc})
+	options = append(options, optWriteCompression, surrealdb.WithTimeout(20*time.Second))
 	return
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/surrealdb/surrealdb.go"
-	"github.com/surrealdb/surrealdb.go/internal/websocket"
 )
 
 // TestDBSuite is a test s for the DB struct
@@ -28,13 +27,7 @@ type testUser struct {
 
 // getOptions returns a list of options to be used when creating a new websocket connection
 func getOptions() (options []surrealdb.Option) {
-	optWriteCompression := surrealdb.Option{
-		WsOption: func(ws *websocket.WebSocket) error {
-			ws.Conn.EnableWriteCompression(true)
-			return nil
-		},
-	}
-	options = append(options, optWriteCompression, surrealdb.WithTimeout(20*time.Second))
+	options = append(options, surrealdb.WithWriteCompression(true), surrealdb.WithTimeout(20*time.Second))
 	return
 }
 


### PR DESCRIPTION
this creates a new WithTimeout function and removes the redundant surrealdb prefix from the option type.

Previously the timeout was unable to be set because websocket was an internal package. packages under the internal directory can not be imported by other modules and as a result I do not think you can create your own option function to set the timeout.