### PR TITLE
Added ability to handle multiple queries

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -23,6 +23,7 @@ type Connection interface {
 	Let(key string, value interface{}) error
 	Unset(key string) error
 	LiveNotifications(id string) (chan Notification, error)
+	GetUnmarshaler() codec.Unmarshaler
 }
 
 type NewConnectionParams struct {

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/surrealdb/surrealdb.go/internal/codec"
+
 	"github.com/surrealdb/surrealdb.go/internal/rand"
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 )
@@ -68,6 +70,10 @@ func (h *HTTPConnection) SetTimeout(timeout time.Duration) *HTTPConnection {
 func (h *HTTPConnection) SetHTTPClient(client *http.Client) *HTTPConnection {
 	h.httpClient = client
 	return h
+}
+
+func (h *HTTPConnection) GetUnmarshaler() codec.Unmarshaler {
+	return h.unmarshaler
 }
 
 func (h *HTTPConnection) Send(dest any, method string, params ...interface{}) error {

--- a/pkg/connection/ws.go
+++ b/pkg/connection/ws.go
@@ -3,6 +3,9 @@ package connection
 import (
 	"errors"
 	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/internal/codec"
+
 	"io"
 	"log/slog"
 	"net"
@@ -132,6 +135,10 @@ func (ws *WebSocketConnection) Let(key string, value interface{}) error {
 
 func (ws *WebSocketConnection) Unset(key string) error {
 	return ws.Send(nil, "unset", key)
+}
+
+func (ws *WebSocketConnection) GetUnmarshaler() codec.Unmarshaler {
+	return ws.unmarshaler
 }
 
 func (ws *WebSocketConnection) Send(dest interface{}, method string, params ...interface{}) error {

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -43,16 +43,16 @@ func (d *CustomDateTime) MarshalCBOR() ([]byte, error) {
 func (d *CustomDateTime) UnmarshalCBOR(data []byte) error {
 	dec := getCborDecoder()
 
-	var temp [2]interface{}
+	var temp [2]int64
 	err := dec.Unmarshal(data, &temp)
 	if err != nil {
 		return err
 	}
 
-	s := temp[0].(uint64)
-	ns := temp[1].(uint64)
+	s := temp[0]
+	ns := temp[1]
 
-	*d = CustomDateTime(time.Unix(int64(s), int64(ns)))
+	*d = CustomDateTime(time.Unix(s, ns))
 
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -1,7 +1,9 @@
 package surrealdb
 
 import (
-	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/surrealdb/surrealdb.go/internal/codec"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
@@ -18,10 +20,18 @@ type QueryResult[T any] struct {
 	Result T      `json:"result"`
 }
 
-type QueryStmt[TResult any] struct {
-	SQL    string
-	Vars   map[string]interface{}
-	Result *connection.RPCResponse[TResult]
+type QueryStmt struct {
+	unmarshaler codec.Unmarshaler
+	SQL         string
+	Vars        map[string]interface{}
+	Result      QueryResult[cbor.RawMessage]
+}
+
+func (q *QueryStmt) GetResult(dest interface{}) error {
+	if q.unmarshaler == nil {
+		return constants.ErrNoUnmarshaler
+	}
+	return q.unmarshaler.Unmarshal(q.Result.Result, dest)
 }
 
 type Relationship struct {


### PR DESCRIPTION
Added the ability to utilise SurrealDB multi-query capabilities. The raw results are returned and the user can directly unmarshal the result

Example:
```go
queries := []surrealdb.QueryStmt{
    {SQL: "CREATE person SET name = 'John'"},
    {SQL: "SELECT * FROM type::table($tb)", Vars: map[string]interface{}{"tb": "person"}},
}

err := surrealdb.QueryRaw(s.db, &queries)
if err != nil {
    panic(err)
}

var created []testPerson
err = queries[0].GetResult(&created)
if err != nil {
    panic(err)
}

var selected []testPerson
err = queries[1].GetResult(&selected)
if err != nil {
    panic(err)
}

// fmt.Printf("%+v\n", created)
// fmt.Printf("%+v\n", selected)
```