### PR TITLE
Add function to check error on unique index.

### DIFF
--- a/db.go
+++ b/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"reflect"
+	"regexp"
 
 	"github.com/surrealdb/surrealdb.go/pkg/websocket"
 )
@@ -318,4 +319,16 @@ func isSlice(possibleSlice interface{}) bool {
 	}
 
 	return slice
+}
+
+// IsDuplicateUniqueIdx returns if the error was caused by
+// trying to create a record with a field that is duplicated
+// in an unique index. This function will return false if the
+// error was caused by a duplicated ID.
+func IsDuplicateUniqueIdx(err error) bool {
+	if err == nil {
+		return false
+	}
+	match, _ := regexp.MatchString(`Database index .* already contains .*, with record .*`, err.Error())
+	return match
 }

--- a/db.go
+++ b/db.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"reflect"
 	"regexp"
 
@@ -321,10 +320,9 @@ func isSlice(possibleSlice interface{}) bool {
 	return slice
 }
 
-// IsDuplicateUniqueIdx returns if the error was caused by
+// IsDuplicateUniqueIdx returns true if the error was caused by
 // trying to create a record with a field that is duplicated
-// in an unique index. This function will return false if the
-// error was caused by a duplicated ID.
+// in an unique index.
 func IsDuplicateUniqueIdx(err error) bool {
 	if err == nil {
 		return false


### PR DESCRIPTION
Just as the `os` module provides users with the `os.IsNotExist` function to test if the error was generated by trying to open a non existent file, regardless of its name, this commit adds the same functionality to check if the error comes from trying to insert data to a table with an unique index. This example, which is in the test generated for the function, shows its behavior:

```go
...
err1 := errors.New("sending request failed for method 'create': There was a problem with the database: Database index `userNameIdx` already contains 'Mark', with record `user:⟨2⟩`")
err2 := errors.New("sending request failed for method 'create': There was a problem with the database: Database index \"''``\" already contains '\\', with record `user:⟨{ foo = []}⟩`")
err3 := errors.New("sending request failed for method 'create': There was a problem with the database: Database index `userNameIdx` THIS MUST NOT PASS, with record `user:⟨2⟩`")
err4 := errors.New(" Database index `uniqueBlob` already contains { date: 'today', location: 'London' }, with record `foo:2`")
err5 := errors.New(" database index `uniqueBlob` already contains { date: 'today', location: 'London' }, with record `foo:2`")
err6 := errors.New("Database record `foo:1` already exists")

fmt.Println(IsDuplicateUniqueIdx(err1))
fmt.Println(IsDuplicateUniqueIdx(err2))
fmt.Println(IsDuplicateUniqueIdx(err3))
fmt.Println(IsDuplicateUniqueIdx(err4))
fmt.Println(IsDuplicateUniqueIdx(err5))
fmt.Println(IsDuplicateUniqueIdx(err6))
...
```

Will print:

```
true
true
false
true
false
false
```