### PR TITLE
Fix HTTP connection & disable LIVE query tests for HTTP & Migrate to Lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,6 @@ jobs:
           go-version: ">=1.18"
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v7
         with:
           args: --timeout=5m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 permissions:
   contents: read
 

--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,0 +1,97 @@
+linters-settings:
+
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - dupSubExpr # https://github.com/go-critic/go-critic/issues/897#issuecomment-568896534
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+  mnd:
+    # don't include the "operation" and "assign"
+    checks:
+      - argument
+      - case
+      - condition
+      - return
+    ignored-numbers:
+      - "0"
+      - "1"
+      - "2"
+      - "3"
+    ignored-functions:
+      - strings.SplitN
+
+  govet:
+    enable:
+      - shadow
+  lll:
+    line-length: 140
+  misspell:
+    locale: US
+  nolintlint:
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gomnd
+
+run:
+  timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,99 +1,105 @@
-linters-settings:
-  depguard:
-    list-type: denylist
-
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - dupSubExpr # https://github.com/go-critic/go-critic/issues/897#issuecomment-568896534
-  gocyclo:
-    min-complexity: 15
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  mnd:
-    # don't include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-    ignored-numbers:
-      - "0"
-      - "1"
-      - "2"
-      - "3"
-    ignored-functions:
-      - strings.SplitN
-
-  govet:
-    enable:
-      - shadow
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - funlen
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - gomnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nakedret
     - noctx
     - nolintlint
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-
-run:
-  timeout: 5m
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - dupSubExpr
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+      ignored-numbers:
+        - "0"
+        - "1"
+        - "2"
+        - "3"
+      ignored-functions:
+        - strings.SplitN
+    nolintlint:
+      require-explanation: false
+      require-specific: false
+      allow-unused: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - mnd
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/golangci/golangci-lint
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/db.go
+++ b/db.go
@@ -45,13 +45,14 @@ func New(connectionURL string) (*DB, error) {
 	}
 
 	var con connection.Connection
