### PR TITLE
feat: support for new ACCESS auth type

### DIFF
--- a/types.go
+++ b/types.go
@@ -47,6 +47,7 @@ type Auth struct {
 	Namespace string `json:"NS,omitempty"`
 	Database  string `json:"DB,omitempty"`
 	Scope     string `json:"SC,omitempty"`
+	Access    string `json:"AC,omitempty"`
 	Username  string `json:"user,omitempty"`
 	Password  string `json:"pass,omitempty"`
 }


### PR DESCRIPTION
`scope` is deprecated, so we should allow usage of `access`. 

Since there is no direct access to the connection and the `Send` function has an allowlist of methods, there is currently no workaround available. 

Fixes #188 