### PR TITLE
#82 Add native insert/bulk insert support via endpoint

### DIFF
--- a/db.go
+++ b/db.go
@@ -268,6 +268,11 @@ func (db *DB) Delete(what string) (interface{}, error) {
 	return db.send("delete", what)
 }
 
+// Insert a table or a row from the database like a POST request.
+func (db *DB) Insert(what string, data interface{}) (interface{}, error) {
+	return db.send("insert", what, data)
+}
+
 // --------------------------------------------------
 // Private methods
 // --------------------------------------------------
@@ -292,6 +297,8 @@ func (db *DB) send(method string, params ...interface{}) (interface{}, error) {
 	case "change":
 		return db.resp(method, params, resp)
 	case "modify":
+		return db.resp(method, params, resp)
+	case "insert":
 		return db.resp(method, params, resp)
 	default:
 		return resp, nil

--- a/db_test.go
+++ b/db_test.go
@@ -126,6 +126,66 @@ func (s *SurrealDBTestSuite) TestDelete() {
 	s.Require().NoError(err)
 }
 
+func (s *SurrealDBTestSuite) TestInsert() {
+
+	s.Run("raw map works", func() {
+		userData, err := s.db.Insert("user", map[string]interface{}{
+			"username": "johnny",
+			"password": "123",
+		})
+		s.Require().NoError(err)
+
+		// unmarshal the data into a user struct
+		var user []testUser
+		err = surrealdb.Unmarshal(userData, &user)
+		s.Require().NoError(err)
+
+		s.Equal("johnny", user[0].Username)
+		s.Equal("123", user[0].Password)
+	})
+
+	s.Run("Single insert works", func() {
+		userData, err := s.db.Insert("user", testUser{
+			Username: "johnny",
+			Password: "123",
+		})
+		s.Require().NoError(err)
+
+		// unmarshal the data into a user struct
+		var user []testUser
+		err = surrealdb.Unmarshal(userData, &user)
+		s.Require().NoError(err)
+
+		s.Equal("johnny", user[0].Username)
+		s.Equal("123", user[0].Password)
+	})
+
+	s.Run("Multiple insert works", func() {
+		var userInsert []testUser
+		userInsert = append(userInsert, testUser{
+			Username: "johnny1",
+			Password: "123",
+		})
+		userInsert = append(userInsert, testUser{
+			Username: "johnny2",
+			Password: "123",
+		})
+		userData, err := s.db.Insert("user", userInsert)
+		s.Require().NoError(err)
+
+		// unmarshal the data into a user struct
+		var users []testUser
+		err = surrealdb.Unmarshal(userData, &users)
+		s.Require().NoError(err)
+		s.Len(users, 2)
+
+		assertContains(s, users, func(user testUser) bool {
+			return user == users[0] ||
+				user == users[1]
+		})
+	})
+}
+
 func (s *SurrealDBTestSuite) TestCreate() {
 	s.Run("raw map works", func() {
 		userData, err := s.db.Create("users", map[string]interface{}{

--- a/db_test.go
+++ b/db_test.go
@@ -127,7 +127,6 @@ func (s *SurrealDBTestSuite) TestDelete() {
 }
 
 func (s *SurrealDBTestSuite) TestInsert() {
-
 	s.Run("raw map works", func() {
 		userData, err := s.db.Insert("user", map[string]interface{}{
 			"username": "johnny",
@@ -161,12 +160,11 @@ func (s *SurrealDBTestSuite) TestInsert() {
 	})
 
 	s.Run("Multiple insert works", func() {
-		var userInsert []testUser
+		userInsert := make([]testUser, 0)
 		userInsert = append(userInsert, testUser{
 			Username: "johnny1",
 			Password: "123",
-		})
-		userInsert = append(userInsert, testUser{
+		}, testUser{
 			Username: "johnny2",
 			Password: "123",
 		})


### PR DESCRIPTION
This PR is to address issue #82 to add insert support in the library. 
It supports raw data, single insert and bulk insert in the same call. I have added the tests as well and it works fine.

Please let me know if there is something I am missing or something I am doing wrong. Looking forward to getting it merged.

Would really appreciate if someone can explain how to pass the automated tests carried out on github