### PR TITLE
Add function to check if error is about duplicate fields on an unique index

### DIFF
--- a/db.go
+++ b/db.go
@@ -243,7 +243,7 @@ func (db *DB) Select(what string) (interface{}, error) {
 	return db.send("select", what)
 }
 
-// Creates a table or record in the database like a POST request.
+// Create a table or record in the database like a POST request.
 func (db *DB) Create(thing string, data interface{}) (interface{}, error) {
 	return db.send("create", thing, data)
 }

--- a/db.go
+++ b/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"reflect"
+	"regexp"
 
 	"github.com/surrealdb/surrealdb.go/pkg/websocket"
 )
@@ -318,4 +319,12 @@ func isSlice(possibleSlice interface{}) bool {
 	}
 
 	return slice
+}
+
+func IsDuplicateUniqueIdx(err error) bool {
+	if err == nil {
+		return false
+	}
+	matches, _ := regexp.MatchString(`Database index \[.*] already contains \[.*]`, err.Error())
+	return matches
 }


### PR DESCRIPTION
Just as the `os` module provides users with the `os.IsNotExist` function to test if the error was generated by trying to open a non existent file, regardless of its name, this commit adds the same functionality to check if the error comes from trying to insert data to a table with an unique index.

P.S. Also, minor typo fixed in a comment.