### PR TITLE
Add flexible test setup

### DIFF
--- a/pkg/conn/gorilla/gorilla.go
+++ b/pkg/conn/gorilla/gorilla.go
@@ -239,7 +239,7 @@ func (ws *WebSocket) initialize() {
 				var res rpc.RPCResponse
 				err := ws.read(&res)
 				if err != nil {
-					// TODO: Handle error correctly, otherwise this can panic
+					// TODO(#119): Handle error correctly, otherwise this can panic
 					// after 1000 tries in a tight loop.
 					ws.logger.Error(err.Error())
 					continue

--- a/pkg/conn/gorilla/gorilla.go
+++ b/pkg/conn/gorilla/gorilla.go
@@ -239,6 +239,8 @@ func (ws *WebSocket) initialize() {
 				var res rpc.RPCResponse
 				err := ws.read(&res)
 				if err != nil {
+					// TODO: Handle error correctly, otherwise this can panic
+					// after 1000 tries in a tight loop.
 					ws.logger.Error(err.Error())
 					continue
 				}

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,90 @@
+package surrealdb
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/surrealdb/surrealdb.go/pkg/marshal"
+)
+
+// TestSurrealDBLocal runs a local SurrealDB instance by calling
+// `NewTestSurrealDB(t)`, which is a dedicated SurrealDB instance with no data.
+func TestSurrealDBLocal(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		schema              []string
+		dbInteraction       func(*testing.T, *DB)
+		keepServerUponError bool
+	}{
+		"first case": {
+			schema: []string{
+				"CREATE user:x SET name = 'xxxx'",
+				"CREATE user:y SET name = 'yyyy'",
+			},
+			dbInteraction: func(t *testing.T, db *DB) {
+				data, err := db.Select("user")
+				if err != nil {
+					t.Fatalf("failed to select, %v", err)
+				}
+				type dataholder struct {
+					ID   string `json:"id,omitempty"`
+					Name string `json:"name,omitempty"`
+				}
+				d, err := marshal.SmartUnmarshal[dataholder](data, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := []dataholder{
+					{ID: "user:x", Name: "xxxx"},
+					{ID: "user:y", Name: "yyyy"},
+				}
+				if diff := cmp.Diff(want, d); diff != "" {
+					t.Errorf("Result mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+		"second case": {
+			schema: []string{
+				"CREATE user:x SET name = 'xxxx'",
+				"CREATE user:y SET name = 'yyyy'",
+			},
+			dbInteraction: func(t *testing.T, db *DB) {
+			},
+		},
+		"third case": {
+			schema: []string{
+				"CREATE user:x SET name = 'xxxx'",
+				"CREATE user:y SET name = 'yyyy'",
+				"CREATE user:y SET name = 'yyyy'", // Should fail
+			},
+			dbInteraction: func(t *testing.T, db *DB) {
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			endpoint, db, cancel := NewTestSurrealDB(t)
+			defer func() {
+				// If test case failed, keep the server running for further
+				// investigation. This could be something we can turn on with
+				// some special flag.
+				if tc.keepServerUponError && t.Failed() {
+					return
+				}
+				// Otherwise cleanup the server.
+				cancel()
+			}()
+			_ = endpoint // Not used for this test.
+
+			for _, s := range tc.schema {
+				db.Prepare(t, s)
+			}
+
+			tc.dbInteraction(t, db.DB)
+		})
+	}
+}

--- a/util_for_test.go
+++ b/util_for_test.go
@@ -182,13 +182,9 @@ func NewTestSurrealDB(t testing.TB) (string, *DBForTest, func()) {
 func getFreePort(t testing.TB) uint32 {
 	t.Helper()
 
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		t.Fatalf("could not find any open port: %v", err)
-	}
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		t.Fatalf("could not listen to \"%s\": %v", addr, err)
+		t.Fatalf("could not listen to localhost:0: %v", err)
 	}
 	defer l.Close()
 	return uint32(l.Addr().(*net.TCPAddr).Port)

--- a/util_for_test.go
+++ b/util_for_test.go
@@ -1,0 +1,304 @@
+package surrealdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	rawslog "log/slog"
+	"net"
+	"os/exec"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/pkg/conn/gorilla"
+	"github.com/surrealdb/surrealdb.go/pkg/logger/slog"
+)
+
+var (
+	testHasSurrealCLI     bool
+	checkSurrealCLIOnce   sync.Once
+	DelayAfterServerStart time.Duration = 300 * time.Millisecond
+	DelayBeforeServerExit time.Duration = 300 * time.Millisecond
+)
+
+func Test_TestSurrealDBParallelSimple(t *testing.T) {
+	t.Parallel()
+	instanceCount := 20
+	for i := 0; i < instanceCount; i++ {
+		t.Run(fmt.Sprintf("parallel__%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			_, db, cancel := NewTestSurrealDB(t)
+			defer cancel()
+
+			// Ensure that CREATE statement does not run against the same
+			// database (which would fail).
+			db.Prepare(t, "CREATE user:x SET name = 'x';")
+		})
+	}
+}
+
+func Test_TestSurrealDBParalleSelect(t *testing.T) {
+	t.Parallel()
+	instanceCount := 20
+	for i := 0; i < instanceCount; i++ {
+		i := i
+		t.Run(fmt.Sprintf("parallel__%d", i), func(t *testing.T) {
+			t.Parallel()
+			_, db, cancel := NewTestSurrealDB(t)
+			defer cancel()
+
+			// Ensure that CREATE statement does not run against the same
+			// database (which would fail).
+			db.Prepare(t, fmt.Sprintf("CREATE user:x SET name = 'x', index = %d;", i))
+
+			// Query the saved data.
+			data, err := db.Select("user")
+			if err != nil {
+				t.Fatalf("failed to select: %v", err)
+			}
+			jsonBytes, err := json.Marshal(data)
+			if err != nil {
+				t.Fatalf("failed to marshal to json: %v", err)
+			}
+			// Note the Index field, which would change based on the for loop.
+			type dataholder struct {
+				ID    string `json:"id,omitempty"`
+				Name  string `json:"name,omitempty"`
+				Index int    `json:"index,omitempty"`
+			}
+			d := []dataholder{}
+			err = json.Unmarshal(jsonBytes, &d)
+			if err != nil {
+				t.Fatalf("failed to unmarshal data: %v", err)
+			}
+			// Simply check all fields match as expected.
+			want := dataholder{ID: "user:x", Name: "x", Index: i}
+			if d[0].ID != want.ID || d[0].Name != want.Name || d[0].Index != want.Index {
+				t.Fatalf("data mismatch:\n    want: %+v, got:  %+v", want, d)
+			}
+		})
+	}
+}
+
+type DBForTest struct {
+	*DB
+}
+
+func NewTestSurrealDB(t testing.TB) (string, *DBForTest, func()) {
+	t.Helper()
+	checkSurrealCLIOnce.Do(func() {
+		if _, err := exec.LookPath("surreal"); err == nil {
+			testHasSurrealCLI = true
+		}
+	})
+	if !testHasSurrealCLI {
+		t.Skip("surreal CLI not found, skipping")
+	}
+
+	port := getFreePort(t)
+	srvEndpoint := fmt.Sprintf("0.0.0.0:%d", port)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "surreal",
+		"start",
+		"--auth",
+		"--user", "root",
+		"--pass", "surrealdb",
+		"--bind", srvEndpoint,
+		"memory")
+	// Ensure to wait for a short while before context cancellation to
+	// propagate, so that the client can shut down before.
+	// NOTE: There is currently a race condition and potential panic due to the
+	// closed websocket being used in a tight loop.
+	cmd.WaitDelay = DelayBeforeServerExit
+
+	go func() {
+		err := cmd.Run()
+		if err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				t.Logf("SurrealDB server shut down by context")
+				return
+			}
+			exit := &exec.ExitError{}
+			if errors.As(err, &exit) {
+				t.Errorf("SurrealDB server exited with error: %v", err)
+				return
+			}
+			t.Errorf("Command failed to run: %v", err)
+		}
+	}()
+
+	clientEndpoint := fmt.Sprintf("localhost:%d", port)
+
+	// Give some time for the server to start up.
+	time.Sleep(DelayAfterServerStart)
+	db := newDBForTest(t, clientEndpoint)
+	login := &Auth{
+		Username:  "root",
+		Password:  "surrealdb",
+		Namespace: "dummy",
+		Database:  "dummy",
+	}
+	if _, err := db.Signin(login); err != nil {
+		t.Fatalf("failed to connect using '%+v' for signin: %v", login, err)
+	}
+
+	// Client can potentially stay around, so ensure to close connection after
+	// the test is complete.
+	t.Cleanup(func() {
+		db.conn.Close()
+	})
+
+	return clientEndpoint, &DBForTest{db}, cancel
+}
+
+func getFreePort(t testing.TB) uint32 {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("could not find any open port: %v", err)
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatalf("could not listen to \"%s\": %v", addr, err)
+	}
+	defer l.Close()
+	return uint32(l.Addr().(*net.TCPAddr).Port)
+}
+
+func newDBForTest(t testing.TB, endpoint string) *DB {
+	url := fmt.Sprintf("ws://%s/rpc", endpoint)
+	buff := bytes.NewBuffer([]byte{})
+	handler := rawslog.NewJSONHandler(buff, &rawslog.HandlerOptions{Level: rawslog.LevelDebug})
+	log := slog.New(handler)
+	ws, err := gorilla.Create().SetTimeOut(5 * time.Second).SetCompression(true).Logger(log).Connect(url)
+	if err != nil {
+		t.Fatalf("failed to create websocket connection: %v", err)
+	}
+	db, err := New(url, ws)
+	if err != nil {
+		t.Errorf("failed to establish connection to \"%v\": %v", url, err)
+	}
+	return db
+}
+
+func (d *DBForTest) Prepare(t testing.TB, schema string) {
+	t.Helper()
+
+	// Use SurrealDB's raw query support. This expects no complex string
+	// manipulation, and thus the second param is set to nil.
+	x, err := d.Query(schema, nil)
+	if err != nil {
+		t.Fatalf("failed to define tables: %v", err)
+	}
+	if err := checkQueryResponse(x); err != nil {
+		t.Errorf("failed to define tables:\n  %v", err)
+	}
+}
+
+type queryResponse struct {
+	Status string `json:"status,omitempty"`
+	Time   string `json:"time,omitempty"`
+	Detail string `json:"detail,omitempty"`
+	// Result string `json:"result,omitempty"`
+}
+
+// checkQueryResponse checks the response bytes which is expected to be a json
+// input, and returns an error if any error is found in that response. If there
+// are multiple errors found, all of the error details are described as a part
+// of the error message.
+func checkQueryResponse(data interface{}) error {
+	var err error
+	var ok bool
+	d := data
+	if isSlice(data) {
+		d, ok = data.([]interface{})
+		if !ok {
+			return errors.New("failed to deserialise response to slice")
+		}
+	}
+	jsonBytes, err := json.Marshal(d)
+	if err != nil {
+		return fmt.Errorf("failed to deserialise response '%+v' to slice", d)
+	}
+
+	var responses []queryResponse
+	err = json.Unmarshal(jsonBytes, &responses)
+	if err != nil {
+		return fmt.Errorf("failed unmarshaling jsonBytes '%s': %w", jsonBytes, err)
+	}
+
+	errs := []string{}
+	emptyErrDetailFound := false
+	for _, r := range responses {
+		if r.Status != "OK" {
+			if r.Detail != "" {
+				errs = append(errs, r.Detail)
+				continue
+			}
+
+			// TODO: The server reuses the "result" field for both the actual
+			// data and error string. If the server uses a different field for
+			// the error details, we should be able to simply rely on the above
+			// logic, and when no detail found, report with unknown error.
+			// errs = append(errs, "unknown error with no detail from server")
+			//
+			// Because this is not the case, adding an extra logic to do a
+			// separate unmarshal to pull out the result string below.
+			emptyErrDetailFound = true
+		}
+	}
+	if emptyErrDetailFound {
+		type errorResponse struct {
+			Status string `json:"status,omitempty"`
+			Time   string `json:"time,omitempty"`
+			Detail string `json:"detail,omitempty"`
+			Result string `json:"result,omitempty"`
+		}
+		var errResponses []errorResponse
+		err = json.Unmarshal(jsonBytes, &errResponses)
+		if err != nil {
+			return fmt.Errorf("failed unmarshaling jsonBytes with error '%s': %w", jsonBytes, err)
+		}
+		for _, r := range errResponses {
+			if r.Status != "OK" {
+				if r.Detail != "" {
+					errs = append(errs, r.Detail)
+					continue
+				}
+				if r.Result != "" {
+					errs = append(errs, r.Result)
+					continue
+				}
+
+				// At this point, neither Detail nor Result have error details.
+				// Report it as unknown error.
+				errs = append(errs, "unknown error with no detail from server")
+			}
+		}
+
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to execute query:\n    %s", strings.Join(errs, "\n    "))
+	}
+
+	return nil
+}
+
+func isSlice(possibleSlice interface{}) bool {
+	val := reflect.ValueOf(possibleSlice)
+	return val.Kind() == reflect.Slice
+}
+
+func toSliceOfAny[T any](s []T) []any {
+	result := make([]any, len(s))
+	for i, v := range s {
+		result[i] = v
+	}
+	return result
+}

