### PR TITLE
update version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/surrealdb/surrealdb.go
 
-go 1.18
+go 1.20
 
 require (
 	github.com/gorilla/websocket v1.5.0


### PR DESCRIPTION
Yesterday, on August 8th, 2023, version 1.21 of Go was released. Since version 1.18 is now outdated, it may be a good idea to update our code base to version 1.20 for improved performance and updated features.