### PR TITLE
Add context.Context support to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ type User struct {
 
 func main() {
 	// Connect to SurrealDB
-	db, err := surrealdb.New("ws://localhost:8000/rpc")
+	db, err := surrealdb.New(context.Background(), "ws://localhost:8000/rpc")
 	if err != nil {
 		panic(err)
 	}
@@ -47,11 +47,11 @@ func main() {
 		Username:  "root",
 		Password:  "root",
 	}
-	if _, err = db.Signin(authData); err != nil {
+	if _, err = db.Signin(context.Background(), authData); err != nil {
 		panic(err)
 	}
 
-	if _, err = db.Use("test", "test"); err != nil {
+	if _, err = db.Use(context.Background(), "test", "test"); err != nil {
 		panic(err)
 	}
 
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	// Insert user
-	data, err := db.Create("user", user)
+	data, err := db.Create(context.Background(), "user", user)
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	// Get user by ID
-	data, err = db.Select(createdUser[0].ID)
+	data, err = db.Select(context.Background(), createdUser[0].ID)
 	if err != nil {
 		panic(err)
 	}
@@ -91,18 +91,18 @@ func main() {
 	changes := map[string]string{"name": "Jane"}
 
 	// Update user
-	if _, err = db.Update(selectedUser.ID, changes); err != nil {
+	if _, err = db.Update(context.Background(), selectedUser.ID, changes); err != nil {
 		panic(err)
 	}
 
-	if _, err = db.Query("SELECT * FROM $record", map[string]interface{}{
+	if _, err = db.Query(context.Background(), "SELECT * FROM $record", map[string]interface{}{
 		"record": createdUser[0].ID,
 	}); err != nil {
 		panic(err)
 	}
 
 	// Delete user by ID
-	if _, err = db.Delete(selectedUser.ID); err != nil {
+	if _, err = db.Delete(context.Background(), selectedUser.ID); err != nil {
 		panic(err)
 	}
 }
@@ -152,7 +152,7 @@ SurrealDB Go library supports smart unmarshal. It means that you can unmarshal a
 ```go
 
 // User struct is a test struct
-data, err := surrealdb.SmartUnmarshal[testUser](s.db.Select(user[0].ID))
+data, err := surrealdb.SmartUnmarshal[testUser](s.db.Select(context.Background(), user[0].ID))
 
 ```
 

--- a/db.go
+++ b/db.go
@@ -1,6 +1,7 @@
 package surrealdb
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/surrealdb/surrealdb.go/pkg/model"
@@ -24,8 +25,8 @@ type Auth struct {
 }
 
 // New creates a new SurrealDB client.
-func New(url string, connection conn.Connection) (*DB, error) {
-	connection, err := connection.Connect(url)
+func New(ctx context.Context, url string, connection conn.Connection) (*DB, error) {
+	connection, err := connection.Connect(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -44,90 +45,90 @@ func (db *DB) Close() {
 // --------------------------------------------------
 
 // Use is a method to select the namespace and table to use.
-func (db *DB) Use(ns, database string) (interface{}, error) {
-	return db.send("use", ns, database)
+func (db *DB) Use(ctx context.Context, ns, database string) (interface{}, error) {
+	return db.send(ctx, "use", ns, database)
 }
 
-func (db *DB) Info() (interface{}, error) {
-	return db.send("info")
+func (db *DB) Info(ctx context.Context) (interface{}, error) {
+	return db.send(ctx, "info")
 }
 
 // Signup is a helper method for signing up a new user.
-func (db *DB) Signup(authData *Auth) (interface{}, error) {
-	return db.send("signup", authData)
+func (db *DB) Signup(ctx context.Context, authData *Auth) (interface{}, error) {
+	return db.send(ctx, "signup", authData)
 }
 
 // Signin is a helper method for signing in a user.
-func (db *DB) Signin(authData *Auth) (interface{}, error) {
-	return db.send("signin", authData)
+func (db *DB) Signin(ctx context.Context, authData *Auth) (interface{}, error) {
+	return db.send(ctx, "signin", authData)
 }
 
-func (db *DB) Invalidate() (interface{}, error) {
-	return db.send("invalidate")
+func (db *DB) Invalidate(ctx context.Context) (interface{}, error) {
+	return db.send(ctx, "invalidate")
 }
 
-func (db *DB) Authenticate(token string) (interface{}, error) {
-	return db.send("authenticate", token)
+func (db *DB) Authenticate(ctx context.Context, token string) (interface{}, error) {
+	return db.send(ctx, "authenticate", token)
 }
 
 // --------------------------------------------------
 
-func (db *DB) Live(table string, diff bool) (string, error) {
-	id, err := db.send("live", table, diff)
+func (db *DB) Live(ctx context.Context, table string, diff bool) (string, error) {
+	id, err := db.send(ctx, "live", table, diff)
 	return id.(string), err
 }
 
-func (db *DB) Kill(liveQueryID string) (interface{}, error) {
-	return db.send("kill", liveQueryID)
+func (db *DB) Kill(ctx context.Context, liveQueryID string) (interface{}, error) {
+	return db.send(ctx, "kill", liveQueryID)
 }
 
-func (db *DB) Let(key string, val interface{}) (interface{}, error) {
-	return db.send("let", key, val)
+func (db *DB) Let(ctx context.Context, key string, val interface{}) (interface{}, error) {
+	return db.send(ctx, "let", key, val)
 }
 
 // Query is a convenient method for sending a query to the database.
-func (db *DB) Query(sql string, vars interface{}) (interface{}, error) {
-	return db.send("query", sql, vars)
+func (db *DB) Query(ctx context.Context, sql string, vars interface{}) (interface{}, error) {
+	return db.send(ctx, "query", sql, vars)
 }
 
 // Select a table or record from the database.
-func (db *DB) Select(what string) (interface{}, error) {
-	return db.send("select", what)
+func (db *DB) Select(ctx context.Context, what string) (interface{}, error) {
+	return db.send(ctx, "select", what)
 }
 
 // Creates a table or record in the database like a POST request.
-func (db *DB) Create(thing string, data interface{}) (interface{}, error) {
-	return db.send("create", thing, data)
+func (db *DB) Create(ctx context.Context, thing string, data interface{}) (interface{}, error) {
+	return db.send(ctx, "create", thing, data)
 }
 
 // Update a table or record in the database like a PUT request.
-func (db *DB) Update(what string, data interface{}) (interface{}, error) {
-	return db.send("update", what, data)
+func (db *DB) Update(ctx context.Context, what string, data interface{}) (interface{}, error) {
+	return db.send(ctx, "update", what, data)
 }
 
 // Merge a table or record in the database like a PATCH request.
-func (db *DB) Merge(what string, data interface{}) (interface{}, error) {
-	return db.send("merge", what, data)
+func (db *DB) Merge(ctx context.Context, what string, data interface{}) (interface{}, error) {
+	return db.send(ctx, "merge", what, data)
 }
 
 // Patch applies a series of JSONPatches to a table or record.
-func (db *DB) Patch(what string, data []Patch) (interface{}, error) {
-	return db.send("patch", what, data)
+func (db *DB) Patch(ctx context.Context, what string, data []Patch) (interface{}, error) {
+	return db.send(ctx, "patch", what, data)
 }
 
 // Delete a table or a row from the database like a DELETE request.
-func (db *DB) Delete(what string) (interface{}, error) {
-	return db.send("delete", what)
+func (db *DB) Delete(ctx context.Context, what string) (interface{}, error) {
+	return db.send(ctx, "delete", what)
 }
 
 // Insert a table or a row from the database like a POST request.
-func (db *DB) Insert(what string, data interface{}) (interface{}, error) {
-	return db.send("insert", what, data)
+func (db *DB) Insert(ctx context.Context, what string, data interface{}) (interface{}, error) {
+	return db.send(ctx, "insert", what, data)
 }
 
 // LiveNotifications returns a channel for live query.
-func (db *DB) LiveNotifications(liveQueryID string) (chan model.Notification, error) {
-	return db.conn.LiveNotifications(liveQueryID)
+func (db *DB) LiveNotifications(ctx context.Context, liveQueryID string) (chan model.Notification, error) {
+	return db.conn.LiveNotifications(ctx, liveQueryID)
 }
 
 // --------------------------------------------------
@@ -135,9 +136,9 @@ func (db *DB) LiveNotifications(liveQueryID string) (chan model.Notification, er
 // --------------------------------------------------
 
 // send is a helper method for sending a query to the database.
-func (db *DB) send(method string, params ...interface{}) (interface{}, error) {
+func (db *DB) send(ctx context.Context, method string, params ...interface{}) (interface{}, error) {
 	// here we send the args through our websocket connection
-	resp, err := db.conn.Send(method, params)
+	resp, err := db.conn.Send(ctx, method, params)
 	if err != nil {
 		return nil, fmt.Errorf("sending request failed for method '%s': %w", method, err)
 	}

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -1,6 +1,7 @@
 package benchmark_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -18,7 +19,7 @@ type testUser struct {
 }
 
 func SetupMockDB() (*surrealdb.DB, error) {
-	return surrealdb.New("", mock.Create())
+	return surrealdb.New(context.Background(), "", mock.Create())
 }
 
 func BenchmarkCreate(b *testing.B) {
@@ -38,7 +39,7 @@ func BenchmarkCreate(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// error is ignored for benchmarking purposes.
-		db.Create(users[i].ID, users[i]) //nolint:errcheck
+		db.Create(context.Background(), users[i].ID, users[i]) //nolint:errcheck
 	}
 }
 
@@ -51,6 +52,6 @@ func BenchmarkSelect(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// error is ignored for benchmarking purposes.
-		db.Select("users:bob") //nolint:errcheck
+		db.Select(context.Background(), "users:bob") //nolint:errcheck
 	}
 }

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"context"
 	"errors"
 
 	"github.com/surrealdb/surrealdb.go/pkg/conn"
@@ -10,11 +11,11 @@ import (
 type ws struct {
 }
 
-func (w *ws) Connect(url string) (conn.Connection, error) {
+func (w *ws) Connect(ctx context.Context, url string) (conn.Connection, error) {
 	return w, nil
 }
 
-func (w *ws) Send(method string, params []interface{}) (interface{}, error) {
+func (w *ws) Send(ctx context.Context, method string, params []interface{}) (interface{}, error) {
 	return nil, nil
 }
 
@@ -22,7 +23,7 @@ func (w *ws) Close() error {
 	return nil
 }
 
-func (w *ws) LiveNotifications(id string) (chan model.Notification, error) {
+func (w *ws) LiveNotifications(ctx context.Context, id string) (chan model.Notification, error) {
 	return nil, errors.New("live queries are unimplemented for mocks")
 }
 

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -1,10 +1,14 @@
 package conn
 
-import "github.com/surrealdb/surrealdb.go/pkg/model"
+import (
+	"context"
+
+	"github.com/surrealdb/surrealdb.go/pkg/model"
+)
 
 type Connection interface {
-	Connect(url string) (Connection, error)
-	Send(method string, params []interface{}) (interface{}, error)
+	Connect(ctx context.Context, url string) (Connection, error)
+	Send(ctx context.Context, method string, params []interface{}) (interface{}, error)
 	Close() error
-	LiveNotifications(id string) (chan model.Notification, error)
+	LiveNotifications(ctx context.Context, id string) (chan model.Notification, error)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,8 +1,10 @@
 package logger
 
+import "context"
+
 type Logger interface {
-	Error(msg string, args ...any)
-	Warn(msg string, args ...any)
-	Info(msg string, args ...any)
-	Debug(msg string, args ...any)
+	Error(ctx context.Context, msg string, args ...any)
+	Warn(ctx context.Context, msg string, args ...any)
+	Info(ctx context.Context, msg string, args ...any)
+	Debug(ctx context.Context, msg string, args ...any)
 }

--- a/pkg/logger/slog/slog.go
+++ b/pkg/logger/slog/slog.go
@@ -1,6 +1,7 @@
 package slog
 
 import (
+	"context"
 	"log/slog"
 )
 
@@ -13,18 +14,18 @@ func New(h slog.Handler) *SlogHandler {
 	return &SlogHandler{logger: logger}
 }
 
-func (handler *SlogHandler) Error(msg string, args ...any) {
-	handler.logger.Error(msg, args...)
+func (handler *SlogHandler) Error(ctx context.Context, msg string, args ...any) {
+	handler.logger.ErrorContext(ctx, msg, args...)
 }
 
-func (handler *SlogHandler) Warn(msg string, args ...any) {
-	handler.logger.Warn(msg, args...)
+func (handler *SlogHandler) Warn(ctx context.Context, msg string, args ...any) {
+	handler.logger.WarnContext(ctx, msg, args...)
 }
 
-func (handler *SlogHandler) Info(msg string, args ...any) {
-	handler.logger.Info(msg, args...)
+func (handler *SlogHandler) Info(ctx context.Context, msg string, args ...any) {
+	handler.logger.InfoContext(ctx, msg, args...)
 }
 
-func (handler *SlogHandler) Debug(msg string, args ...any) {
-	handler.logger.Debug(msg, args...)
+func (handler *SlogHandler) Debug(ctx context.Context, msg string, args ...any) {
+	handler.logger.DebugContext(ctx, msg, args...)
 }

--- a/pkg/logger/slog/slog_test.go
+++ b/pkg/logger/slog/slog_test.go
@@ -2,6 +2,7 @@ package slog_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -14,7 +15,7 @@ import (
 )
 
 type testMethod struct {
-	fn    func(msg string, args ...any)
+	fn    func(ctx context.Context, msg string, args ...any)
 	level rawslog.Level
 }
 
@@ -54,10 +55,10 @@ func TestLogger(t *testing.T) {
 	}
 }
 
-func checkMethod(loggerFunc func(msg string, args ...any), buffer *bytes.Buffer, levelStr string, t *testing.T) {
+func checkMethod(loggerFunc func(ctx context.Context, msg string, args ...any), buffer *bytes.Buffer, levelStr string, t *testing.T) {
 	require.NotEmpty(t, buffer)
 
-	loggerFunc(LogText, CustomFieldName, CustomFieldVal)
+	loggerFunc(context.Background(), LogText, CustomFieldName, CustomFieldVal)
 
 	line := buffer.Bytes()
 


### PR DESCRIPTION
The change adds context.Context support to the APIs. The context is
currently unused and just serves as an API change before more
functionality is added (eg. tracing).

This is a breaking API change.

Closes #100 
