### PR TITLE
feat(marshal): smartUnmarshalRaw1 to handle raw query single return result including THROW statement errors

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -612,7 +612,6 @@ func (s *SurrealDBTestSuite) TestSmartUnMarshalRaw1Query() {
 		s.Require().Error(err)
 		s.Require().Contains(err.Error(), "blocked")
 	})
-
 }
 
 func (s *SurrealDBTestSuite) TestSmartMarshalQuery() {

--- a/db_test.go
+++ b/db_test.go
@@ -581,7 +581,7 @@ func (s *SurrealDBTestSuite) TestSmartUnMarshalRaw1Query() {
 	}
 
 	s.Run("raw create query", func() {
-		QueryStr := "Create Only users set Username = $user, Password = $pass"
+		QueryStr := "CREATE ONLY users SET Username = $user, Password = $pass"
 		data, err := marshal.SmartUnmarshalRaw1[testUser](s.db.Query(QueryStr, map[string]interface{}{
 			"user": user.Username,
 			"pass": user.Password,
@@ -593,7 +593,7 @@ func (s *SurrealDBTestSuite) TestSmartUnMarshalRaw1Query() {
 	})
 
 	s.Run("raw select query", func() {
-		dataArr, err := marshal.SmartUnmarshalRaw1[[]testUser](s.db.Query("Select * from $record", map[string]interface{}{
+		dataArr, err := marshal.SmartUnmarshalRaw1[[]testUser](s.db.Query("SELECT * FROM $record", map[string]interface{}{
 			"record": user.ID,
 		}))
 

--- a/pkg/marshal/marshal.go
+++ b/pkg/marshal/marshal.go
@@ -21,7 +21,7 @@ type RawQuery[I any] struct {
 	Detail string `json:"detail"`
 }
 
-type RawQueryRaw[I any] struct {
+type RawQuerySingle[I any] struct {
 	Status string `json:"status"`
 	Time   string `json:"time"`
 	Result I      `json:"result"`
@@ -131,7 +131,7 @@ func SmartUnmarshalRaw1[I any](respond interface{}, wrapperError error) (output 
 		return output, err
 	}
 
-	var rawArr []RawQueryRaw[I]
+	var rawArr []RawQuerySingle[I]
 	if err = json.Unmarshal(data, &rawArr); err == nil {
 		if len(rawArr) == 1 {
 			raw := rawArr[0]
@@ -146,7 +146,7 @@ func SmartUnmarshalRaw1[I any](respond interface{}, wrapperError error) (output 
 	} else {
 		// Error in Result field
 		unmarshalError := err
-		var rawError []RawQueryRaw[string]
+		var rawError []RawQuerySingle[string]
 		if err = json.Unmarshal(data, &rawError); err == nil {
 			if len(rawError) == 1 {
 				if rawError[0].Status != StatusOK {


### PR DESCRIPTION
current SmartUnmarshal only handles array return results, doesn't handle other return types such as `create only user` which returns an object.

the new SmartUnmarshalRaw1 only handles raw query, and only handles single return result: [map[result:true status:OK time:4.219606ms]]

This is required because of custom functions `DEFINE FUNCTION fn::xxx` and `BEGIN;...COMMIT;` block doesn't return arrays, and only returns single result.

it also handles `THROW` statement errors `BEGIN; THROW 'blocked'; COMMIT;` : [map[result:An error occurred: blocked status:ERR time:4.219606ms]]

this function should cover 99% of people's needs

tested against surrealdb v1.0.0
