### PR TITLE
Added specific map type to map[string]any for JSON

### DIFF
--- a/pkg/models/cbor.go
+++ b/pkg/models/cbor.go
@@ -123,7 +123,8 @@ func getCborEncoder() cbor.EncMode {
 func getCborDecoder() cbor.DecMode {
 	tags := registerCborTags()
 	dm, err := cbor.DecOptions{
-		TimeTagToAny: cbor.TimeTagToTime,
+		TimeTagToAny:   cbor.TimeTagToTime,
+		DefaultMapType: reflect.TypeOf(map[string]any(nil)),
 	}.DecModeWithTags(tags)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
CBOR decode map to map[any]any which causes the JSON marshaller to fail as it is not a supported type. We can force the map type to map[string]any in the CBOR decoder.

See issue #207 
Found solution: [CBOR](https://github.com/fxamacker/cbor/issues/654)

Questionning:
1. Does surreal support different field key than string?
2. Should we open the decoder options as parameter?