### PR TITLE
Update datetime marshal to use `UnixNano()`

### DIFF
--- a/pkg/models/datetime.go
+++ b/pkg/models/datetime.go
@@ -16,14 +16,14 @@ type CustomDateTime struct {
 func (d *CustomDateTime) MarshalCBOR() ([]byte, error) {
 	enc := getCborEncoder()
 
-	totalNS := d.Nanosecond()
+	totalNS := d.UnixNano()
 
 	s := totalNS / constants.OneSecondToNanoSecond
 	ns := totalNS % constants.OneSecondToNanoSecond
 
 	return enc.Marshal(cbor.Tag{
 		Number:  TagCustomDatetime,
-		Content: [2]int64{int64(s), int64(ns)},
+		Content: [2]int64{s, ns},
 	})
 }
 


### PR DESCRIPTION
Previously used `t.Nanosecond()` which caused the marshalling to almost always result to `t = 0`. This fixes that.

Fixes #170 