### PR TITLE
Fix #124

### DIFF
--- a/db.go
+++ b/db.go
@@ -37,8 +37,8 @@ func New(url string, connection conn.Connection) (*DB, error) {
 // --------------------------------------------------
 
 // Close closes the underlying WebSocket connection.
-func (db *DB) Close() {
-	_ = db.conn.Close()
+func (db *DB) Close() error {
+	return db.conn.Close()
 }
 
 // --------------------------------------------------


### PR DESCRIPTION
Fix #124
Refactor: return err with db.Close() method.
Added log printer after tearing down tests for showing network errors