### PR TITLE
Refactor SmartUnmarshal

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,22 +1,10 @@
 package surrealdb
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 
-	"reflect"
-
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/websocket"
-)
-
-const statusOK = "OK"
-
-var (
-	InvalidResponse = errors.New("invalid SurrealDB response") //nolint:stylecheck
-	ErrQuery        = errors.New("error occurred processing the SurrealDB query")
-	ErrNoRow        = errors.New("error no row")
 )
 
 // DB is a client for the SurrealDB database that holds are websocket connection.
@@ -27,174 +15,6 @@ type DB struct {
 // New creates a new SurrealDB client.
 func New(url string, ws websocket.WebSocket) (*DB, error) {
 	return &DB{ws}, nil
-}
-
-// Unmarshal loads a SurrealDB response into a struct.
-func Unmarshal(data, v interface{}) error {
-	var jsonBytes []byte
-	var err error
-	if isSlice(v) {
-		assertedData, ok := data.([]interface{})
-		if !ok {
-			return fmt.Errorf("failed to deserialise response to slice: %w", InvalidResponse)
-		}
-		jsonBytes, err = json.Marshal(assertedData)
-		if err != nil {
-			return fmt.Errorf("failed to deserialise response '%+v' to slice: %w", assertedData, InvalidResponse)
-		}
-	} else {
-		jsonBytes, err = json.Marshal(data)
-		if err != nil {
-			return fmt.Errorf("failed to deserialise response '%+v' to object: %w", data, err)
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(jsonBytes, v)
-	if err != nil {
-		return fmt.Errorf("failed unmarshaling jsonBytes '%+v': %w", jsonBytes, err)
-	}
-	return nil
-}
-
-// UnmarshalRaw loads a raw SurrealQL response returned by Query into a struct. Queries that return with results will
-// return ok = true, and queries that return with no results will return ok = false.
-func UnmarshalRaw(rawData, v interface{}) (ok bool, err error) {
-	var data []interface{}
-	if data, ok = rawData.([]interface{}); !ok {
-		return false, fmt.Errorf("failed raw unmarshaling to interface slice: %w", InvalidResponse)
-	}
-
-	var responseObj map[string]interface{}
-	if responseObj, ok = data[0].(map[string]interface{}); !ok {
-		return false, fmt.Errorf("failed mapping to response object: %w", InvalidResponse)
-	}
-
-	var status string
-	if status, ok = responseObj["status"].(string); !ok {
-		return false, fmt.Errorf("failed retrieving status: %w", InvalidResponse)
-	}
-	if status != statusOK {
-		return false, fmt.Errorf("status was not ok: %w", ErrQuery)
-	}
-
-	result := responseObj["result"]
-	if len(result.([]interface{})) == 0 {
-		return false, nil
-	}
-	err = Unmarshal(result, v)
-	if err != nil {
-		return false, fmt.Errorf("failed to unmarshal: %w", err)
-	}
-
-	return true, nil
-}
-
-// Used for RawQuery Unmarshaling
-type RawQuery[I any] struct {
-	Status string `json:"status"`
-	Time   string `json:"time"`
-	Result []I    `json:"result"`
-	Detail string `json:"detail"`
-}
-
-// SmartUnmarshal using generics for return desired type.
-// Supports both raw and normal queries.
-func SmartUnmarshal[I any](respond interface{}, wrapperError error) (outputs []I, err error) {
-	if wrapperError != nil {
-		return outputs, wrapperError
-	}
-	// Handle delete
-	if respond == nil {
-		return outputs, nil
-	}
-	data, err := json.Marshal(respond)
-	if err != nil {
-		return outputs, err
-	}
-	// Needed for checking fields
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if _, isArr := respond.([]interface{}); !isArr {
-		// Non Arr Normal
-		var output I
-		err = decoder.Decode(&output)
-		if err == nil {
-			outputs = append(outputs, output)
-		}
-	} else {
-		// Arr Normal
-		if err = decoder.Decode(&outputs); err != nil {
-			// Arr Raw
-			var rawArr []RawQuery[I]
-			if err = json.Unmarshal(data, &rawArr); err == nil {
-				outputs = make([]I, 0)
-				for _, raw := range rawArr {
-					if raw.Status != statusOK {
-						err = errors.New(err.Error() + fmt.Sprintf("%s: %s\n", raw.Status, raw.Detail))
-					} else {
-						outputs = append(outputs, raw.Result...)
-					}
-				}
-			}
-		}
-	}
-	return outputs, err
-}
-
-// Used for define table name, it has no value.
-type Basemodel struct{}
-
-// Smart Marshal Errors
-var (
-	ErrNotStruct    = errors.New("data is not struct")
-	ErrNotValidFunc = errors.New("invalid function")
-)
-
-// Smartmarshal can be used with all DB methods with generics and type safety.
-// This handles errors and can use any struct tag with `BaseModel` type.
-// Warning: "ID" field is case sensitive and expect string.
-// Upon failure, the following will happen
-// 1. If there are some ID on struct it will fill the table with the ID
-// 2. If there are struct tags of the type `Basemodel`, it will use those values instead
-// 3. If everything above fails or the IDs do not exist, SmartUnmarshal will use the struct name as the table name.
-func SmartMarshal[I any](inputfunc interface{}, data I) (output interface{}, err error) {
-	var table string
-	datatype := reflect.TypeOf(data)
-	datavalue := reflect.ValueOf(data)
-	if datatype.Kind() == reflect.Pointer {
-		datatype = datatype.Elem()
-		datavalue = datavalue.Elem()
-	}
-	if datatype.Kind() == reflect.Struct {
-		if _, ok := datavalue.Field(0).Interface().(Basemodel); ok {
-			if temptable, ok := datatype.Field(0).Tag.Lookup("table"); ok {
-				table = temptable
-			} else {
-				table = reflect.TypeOf(data).Name()
-			}
-		}
-		if id, ok := datatype.FieldByName("ID"); ok {
-			if id.Type.Kind() == reflect.String {
-				if str, ok := datavalue.FieldByName("ID").Interface().(string); ok {
-					if str != "" {
-						table = str
-					}
-				}
-			}
-		}
-	} else {
-		return nil, ErrNotStruct
-	}
-	if function, ok := inputfunc.(func(thing string, data interface{}) (interface{}, error)); ok {
-		return function(table, data)
-	}
-	if function, ok := inputfunc.(func(thing string) (interface{}, error)); ok {
-		return function(table)
-	}
-	return nil, ErrNotValidFunc
 }
 
 // --------------------------------------------------
@@ -324,21 +144,7 @@ func (db *DB) send(method string, params ...interface{}) (interface{}, error) {
 // resp is a helper method for parsing the response from a query.
 func (db *DB) resp(_ string, _ []interface{}, res interface{}) (interface{}, error) {
 	if res == nil {
-		return nil, ErrNoRow
+		return nil, constants.ErrNoRow
 	}
 	return res, nil
-}
-
-func isSlice(possibleSlice interface{}) bool {
-	slice := false
-
-	switch v := possibleSlice.(type) { //nolint:gocritic
-	default:
-		res := fmt.Sprintf("%s", v)
-		if res == "[]" || res == "&[]" || res == "*[]" {
-			slice = true
-		}
-	}
-
-	return slice
 }

--- a/db.go
+++ b/db.go
@@ -133,7 +133,7 @@ func SmartUnmarshal[I any](respond interface{}, wrapperError error) (outputs []I
 				outputs = make([]I, 0)
 				for _, raw := range rawArr {
 					if raw.Status != statusOK {
-						err = errors.Join(err, fmt.Errorf("%s: %s", raw.Status, raw.Detail))
+						err = errors.New(err.Error() + fmt.Sprintf("%s: %s\n", raw.Status, raw.Detail))
 					} else {
 						outputs = append(outputs, raw.Result...)
 					}

--- a/db_test.go
+++ b/db_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	gorilla "github.com/surrealdb/surrealdb.go/pkg/gorilla"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/marshal"
 	"github.com/surrealdb/surrealdb.go/pkg/websocket"
 )
 
@@ -27,10 +29,10 @@ type SurrealDBTestSuite struct {
 
 // a simple user struct for testing
 type testUser struct {
-	surrealdb.Basemodel `table:"test"`
-	Username            string `json:"username,omitempty"`
-	Password            string `json:"password,omitempty"`
-	ID                  string `json:"id,omitempty"`
+	marshal.Basemodel `table:"test"`
+	Username          string `json:"username,omitempty"`
+	Password          string `json:"password,omitempty"`
+	ID                string `json:"id,omitempty"`
 }
 
 func TestSurrealDBSuite(t *testing.T) {
@@ -122,7 +124,7 @@ func (s *SurrealDBTestSuite) TestDelete() {
 
 	// unmarshal the data into a user struct
 	var user []testUser
-	err = surrealdb.Unmarshal(userData, &user)
+	err = marshal.Unmarshal(userData, &user)
 	s.Require().NoError(err)
 
 	// Delete the users...
@@ -140,7 +142,7 @@ func (s *SurrealDBTestSuite) TestInsert() {
 
 		// unmarshal the data into a user struct
 		var user []testUser
-		err = surrealdb.Unmarshal(userData, &user)
+		err = marshal.Unmarshal(userData, &user)
 		s.Require().NoError(err)
 
 		s.Equal("johnny", user[0].Username)
@@ -156,7 +158,7 @@ func (s *SurrealDBTestSuite) TestInsert() {
 
 		// unmarshal the data into a user struct
 		var user []testUser
-		err = surrealdb.Unmarshal(userData, &user)
+		err = marshal.Unmarshal(userData, &user)
 		s.Require().NoError(err)
 
 		s.Equal("johnny", user[0].Username)
@@ -177,11 +179,11 @@ func (s *SurrealDBTestSuite) TestInsert() {
 
 		// unmarshal the data into a user struct
 		var users []testUser
-		err = surrealdb.Unmarshal(userData, &users)
+		err = marshal.Unmarshal(userData, &users)
 		s.Require().NoError(err)
 		s.Len(users, 2)
 
-		assertContains[testUser](s, users, func(user testUser) bool {
+		assertContains(s, users, func(user testUser) bool {
 			return s.Contains(users, user)
 		})
 	})
@@ -197,7 +199,7 @@ func (s *SurrealDBTestSuite) TestCreate() {
 
 		// unmarshal the data into a user struct
 		var userSlice []testUser
-		err = surrealdb.Unmarshal(userData, &userSlice)
+		err = marshal.Unmarshal(userData, &userSlice)
 		s.Require().NoError(err)
 		s.Len(userSlice, 1)
 
@@ -214,7 +216,7 @@ func (s *SurrealDBTestSuite) TestCreate() {
 
 		// unmarshal the data into a user struct
 		var userSlice []testUser
-		err = surrealdb.Unmarshal(userData, &userSlice)
+		err = marshal.Unmarshal(userData, &userSlice)
 		s.Require().NoError(err)
 		s.Len(userSlice, 1)
 
@@ -238,7 +240,7 @@ func (s *SurrealDBTestSuite) TestCreate() {
 
 		// unmarshal the data into a user struct
 		var users []testUser
-		err = surrealdb.Unmarshal(userData, &users)
+		err = marshal.Unmarshal(userData, &users)
 		s.Require().NoError(err)
 
 		assertContains(s, users, func(user testUser) bool {
@@ -255,7 +257,7 @@ func (s *SurrealDBTestSuite) TestSelect() {
 	s.Require().NoError(err)
 	s.NotEmpty(createdUsers)
 	var createdUsersUnmarshalled []testUser
-	s.Require().NoError(surrealdb.Unmarshal(createdUsers, &createdUsersUnmarshalled))
+	s.Require().NoError(marshal.Unmarshal(createdUsers, &createdUsersUnmarshalled))
 	s.NotEmpty(createdUsersUnmarshalled)
 	s.NotEmpty(createdUsersUnmarshalled[0].ID, "The ID should have been set by the database")
 
@@ -265,7 +267,7 @@ func (s *SurrealDBTestSuite) TestSelect() {
 
 		// unmarshal the data into a user slice
 		var users []testUser
-		err = surrealdb.Unmarshal(userData, &users)
+		err = marshal.Unmarshal(userData, &users)
 		s.NoError(err)
 		matching := assertContains(s, users, func(item testUser) bool {
 			return item.Username == "johnnyjohn"
@@ -279,7 +281,7 @@ func (s *SurrealDBTestSuite) TestSelect() {
 
 		// unmarshal the data into a user struct
 		var user testUser
-		err = surrealdb.Unmarshal(userData, &user)
+		err = marshal.Unmarshal(userData, &user)
 		s.Require().NoError(err)
 
 		s.Equal("johnnyjohn", user.Username)
@@ -300,7 +302,7 @@ func (s *SurrealDBTestSuite) TestUpdate() {
 		createdUser, err := s.db.Create("users", v)
 		s.Require().NoError(err)
 		var tempUserArr []testUser
-		err = surrealdb.Unmarshal(createdUser, &tempUserArr)
+		err = marshal.Unmarshal(createdUser, &tempUserArr)
 		s.Require().NoError(err)
 		createdUsers = append(createdUsers, tempUserArr...)
 	}
@@ -313,7 +315,7 @@ func (s *SurrealDBTestSuite) TestUpdate() {
 
 	// unmarshal the data into a user struct
 	var updatedUser testUser
-	err = surrealdb.Unmarshal(UpdatedUserRaw, &updatedUser)
+	err = marshal.Unmarshal(UpdatedUserRaw, &updatedUser)
 	s.Require().NoError(err)
 
 	// Check if password changes
@@ -325,7 +327,7 @@ func (s *SurrealDBTestSuite) TestUpdate() {
 
 	// unmarshal the data into a user struct
 	var controlUser testUser
-	err = surrealdb.Unmarshal(controlUserRaw, &controlUser)
+	err = marshal.Unmarshal(controlUserRaw, &controlUser)
 	s.Require().NoError(err)
 
 	// check control user is changed or not
@@ -343,13 +345,13 @@ func (s *SurrealDBTestSuite) TestUnmarshalRaw() {
 	})
 	s.Require().NoError(err)
 
-	var userSlice []testUser
-	ok, err := surrealdb.UnmarshalRaw(userData, &userSlice)
+	var userSlice []marshal.RawQuery[testUser]
+	err = marshal.UnmarshalRaw(userData, &userSlice)
 	s.Require().NoError(err)
-	s.True(ok)
 	s.Len(userSlice, 1)
-	s.Equal(username, userSlice[0].Username)
-	s.Equal(password, userSlice[0].Password)
+	s.Equal(userSlice[0].Status, marshal.StatusOK)
+	s.Equal(username, userSlice[0].Result[0].Username)
+	s.Equal(password, userSlice[0].Result[0].Password)
 
 	// send query with empty result and unmarshal
 	userData, err = s.db.Query("select * from users where id = $id", map[string]interface{}{
@@ -357,9 +359,10 @@ func (s *SurrealDBTestSuite) TestUnmarshalRaw() {
 	})
 	s.Require().NoError(err)
 
-	ok, err = surrealdb.UnmarshalRaw(userData, &userSlice)
+	err = marshal.UnmarshalRaw(userData, &userSlice)
 	s.NoError(err)
-	s.False(ok, "select should return an empty result")
+	s.Equal(userSlice[0].Status, marshal.StatusOK)
+	s.Empty(userSlice[0].Result)
 }
 
 func (s *SurrealDBTestSuite) TestModify() {
@@ -394,13 +397,13 @@ func (s *SurrealDBTestSuite) TestNonRowSelect() {
 	}
 
 	_, err := s.db.Select("users:notexists")
-	s.Equal(err, surrealdb.ErrNoRow)
+	s.Equal(err, constants.ErrNoRow)
 
-	_, err = surrealdb.SmartUnmarshal[testUser](s.db.Select("users:notexists"))
-	s.Equal(err, surrealdb.ErrNoRow)
+	_, err = marshal.SmartUnmarshal[testUser](s.db.Select("users:notexists"))
+	s.Equal(err, constants.ErrNoRow)
 
-	_, err = surrealdb.SmartUnmarshal[testUser](surrealdb.SmartMarshal(s.db.Select, user))
-	s.Equal(err, surrealdb.ErrNoRow)
+	_, err = marshal.SmartUnmarshal[testUser](marshal.SmartMarshal(s.db.Select, user))
+	s.Equal(err, constants.ErrNoRow)
 }
 
 func (s *SurrealDBTestSuite) TestSmartUnMarshalQuery() {
@@ -411,7 +414,7 @@ func (s *SurrealDBTestSuite) TestSmartUnMarshalQuery() {
 
 	s.Run("raw create query", func() {
 		QueryStr := "Create users set Username = $user, Password = $pass"
-		dataArr, err := surrealdb.SmartUnmarshal[testUser](s.db.Query(QueryStr, map[string]interface{}{
+		dataArr, err := marshal.SmartUnmarshal[testUser](s.db.Query(QueryStr, map[string]interface{}{
 			"user": user[0].Username,
 			"pass": user[0].Password,
 		}))
@@ -422,7 +425,7 @@ func (s *SurrealDBTestSuite) TestSmartUnMarshalQuery() {
 	})
 
 	s.Run("raw select query", func() {
-		dataArr, err := surrealdb.SmartUnmarshal[testUser](s.db.Query("Select * from $record", map[string]interface{}{
+		dataArr, err := marshal.SmartUnmarshal[testUser](s.db.Query("Select * from $record", map[string]interface{}{
 			"record": user[0].ID,
 		}))
 
@@ -431,21 +434,21 @@ func (s *SurrealDBTestSuite) TestSmartUnMarshalQuery() {
 	})
 
 	s.Run("select query", func() {
-		data, err := surrealdb.SmartUnmarshal[testUser](s.db.Select(user[0].ID))
+		data, err := marshal.SmartUnmarshal[testUser](s.db.Select(user[0].ID))
 
 		s.Require().NoError(err)
 		s.Equal("electwix", data[0].Username)
 	})
 
 	s.Run("select array query", func() {
-		data, err := surrealdb.SmartUnmarshal[testUser](s.db.Select("users"))
+		data, err := marshal.SmartUnmarshal[testUser](s.db.Select("users"))
 
 		s.Require().NoError(err)
 		s.Equal("electwix", data[0].Username)
 	})
 
 	s.Run("delete record query", func() {
-		data, err := surrealdb.SmartUnmarshal[testUser](s.db.Delete(user[0].ID))
+		data, err := marshal.SmartUnmarshal[testUser](s.db.Delete(user[0].ID))
 
 		s.Require().NoError(err)
 		s.Len(data, 0)
@@ -460,14 +463,14 @@ func (s *SurrealDBTestSuite) TestSmartMarshalQuery() {
 	}}
 
 	s.Run("create with SmartMarshal query", func() {
-		data, err := surrealdb.SmartUnmarshal[testUser](surrealdb.SmartMarshal(s.db.Create, user[0]))
+		data, err := marshal.SmartUnmarshal[testUser](marshal.SmartMarshal(s.db.Create, user[0]))
 		s.Require().NoError(err)
 		s.Len(data, 1)
 		s.Equal(user[0], data[0])
 	})
 
 	s.Run("select with SmartMarshal query", func() {
-		data, err := surrealdb.SmartUnmarshal[testUser](surrealdb.SmartMarshal(s.db.Select, user[0]))
+		data, err := marshal.SmartUnmarshal[testUser](marshal.SmartMarshal(s.db.Select, user[0]))
 		s.Require().NoError(err)
 		s.Len(data, 1)
 		s.Equal(user[0], data[0])
@@ -475,21 +478,21 @@ func (s *SurrealDBTestSuite) TestSmartMarshalQuery() {
 
 	s.Run("update with SmartMarshal query", func() {
 		user[0].Password = "test123"
-		data, err := surrealdb.SmartUnmarshal[testUser](surrealdb.SmartMarshal(s.db.Update, user[0]))
+		data, err := marshal.SmartUnmarshal[testUser](marshal.SmartMarshal(s.db.Update, user[0]))
 		s.Require().NoError(err)
 		s.Len(data, 1)
 		s.Equal(user[0].Password, data[0].Password)
 	})
 
 	s.Run("delete with SmartMarshal query", func() {
-		data, err := surrealdb.SmartMarshal[testUser](s.db.Delete, user[0])
+		data, err := marshal.SmartMarshal(s.db.Delete, user[0])
 		s.Require().NoError(err)
 		s.Nil(data)
 	})
 
 	s.Run("check if data deleted SmartMarshal query", func() {
-		data, err := surrealdb.SmartUnmarshal[testUser](surrealdb.SmartMarshal(s.db.Select, user[0]))
-		s.Require().Equal(err, surrealdb.ErrNoRow)
+		data, err := marshal.SmartUnmarshal[testUser](marshal.SmartMarshal(s.db.Select, user[0]))
+		s.Require().Equal(err, constants.ErrNoRow)
 		s.Len(data, 0)
 	})
 }
@@ -509,7 +512,7 @@ func (s *SurrealDBTestSuite) TestConcurrentOperations() {
 			go func(j int) {
 				defer wg.Done()
 				_, err := s.db.Select(fmt.Sprintf("users:%d", j))
-				s.Require().Equal(err, surrealdb.ErrNoRow)
+				s.Require().Equal(err, constants.ErrNoRow)
 			}(i)
 		}
 		wg.Wait()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/surrealdb/surrealdb.go
 
-go 1.18
+go 1.20
 
 require (
 	github.com/gorilla/websocket v1.5.0

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -6,14 +6,15 @@ import (
 
 	"github.com/surrealdb/surrealdb.go"
 	"github.com/surrealdb/surrealdb.go/internal/mock"
+	"github.com/surrealdb/surrealdb.go/pkg/marshal"
 )
 
 // a simple user struct for testing
 type testUser struct {
-	surrealdb.Basemodel `table:"test"`
-	Username            string `json:"username,omitempty"`
-	Password            string `json:"password,omitempty"`
-	ID                  string `json:"id,omitempty"`
+	marshal.Basemodel `table:"test"`
+	Username          string `json:"username,omitempty"`
+	Password          string `json:"password,omitempty"`
+	ID                string `json:"id,omitempty"`
 }
 
 func SetupMockDB() (*surrealdb.DB, error) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,10 @@
+package constants
+
+import "errors"
+
+// Errors
+var (
+	InvalidResponse = errors.New("invalid SurrealDB response") //nolint:stylecheck
+	ErrQuery        = errors.New("error occurred processing the SurrealDB query")
+	ErrNoRow        = errors.New("error no row")
+)

--- a/pkg/marshal/marshal.go
+++ b/pkg/marshal/marshal.go
@@ -1,0 +1,164 @@
+package marshal
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
+	"github.com/surrealdb/surrealdb.go/pkg/util"
+)
+
+const StatusOK = "OK"
+
+// Used for RawQuery Unmarshaling
+type RawQuery[I any] struct {
+	Status string `json:"status"`
+	Time   string `json:"time"`
+	Result []I    `json:"result"`
+	Detail string `json:"detail"`
+}
+
+// Unmarshal loads a SurrealDB response into a struct.
+func Unmarshal(data, v interface{}) (err error) {
+	var jsonBytes []byte
+	if util.IsSlice(v) {
+		assertedData, ok := data.([]interface{})
+		if !ok {
+			return fmt.Errorf("failed to deserialise response to slice: %w", constants.InvalidResponse)
+		}
+		jsonBytes, err = json.Marshal(assertedData)
+		if err != nil {
+			return fmt.Errorf("failed to deserialise response '%+v' to slice: %w", assertedData, constants.InvalidResponse)
+		}
+	} else {
+		jsonBytes, err = json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("failed to deserialise response '%+v' to object: %w", data, err)
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(jsonBytes, v)
+	if err != nil {
+		return fmt.Errorf("failed unmarshaling jsonBytes '%+v': %w", jsonBytes, err)
+	}
+	return nil
+}
+
+// UnmarshalRaw loads a raw SurrealQL response returned by Query into a struct. Queries that return with results will
+// return ok = true, and queries that return with no results will return ok = false.
+func UnmarshalRaw[I any](rawData interface{}, v *[]RawQuery[I]) (err error) {
+	data, err := json.Marshal(rawData)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(data, &v)
+	if err != nil {
+		return
+	}
+	for _, v := range *v {
+		if v.Status != StatusOK {
+			err = errors.Join(err, fmt.Errorf("status: %s, detail: %s", v.Status, v.Detail))
+		}
+	}
+	return
+}
+
+// SmartUnmarshal using generics for return desired type.
+// Supports both raw and normal queries.
+func SmartUnmarshal[I any](respond interface{}, wrapperError error) (outputs []I, err error) {
+	// Handle delete
+	if respond == nil || wrapperError != nil {
+		return outputs, wrapperError
+	}
+	data, err := json.Marshal(respond)
+	if err != nil {
+		return outputs, err
+	}
+	// Needed for checking fields
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if _, isArr := respond.([]interface{}); !isArr {
+		// Non Arr Normal
+		var output I
+		err = decoder.Decode(&output)
+		if err == nil {
+			outputs = append(outputs, output)
+		}
+	} else {
+		// Arr Normal
+		if err = decoder.Decode(&outputs); err != nil {
+			// Arr Raw
+			var rawArr []RawQuery[I]
+			if err = json.Unmarshal(data, &rawArr); err == nil {
+				outputs = make([]I, 0)
+				for _, raw := range rawArr {
+					if raw.Status != StatusOK {
+						err = errors.Join(err, errors.New(raw.Status))
+					} else {
+						outputs = append(outputs, raw.Result...)
+					}
+				}
+			}
+		}
+	}
+	return outputs, err
+}
+
+// Used for define table name, it has no value.
+type Basemodel struct{}
+
+// Smart Marshal Errors
+var (
+	ErrNotStruct    = errors.New("data is not struct")
+	ErrNotValidFunc = errors.New("invalid function")
+)
+
+// Smartmarshal can be used with all DB methods with generics and type safety.
+// This handles errors and can use any struct tag with `BaseModel` type.
+// Warning: "ID" field is case sensitive and expect string.
+// Upon failure, the following will happen
+// 1. If there are some ID on struct it will fill the table with the ID
+// 2. If there are struct tags of the type `Basemodel`, it will use those values instead
+// 3. If everything above fails or the IDs do not exist, SmartUnmarshal will use the struct name as the table name.
+func SmartMarshal[I any](inputfunc interface{}, data I) (output interface{}, err error) {
+	var table string
+	datatype := reflect.TypeOf(data)
+	datavalue := reflect.ValueOf(data)
+	if datatype.Kind() == reflect.Pointer {
+		datatype = datatype.Elem()
+		datavalue = datavalue.Elem()
+	}
+	if datatype.Kind() == reflect.Struct {
+		if _, ok := datavalue.Field(0).Interface().(Basemodel); ok {
+			if temptable, ok := datatype.Field(0).Tag.Lookup("table"); ok {
+				table = temptable
+			} else {
+				table = reflect.TypeOf(data).Name()
+			}
+		}
+		if id, ok := datatype.FieldByName("ID"); ok {
+			if id.Type.Kind() == reflect.String {
+				if str, ok := datavalue.FieldByName("ID").Interface().(string); ok {
+					if str != "" {
+						table = str
+					}
+				}
+			}
+		}
+	} else {
+		return nil, ErrNotStruct
+	}
+	if function, ok := inputfunc.(func(thing string, data interface{}) (interface{}, error)); ok {
+		return function(table, data)
+	}
+	if function, ok := inputfunc.(func(thing string) (interface{}, error)); ok {
+		return function(table)
+	}
+	return nil, ErrNotValidFunc
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,7 @@
+package util
+
+import "reflect"
+
+func IsSlice(value interface{}) bool {
+	return reflect.TypeOf(value).Kind() == reflect.Slice
+}


### PR DESCRIPTION
SmartUnmarshal output has changed to array
SmartUnmarshal now supports `non-arr normal`, `arr normal` and `arr raw`
fix Typo
fix #79