### PR TITLE
fix: update change and modify method

### DIFF
--- a/db.go
+++ b/db.go
@@ -89,14 +89,14 @@ func (db *DB) Update(what string, data interface{}) (interface{}, error) {
 	return db.send("update", what, data)
 }
 
-// Change a table or record in the database like a PATCH request.
-func (db *DB) Change(what string, data interface{}) (interface{}, error) {
-	return db.send("change", what, data)
+// Merge a table or record in the database like a PATCH request.
+func (db *DB) Merge(what string, data interface{}) (interface{}, error) {
+	return db.send("merge", what, data)
 }
 
-// Modify applies a series of JSONPatches to a table or record.
-func (db *DB) Modify(what string, data []Patch) (interface{}, error) {
-	return db.send("modify", what, data)
+// Patch applies a series of JSONPatches to a table or record.
+func (db *DB) Patch(what string, data []Patch) (interface{}, error) {
+	return db.send("patch", what, data)
 }
 
 // Delete a table or a row from the database like a DELETE request.
@@ -122,20 +122,10 @@ func (db *DB) send(method string, params ...interface{}) (interface{}, error) {
 	}
 
 	switch method {
+	case "select", "create", "update", "merge", "patch", "insert":
+		return db.resp(method, params, resp)
 	case "delete":
 		return nil, nil
-	case "select":
-		return db.resp(method, params, resp)
-	case "create":
-		return db.resp(method, params, resp)
-	case "update":
-		return db.resp(method, params, resp)
-	case "change":
-		return db.resp(method, params, resp)
-	case "modify":
-		return db.resp(method, params, resp)
-	case "insert":
-		return db.resp(method, params, resp)
 	default:
 		return resp, nil
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -374,7 +374,28 @@ func (s *SurrealDBTestSuite) TestUnmarshalRaw() {
 	s.Empty(userSlice[0].Result)
 }
 
-func (s *SurrealDBTestSuite) TestModify() {
+func (s *SurrealDBTestSuite) TestMerge() {
+	_, err := s.db.Create("users:999", map[string]interface{}{
+		"username": "john999",
+		"password": "123",
+	})
+	s.NoError(err)
+
+	// Update the user
+	_, err = s.db.Merge("users:999", map[string]string{
+		"password": "456",
+	})
+	s.Require().NoError(err)
+
+	user2, err := s.db.Select("users:999")
+	s.Require().NoError(err)
+
+	data := (user2).(map[string]interface{})["password"].(string)
+
+	s.Equal("456", data)
+}
+
+func (s *SurrealDBTestSuite) TestPatch() {
 	_, err := s.db.Create("users:999", map[string]interface{}{
 		"username": "john999",
 		"password": "123",
@@ -387,7 +408,7 @@ func (s *SurrealDBTestSuite) TestModify() {
 	}
 
 	// Update the user
-	_, err = s.db.Modify("users:999", patches)
+	_, err = s.db.Patch("users:999", patches)
 	s.Require().NoError(err)
 
 	user2, err := s.db.Select("users:999")

--- a/db_test.go
+++ b/db_test.go
@@ -390,9 +390,11 @@ func (s *SurrealDBTestSuite) TestMerge() {
 	user2, err := s.db.Select("users:999")
 	s.Require().NoError(err)
 
-	data := (user2).(map[string]interface{})["password"].(string)
+	username := (user2).(map[string]interface{})["username"].(string)
+	password := (user2).(map[string]interface{})["password"].(string)
 
-	s.Equal("456", data)
+	s.Equal("john999", username) // Ensure username hasn't change.
+	s.Equal("456", password)
 }
 
 func (s *SurrealDBTestSuite) TestPatch() {
@@ -414,9 +416,11 @@ func (s *SurrealDBTestSuite) TestPatch() {
 	user2, err := s.db.Select("users:999")
 	s.Require().NoError(err)
 
+	username := (user2).(map[string]interface{})["username"].(string)
 	data := (user2).(map[string]interface{})["age"].(float64)
 
-	s.Equal(patches[1].Value, int(data))
+	s.Equal("john999", username) // Ensure username hasn't change.
+	s.EqualValues(patches[1].Value, data)
 }
 
 func (s *SurrealDBTestSuite) TestNonRowSelect() {


### PR DESCRIPTION
## Motivation

With the release of [v1.0.0-beta.10](https://github.com/surrealdb/surrealdb/releases/tag/v1.0.0-beta.10), it looks like some methods I used changed and I got error messages like this:
```
sending request failed for method 'change': Method not found
```

After some search, I found a change on this two methods:
`change` -> `merge` 
`modify` -> `patch`

So here's a PR to update those two methods, if there is more changes to do (like on other method I didn't check), I will be happy to update the PR.
I also took the liberty to update the `switch method`, I found it more clear like this, but I can rollback if you want to.