--- a/util_for_test.go
+++ b/util_for_test.go
@@ -33,8 +33,8 @@ func Test_TestSurrealDBParallelSimple(t *testing.T) {
 		t.Run(fmt.Sprintf("parallel__%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			_, db, cancel := NewTestSurrealDB(t)
-			defer cancel()
+			_, db, close := NewTestSurrealDB(t)
+			defer close()
 
 			// Ensure that CREATE statement does not run against the same
 			// database (which would fail).
@@ -50,8 +50,8 @@ func Test_TestSurrealDBParalleSelect(t *testing.T) {
 		i := i
 		t.Run(fmt.Sprintf("parallel__%d", i), func(t *testing.T) {
 			t.Parallel()
-			_, db, cancel := NewTestSurrealDB(t)
-			defer cancel()
+			_, db, close := NewTestSurrealDB(t)
+			defer close()
 
 			// Ensure that CREATE statement does not run against the same
 			// database (which would fail).

--- a/util_for_test.go
+++ b/util_for_test.go
@@ -92,6 +92,7 @@ type DBForTest struct {
 
 func NewTestSurrealDB(t testing.TB) (string, *DBForTest, func()) {
 	t.Helper()
+
 	checkSurrealCLIOnce.Do(func() {
 		if _, err := exec.LookPath("surreal"); err == nil {
 			testHasSurrealCLI = true
@@ -159,6 +160,8 @@ func NewTestSurrealDB(t testing.TB) (string, *DBForTest, func()) {
 }
 
 func getFreePort(t testing.TB) uint32 {
+	t.Helper()
+
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("could not find any open port: %v", err)
@@ -172,6 +175,8 @@ func getFreePort(t testing.TB) uint32 {
 }
 
 func newDBForTest(t testing.TB, endpoint string) *DB {
+	t.Helper()
+
 	url := fmt.Sprintf("ws://%s/rpc", endpoint)
 	buff := bytes.NewBuffer([]byte{})
 	handler := rawslog.NewJSONHandler(buff, &rawslog.HandlerOptions{Level: rawslog.LevelDebug})

--- a/util_for_test.go
+++ b/util_for_test.go
@@ -26,6 +26,26 @@ var (
 	DelayBeforeServerExit time.Duration = 300 * time.Millisecond
 )
 
+func Test_NewTestSurrealDB_Simple(t *testing.T) {
+	// Simple illustration of how NewTestSurrealDB can be used.
+
+	// Tests can run in parallel.
+	t.Parallel()
+
+	// NewTestSurrealDB returns endpoint (random open port used), DB instance
+	// (which is wrapped in DBForTest to provide extra methods), and a func to
+	// shutdown the SurrealDB server.
+	endpoint, db, close := NewTestSurrealDB(t)
+	defer close()
+	_ = endpoint // endpoint could be useful for some low level testing.
+
+	// DBForTest.Prepare is to run any SurrealQL for test prep. This would fail
+	// early if the provided string results in an error from SurrealDB server.
+	db.Prepare(t, "CREATE user:x SET name = 'x'")
+
+	// More interactions can simply use db instance from here on.
+}
+
 func Test_TestSurrealDBParallelSimple(t *testing.T) {
 	t.Parallel()
 	instanceCount := 20


### PR DESCRIPTION
## WHAT

This adds a new function `func NewTestSurrealDB(t testing.TB) (string, *DBForTest, func())` for test code. 

By checking the PATH with `exec.LookPath` for `surreal` CLI, we can assume that the real SurrealDB process can be spawned for each test case. This does not need any extra setup other than `surreal` CLI, and simply running `go test ./...` would create as many SurrealDB instances necessary locally.

## WHY

There will be many test cases where we want to have more complicated queries and interactions. With the existing test suite setup, SurrealDB instance is carefully managed to ensure each test to run cleanly, but it has quite a bit of learning curve. With this new function, there could be as many test cases as necessary, and we can easily define table driven test cases for various test cases.

## HOW

As an example, the simplest way to start a test SurrealDB instance is as follows.

```go
func TestSimpleTestSurrealDB(t *testing.T) {
	_, db, cancel := NewTestSurrealDB(t)
	defer cancel()

	// If you want to add some seed data, you can use Prepare method.
	db.Prepare(t, "CREATE user:x SET name = 'x'")

	// ... More test steps ...
}
```

The `Prepare` command is an extra helper method to add some test data prior to the test. Its implementation is rather crude, but it would be helpful to have a separate function like this with `testing.TB`, so that anyone new to the code would see this as test setup before the actual test details.

# Other Notes

- I didn't want to touch any of the existing test cases yet, as that would be a massive change
- When `surreal` CLI is not available in PATH, it would simply skip the test cases (with some logging)
- It may require some adjustment for CI/CD setup?
- I would suggest adding direnv setup so that anyone who opens up this repository will get SurrealDB CLI added to their PATH (as long as they use Nix + direnv)
- I considered creating a separate package, so that other packages can refer to for their testing (similar to https://pkg.go.dev/cloud.google.com/go/spanner/spannertest), but kept it for this repo for now
- I hit many websocket impl related panic during my local testing, and left a comment on that