### PR TITLE
fix: add ability to unmarshall objects (#139)

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -543,7 +543,7 @@ func (s *SurrealDBTestSuite) TestUnmarshalRaw() {
 	})
 	s.Require().NoError(err)
 
-	var userSlice []marshal.RawQuery[testUser]
+	var userSlice []marshal.RawQuery[[]testUser]
 	err = marshal.UnmarshalRaw(userData, &userSlice)
 	s.Require().NoError(err)
 	s.Len(userSlice, 1)

--- a/pkg/marshal/marshal.go
+++ b/pkg/marshal/marshal.go
@@ -17,7 +17,7 @@ const StatusOK = "OK"
 type RawQuery[I any] struct {
 	Status string `json:"status"`
 	Time   string `json:"time"`
-	Result []I    `json:"result"`
+	Result I      `json:"result"`
 	Detail string `json:"detail"`
 }
 
@@ -94,7 +94,7 @@ func SmartUnmarshal[I any](respond interface{}, wrapperError error) (outputs []I
 		// Arr Normal
 		if err = decoder.Decode(&outputs); err != nil {
 			// Arr Raw
-			var rawArr []RawQuery[I]
+			var rawArr []RawQuery[[]I]
 			if err = json.Unmarshal(data, &rawArr); err == nil {
 				outputs = make([]I, 0)
 				for _, raw := range rawArr {


### PR DESCRIPTION
Fixes #139 

This PR makes it possible to unmarshall queries returning objects

currently query like this 
```
RETURN [3]
```
is unmarshalled to this type 
```go
var num []marshal.RawQuery[int]
```
even tought the return type of the query is array

and query like this 
```
RETURN 3
```
is impossible to unmarshall with UnmarshalRaw.

This PR chanes it that the first query is unmarshalled to
```go
var num []marshal.RawQuery[[]int]
```
and the second one to
```go
var num []marshal.RawQuery[int]
```