### PR TITLE
change action docker file with binary cuz fail of docker io limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,17 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/checkout@v3
-      - name: Start SurrealDB
-        run: docker run -it -d --rm --name surrealdb -p 8000:8000 surrealdb/surrealdb:nightly start -u root -p root
-      - name: Test
+          check-latest: true
+          cache-dependency-path: go.sum
+      - name: download surrealdb
+        run: curl --proto '=https' --tlsv1.2 -sSf https://install.surrealdb.com | sh -s -- --nightly
+      - name: start surrealdb
+        run: surreal start memory -A --auth --user root --pass root &
+      - name: test
         run: go test -v -cover ./...
         env:
           SURREALDB_URL: ws://localhost:8000/rpc
-      - name: Stop SurrealDB
-        run: docker stop -t 1 surrealdb


### PR DESCRIPTION
checkout@v3 and setup-go@v3 move v4 for cache modules for faster ci run


----


## Tests with docker and binary of surrealDB

| Tests   |  Tested With|  Status | Error
|----------|:-------------:|------| ---- |
| [Base 1](https://github.com/ElecTwix/surrealdb.go/actions/runs/6590027099/attempts/1)   |  Docker   |    Fail | `panic: repeated read on failed websocket connection`
| [Base 2](https://github.com/ElecTwix/surrealdb.go/actions/runs/6590027099/attempts/2)   |  Docker   |    Fail | `panic: repeated read on failed websocket connection`
| [Base 3](https://github.com/ElecTwix/surrealdb.go/actions/runs/6590027099/attempts/3)   |  Docker   |    Fail | `panic: repeated read on failed websocket connection`
| [Test 1](https://github.com/ElecTwix/surrealdb.go/actions/runs/6591008554/attempts/1) |    Binary   |   Sucesss | None
| [Test 2](https://github.com/ElecTwix/surrealdb.go/actions/runs/6591008554/attempts/2) |    Binary   |   Sucesss | None
| [Test 3](https://github.com/ElecTwix/surrealdb.go/actions/runs/6591008554/attempts/3) |    Binary   |   Sucesss |None