-	if scheme == "http" || scheme == "https" {
+	switch scheme {
+	case "http", "https":
 		con = connection.NewHTTPConnection(newParams)
-	} else if scheme == "ws" || scheme == "wss" {
+	case "ws", "wss":
 		con = connection.NewWebSocketConnection(newParams)
-	} else if scheme == "memory" || scheme == "mem" || scheme == "surrealkv" {
+	case "memory", "mem", "surrealkv":
 		return nil, fmt.Errorf("embedded database not enabled")
-	} else {
+	default:
 		return nil, fmt.Errorf("invalid connection url")
 	}
 

--- a/db.go
+++ b/db.go
@@ -111,7 +111,7 @@ func (db *DB) SignIn(authData *Auth) (string, error) {
 		return "", err
 	}
 
-	if err := db.con.Let(constants.AuthTokenKey, token.Result); err != nil {
+	if err := db.con.Let(constants.AuthTokenKey, *token.Result); err != nil {
 		return "", err
 	}
 

--- a/db.go
+++ b/db.go
@@ -51,7 +51,6 @@ func New(connectionURL string) (*DB, error) {
 		con = connection.NewWebSocketConnection(newParams)
 	} else if scheme == "memory" || scheme == "mem" || scheme == "surrealkv" {
 		return nil, fmt.Errorf("embedded database not enabled")
-		// con = connection.NewEmbeddedConnection(newParams)
 	} else {
 		return nil, fmt.Errorf("invalid connection url")
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -3,6 +3,7 @@ package surrealdb_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -92,9 +93,9 @@ func (s *SurrealDBTestSuite) SetupSuite() {
 	s.Require().NoError(err, "should not return an error when initializing db")
 	s.db = db
 
+	err = db.Use("test", "test")
 	_ = signIn(s)
 
-	err = db.Use("test", "test")
 	s.Require().NoError(err, "should not return an error when setting namespace and database")
 }
 
@@ -231,6 +232,11 @@ func (s *SurrealDBTestSuite) TestUpdate() {
 }
 
 func (s *SurrealDBTestSuite) TestLiveViaMethod() {
+	if strings.HasPrefix(getURL(), "http") {
+		s.T().Skip("Live queries are not supported in HTTP connection")
+		return
+	}
+
 	live, err := surrealdb.Live(s.db, "users", false)
 	s.Require().NoError(err, "should not return error on live request")
 
@@ -254,6 +260,10 @@ func (s *SurrealDBTestSuite) TestLiveViaMethod() {
 }
 
 func (s *SurrealDBTestSuite) TestLiveViaQuery() {
+	if strings.HasPrefix(getURL(), "http") {
+		s.T().Skip("Live queries are not supported in HTTP connection")
+		return
+	}
 	res, err := surrealdb.Query[models.UUID](s.db, "LIVE SELECT * FROM users", map[string]interface{}{})
 	s.Require().NoError(err)
 

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -151,6 +152,10 @@ func (h *HTTPConnection) MakeRequest(req *http.Request) ([]byte, error) {
 		return respBytes, nil
 	}
 
+	contentType := strings.Split(resp.Header.Get("Content-Type"), ";")[0]
+	if strings.TrimSpace(contentType) == "" {
+		return nil, fmt.Errorf(string(respBytes))
+	}
 	var errorResponse RPCResponse[any]
 	err = h.unmarshaler.Unmarshal(respBytes, &errorResponse)
 	if err != nil {

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -172,9 +172,6 @@ func (h *HTTPConnection) Use(namespace, database string) error {
 }
 
 func (h *HTTPConnection) Let(key string, value interface{}) error {
-	if v, ok := value.(*string); ok {
-		value = *v
-	}
 	h.variables.Store(key, value)
 	return nil
 }

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -111,7 +111,7 @@ func (h *HTTPConnection) Send(dest any, method string, params ...interface{}) er
 	}
 
 	if token, ok := h.variables.Load(constants.AuthTokenKey); ok {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *token.(*string)))
 	}
 
 	respData, err := h.MakeRequest(req)
@@ -154,7 +154,7 @@ func (h *HTTPConnection) MakeRequest(req *http.Request) ([]byte, error) {
 	var errorResponse RPCResponse[any]
 	err = h.unmarshaler.Unmarshal(respBytes, &errorResponse)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("%s: %s", err, string(respBytes)))
 	}
 	return nil, errorResponse.Error
 }

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -154,7 +154,7 @@ func (h *HTTPConnection) MakeRequest(req *http.Request) ([]byte, error) {
 
 	contentType := strings.Split(resp.Header.Get("Content-Type"), ";")[0]
 	if strings.TrimSpace(contentType) == "" {
-		return nil, fmt.Errorf(string(respBytes))
+		return nil, fmt.Errorf("%s", string(respBytes))
 	}
 	var errorResponse RPCResponse[any]
 	err = h.unmarshaler.Unmarshal(respBytes, &errorResponse)

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -112,7 +112,7 @@ func (h *HTTPConnection) Send(dest any, method string, params ...interface{}) er
 	}
 
 	if token, ok := h.variables.Load(constants.AuthTokenKey); ok {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *token.(*string)))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.(string)))
 	}
 
 	respData, err := h.MakeRequest(req)
@@ -172,6 +172,9 @@ func (h *HTTPConnection) Use(namespace, database string) error {
 }
 
 func (h *HTTPConnection) Let(key string, value interface{}) error {
+	if v, ok := value.(*string); ok {
+		value = *v
+	}
 	h.variables.Store(key, value)
 	return nil
 }

--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -4,7 +4,7 @@ import "errors"
 
 // Errors
 var (
-	InvalidResponse = errors.New("invalid SurrealDB response") //nolint:stylecheck
+	InvalidResponse = errors.New("invalid SurrealDB response") //nolint:staticcheck
 	ErrQuery        = errors.New("error occurred processing the SurrealDB query")
 	ErrNoRow        = errors.New("error no row")
 )


### PR DESCRIPTION
1. HTTP connections did send pointer address instad of token
2. Use needs to be called before SIGNIN with HTTP conenctions
3. Improove panic when parsing failes (On error a string is returned instad of an encoded message)

Fixes #200

Tested against:
https://github.com/surrealdb/surrealdb/commit/d8149ddcd717889f30f9eb7ebb73e86ae7aabfa0 (main from 29.03.2025)