### PR TITLE
Fix Version method

### DIFF
--- a/example/connection.go
+++ b/example/connection.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
@@ -13,18 +14,40 @@ const (
 
 var currentURL = os.Getenv("SURREALDB_URL")
 
-func getSurrealDBURL() string {
+func getSurrealDBWSURL() string {
 	if currentURL == "" {
 		return defaultURL
 	}
 	return currentURL
 }
 
-func newSurrealDBConnection(namespace, database string, tables ...string) *surrealdb.DB {
-	db, err := surrealdb.New(getSurrealDBURL())
+func getSurrealDBHTTPURL() string {
+	if currentURL == "" {
+		return "http://localhost:8000"
+	}
+	return strings.ReplaceAll(currentURL, "ws", "http")
+}
+
+func newSurrealDBWSConnection(database string, tables ...string) *surrealdb.DB {
+	db, err := surrealdb.New(getSurrealDBWSURL())
 	if err != nil {
 		panic(err)
 	}
+
+	return initConnection(db, "examples", database, tables...)
+}
+
+func newSurrealDBHTTPConnection(database string, tables ...string) *surrealdb.DB {
+	db, err := surrealdb.New(getSurrealDBHTTPURL())
+	if err != nil {
+		panic(err)
+	}
+
+	return initConnection(db, "examples", database, tables...)
+}
+
+func initConnection(db *surrealdb.DB, namespace, database string, tables ...string) *surrealdb.DB {
+	var err error
 
 	if err = db.Use(namespace, database); err != nil {
 		panic(err)

--- a/example/main.go
+++ b/example/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
+//nolint:funlen
 func main() {
 	// Connect to SurrealDB
 	db, err := surrealdb.New("ws://localhost:8000")

--- a/example/query_return_test.go
+++ b/example/query_return_test.go
@@ -10,8 +10,10 @@ import (
 
 // ExampleQueryReturn demonstrates how to use the RETURN NONE clause in a query.
 // See https://github.com/surrealdb/surrealdb.go/issues/203 for more context.
+//
+//nolint:funlen
 func ExampleQuery_return() {
-	db := newSurrealDBConnection("examples", "query", "persons")
+	db := newSurrealDBWSConnection("query", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/query_test.go
+++ b/example/query_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleQuery() {
-	db := newSurrealDBConnection("examples", "query", "persons")
+	db := newSurrealDBWSConnection("query", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/update_test.go
+++ b/example/update_test.go
@@ -10,7 +10,7 @@ import (
 
 //nolint:funlen // ExampleUpdate demonstrates how to update records in SurrealDB.
 func ExampleUpdate() {
-	db := newSurrealDBConnection("examples", "update", "persons")
+	db := newSurrealDBWSConnection("update", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/version_test.go
+++ b/example/version_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+)
+
+//nolint:lll,govet
+func ExampleVersion() {
+	ws := newSurrealDBWSConnection("version")
+	v, err := ws.Version()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("VersionData (WebSocket): %+v\n", v)
+
+	http := newSurrealDBHTTPConnection("version")
+	v, err = http.Version()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("VersionData (HTTP): %+v\n", v)
+
+	// You get something like below depending on your SurrealDB version:
+	//
+	// VersionData (WebSocket): &{Version:2.3.7 Build: Timestamp:}
+	// VersionData (HTTP): &{Version:2.3.7 Build: Timestamp:}
+}


### PR DESCRIPTION
It seems like the `version` RPC method can return strings like `surrealdb-2.3.7` instead of objects as explained in https://surrealdb.com/docs/surrealdb/integration/rpc#version 🤔 

Fixes #183
