### PR TITLE
Feature: Added support for multiple entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,14 @@ func main() {
 		panic(err)
 	}
 
-	// insert multiple entries
+	// Unmarshal data
+	createdUser := make([]User, 1)
+	err = surrealdb.Unmarshal(data, &createdUser)
+	if err != nil {
+		panic(err)
+	}
+
+	// Insert multiple entries
 	userList := []testUser{
 		{
 			Username: "dwight",
@@ -81,13 +88,6 @@ func main() {
 
 	createdUsers, err := s.db.CreateMany("users", userList)
 
-	if err != nil {
-		panic(err)
-	}
-
-	// Unmarshal data
-	createdUser := make([]User, 1)
-	err = surrealdb.Unmarshal(data, &createdUser)
 	if err != nil {
 		panic(err)
 	}

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ func main() {
 	}
 
 	// Insert multiple entries
-	userList := []testUser{
+	userList := []User{
 		{
-			Username: "dwight",
-			Password: "123",
+			Name: "John",
+			Surname: "Doe",
 		},
 		{
-			Username: "michael",
-			Password: "456",
+			Name: "Jane",
+			Surname: "Doe",
 		},
 	}
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ func main() {
 		panic(err)
 	}
 
+	// insert multiple entries
+	userList := []testUser{
+		{
+			Username: "dwight",
+			Password: "123",
+		},
+		{
+			Username: "michael",
+			Password: "456",
+		},
+	}
+
+	createdUsers, err := s.db.CreateMany("users", userList)
+
+	if err != nil {
+		panic(err)
+	}
+
 	// Unmarshal data
 	createdUser := make([]User, 1)
 	err = surrealdb.Unmarshal(data, &createdUser)

--- a/db.go
+++ b/db.go
@@ -100,6 +100,13 @@ func (db *DB) Create(thing string, data interface{}) (interface{}, error) {
 	return db.send("create", thing, data)
 }
 
+// Creates multiple records in table
+func (db *DB) CreateMany(thing string, records interface{}) (interface{}, error) {
+	return db.send("query", fmt.Sprintf("INSERT INTO %s ($records)", thing), map[string]interface{}{
+		"records": records,
+	})
+}
+
 // Update a table or record in the database like a PUT request.
 func (db *DB) Update(what string, data interface{}) (interface{}, error) {
 	return db.send("update", what, data)

--- a/db_test.go
+++ b/db_test.go
@@ -447,6 +447,40 @@ func (s *SurrealDBTestSuite) TestCreate() {
 	})
 }
 
+func (s *SurrealDBTestSuite) TestCreateMany() {
+
+	userList := []testUser{
+		{
+			Username: "dwight",
+			Password: "123",
+		},
+		{
+			Username: "michael",
+			Password: "456",
+		},
+	}
+
+	createdUsers, err := s.db.CreateMany("users", userList)
+
+	s.Require().NoError(err)
+	s.NotEmpty(createdUsers)
+
+	var userSlice []marshal.RawQuery[testUser]
+	err = marshal.UnmarshalRaw(createdUsers, &userSlice)
+	s.Require().NoError(err)
+	s.Len(userSlice, 1)
+	s.Equal(userSlice[0].Status, marshal.StatusOK)
+
+	s.Len(userSlice[0].Result, 2)
+
+	s.NotEmpty(userSlice[0].Result[0].ID, "The ID should have been set by the database for record 1")
+	s.Equal("dwight", userSlice[0].Result[0].Username)
+
+	s.NotEmpty(userSlice[0].Result[1].ID, "The ID should have been set by the database for record 1")
+	s.Equal("michael", userSlice[0].Result[1].Username)
+
+}
+
 func (s *SurrealDBTestSuite) TestSelect() {
 	createdUsers, err := s.db.Create("users", testUser{
 		Username: "johnnyjohn",


### PR DESCRIPTION
Added db method to insert multiple records at once, with updated readme file and test.

Method `CreateMany` calls `Query` method with the insert query based on the documentation.

Surreal DB Version : 1.3.1
