### PR TITLE
Fix data race in WebSocketConnection.Connect

### DIFF
--- a/pkg/connection/ws.go
+++ b/pkg/connection/ws.go
@@ -20,22 +20,16 @@ import (
 	gorilla "github.com/gorilla/websocket"
 )
 
-var DefaultDialer *gorilla.Dialer
-
-func init() {
-	var subprotocols []string
-
-	subprotocols = append(subprotocols, gorilla.DefaultDialer.Subprotocols...)
-	subprotocols = append(subprotocols, "cbor")
-
-	d := gorilla.Dialer{
-		Proxy:             gorilla.DefaultDialer.Proxy,
-		HandshakeTimeout:  gorilla.DefaultDialer.HandshakeTimeout,
-		EnableCompression: true,
-		Subprotocols:      subprotocols,
-	}
-
-	DefaultDialer = &d
+// DefaultDialer is the default gorilla dialer used by the WebSocketConnection
+//
+// It uses the default gorilla dialer as of gorilla/websocket v1.5.0 with the following modifications:
+// - EnableCompression is set to true
+// - Subprotocols is set to ["cbor"]
+var DefaultDialer = &gorilla.Dialer{
+	Proxy:             gorilla.DefaultDialer.Proxy,
+	HandshakeTimeout:  gorilla.DefaultDialer.HandshakeTimeout,
+	EnableCompression: true,
+	Subprotocols:      []string{"cbor"},
 }
 
 type Option func(ws *WebSocketConnection) error

--- a/pkg/connection/ws.go
+++ b/pkg/connection/ws.go
@@ -20,6 +20,24 @@ import (
 	gorilla "github.com/gorilla/websocket"
 )
 
+var DefaultDialer *gorilla.Dialer
+
+func init() {
+	var subprotocols []string
+
+	subprotocols = append(subprotocols, gorilla.DefaultDialer.Subprotocols...)
+	subprotocols = append(subprotocols, "cbor")
+
+	d := gorilla.Dialer{
+		Proxy:             gorilla.DefaultDialer.Proxy,
+		HandshakeTimeout:  gorilla.DefaultDialer.HandshakeTimeout,
+		EnableCompression: true,
+		Subprotocols:      subprotocols,
+	}
+
+	DefaultDialer = &d
+}
+
 type Option func(ws *WebSocketConnection) error
 
 type WebSocketConnection struct {
@@ -60,11 +78,7 @@ func (ws *WebSocketConnection) Connect() error {
 		return err
 	}
 
-	dialer := gorilla.DefaultDialer
-	dialer.EnableCompression = true
-	dialer.Subprotocols = append(dialer.Subprotocols, "cbor")
-
-	connection, res, err := dialer.Dial(fmt.Sprintf("%s/rpc", ws.baseURL), nil)
+	connection, res, err := DefaultDialer.Dial(fmt.Sprintf("%s/rpc", ws.baseURL), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We have a race issue when modifying the `gorilla.DefaultDialer.Subprotocols`, where multiple go routines that call `Connect` could race on the Subprotocols slice.

Can we fix it to see if it fixes another issue that might be affected by it?

EDIT: It apparently did. I have seen no panic since rebuilding my app with `surrealdb.go` v0.3.0 plus this patch.

---

I'm encountering this potentially relevant panic at L65 of the `ws.go`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1eb136b]

goroutine 177 [running]:
github.com/surrealdb/surrealdb.go/pkg/connection.(*WebSocketConnection).Connect(0xc000984200)
        /home/ubuntu/go/pkg/mod/github.com/surrealdb/surrealdb.go@v0.3.0/pkg/connection/ws.go:65 +0x10b
github.com/surrealdb/surrealdb%2ego.New({0x7fff52a3c579?, 0xc0005cbe78?})
        /home/ubuntu/go/pkg/mod/github.com/surrealdb/surrealdb.go@v0.3.0/db.go:56 +0x542
github.com/pingcap/go-ycsb/db/surrealdb.(*surrealDB).connect(0xc0002b0000)
        /usr/local/go-ycsb/db/surrealdb/db.go:61 +0x26
github.com/pingcap/go-ycsb/db/surrealdb.(*surrealDB).InitThread(0xa?, {0x28d9298, 0xc000564030}, 0x76b1c920aff8?, 0xc0003eaa00?)
        /usr/local/go-ycsb/db/surrealdb/db.go:100 +0x25
github.com/pingcap/go-ycsb/pkg/client.DbWrapper.InitThread(...)
        /usr/local/go-ycsb/pkg/client/dbwrapper.go:46
github.com/pingcap/go-ycsb/pkg/client.(*Client).Run.func2(0x6a)
        /usr/local/go-ycsb/pkg/client/client.go:214 +0xfa
created by github.com/pingcap/go-ycsb/pkg/client.(*Client).Run in goroutine 1
        /usr/local/go-ycsb/pkg/client/client.go:209 +0x154
```

To panic at `ws.go:65` in Go, `dialer` and therefore `gorilla.DefaultDialier` must be nil in:

https://github.com/surrealdb/surrealdb.go/blob/184f6bf409d80d5cdba12e89c04f5c67ec35f334/pkg/connection/ws.go#L65

But the dialer is not nil because L64, which also accesses the `dialer` `EnableCompression` field, is passing fine.

Note appending to a nil slice in Go is OK, so in Go it's impossible to panic at L65 with `dialer` not being nil:

https://github.com/surrealdb/surrealdb.go/blob/184f6bf409d80d5cdba12e89c04f5c67ec35f334/pkg/connection/ws.go#L64

Go playground: https://go.dev/play/p/ob6JunXDNpG

I suspect the race issue causes this because in Go, AFAIK, behaviors on data race are undefined.
