### PR TITLE
Change db from release to nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
       - name: Start SurrealDB
-        run: docker run -it -d --rm --name surrealdb -p 8000:8000 surrealdb/surrealdb start -u root -p root
+        run: docker run -it -d --rm --name surrealdb -p 8000:8000 surrealdb/surrealdb:nightly start -u root -p root
       - name: Test
         run: go test -v -cover ./...
         env:


### PR DESCRIPTION
Driver is currently tested against latest release.
This prevents us from acessing new features.
Instead use nightly.