### PR TITLE
Fix excessive CBOR encoder/decoder generation

### DIFF
--- a/db.go
+++ b/db.go
@@ -38,8 +38,8 @@ func New(connectionURL string) (*DB, error) {
 	scheme := u.Scheme
 
 	newParams := connection.NewConnectionParams{
-		Marshaler:   models.CborMarshaler{},
-		Unmarshaler: models.CborUnmarshaler{},
+		Marshaler:   &models.CborMarshaler{},
+		Unmarshaler: &models.CborUnmarshaler{},
 		BaseURL:     fmt.Sprintf("%s://%s", u.Scheme, u.Host),
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
 	}

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -30,15 +30,15 @@ func TestConnectionTestSuite(t *testing.T) {
 
 	ts.connImplementations["ws"] = NewWebSocketConnection(NewConnectionParams{
 		BaseURL:     "ws://localhost:8000",
-		Marshaler:   models.CborMarshaler{},
-		Unmarshaler: models.CborUnmarshaler{},
+		Marshaler:   &models.CborMarshaler{},
+		Unmarshaler: &models.CborUnmarshaler{},
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
 	})
 
 	ts.connImplementations["http"] = NewHTTPConnection(NewConnectionParams{
 		BaseURL:     "http://localhost:8000",
-		Marshaler:   models.CborMarshaler{},
-		Unmarshaler: models.CborUnmarshaler{},
+		Marshaler:   &models.CborMarshaler{},
+		Unmarshaler: &models.CborUnmarshaler{},
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
 	})
 

--- a/pkg/connection/http_test.go
+++ b/pkg/connection/http_test.go
@@ -66,8 +66,8 @@ func (s *HTTPTestSuite) TestMockClientEngine_MakeRequest() {
 
 	p := NewConnectionParams{
 		BaseURL:     "http://test.surreal",
-		Marshaler:   models.CborMarshaler{},
-		Unmarshaler: models.CborUnmarshaler{},
+		Marshaler:   &models.CborMarshaler{},
+		Unmarshaler: &models.CborUnmarshaler{},
 	}
 
 	httpEngine := NewHTTPConnection(p)

--- a/pkg/models/cbor_test.go
+++ b/pkg/models/cbor_test.go
@@ -23,6 +23,19 @@ func TestForGeometryPoint(t *testing.T) {
 
 	assert.Nil(t, err, "Should not encounter an error while decoding")
 	assert.Equal(t, gp, decoded)
+
+	var decoded2 any
+	err = dm.Unmarshal(encoded, &decoded2)
+	assert.Nil(t, err, "Should not encounter an error while decoding to any")
+	assert.IsType(t, GeometryPoint{}, decoded2, "Decoded value should be of type GeometryPoint")
+	assert.Equal(t, gp, decoded2, "Decoded value should match the original GeometryPoint")
+
+	// Note the difference between the standard cbor the custom, SurrealDB-specific cbor tag aware cbor.
+	var decoded3 any
+	err = cbor.Unmarshal(encoded, &decoded3)
+	assert.Nil(t, err, "Should not encounter an error while decoding to any using cbor")
+	assert.IsType(t, cbor.Tag{}, decoded3, "Decoded value should be of type GeometryPoint")
+	assert.Equal(t, cbor.Tag{Number: TagGeometryPoint, Content: []interface{}{12.23, 45.65}}, decoded3)
 }
 
 func TestForGeometryLine(t *testing.T) {

--- a/pkg/models/datetime.go
+++ b/pkg/models/datetime.go
@@ -44,7 +44,7 @@ func (d *CustomDateTime) UnmarshalCBOR(data []byte) error {
 	s := temp[0]
 	ns := temp[1]
 
-	*d = CustomDateTime{time.Unix(s, ns).UTC()}
+	*d = CustomDateTime{time.Unix(s, ns)}
 
 	return nil
 }

--- a/pkg/models/datetime.go
+++ b/pkg/models/datetime.go
@@ -14,24 +14,29 @@ type CustomDateTime struct {
 }
 
 func (d *CustomDateTime) MarshalCBOR() ([]byte, error) {
-	enc := getCborEncoder()
-
 	totalNS := d.UnixNano()
 
 	s := totalNS / constants.OneSecondToNanoSecond
 	ns := totalNS % constants.OneSecondToNanoSecond
 
-	return enc.Marshal(cbor.Tag{
+	return cbor.Marshal(cbor.Tag{
 		Number:  TagCustomDatetime,
 		Content: [2]int64{s, ns},
 	})
 }
 
 func (d *CustomDateTime) UnmarshalCBOR(data []byte) error {
-	dec := getCborDecoder()
+	var tag cbor.Tag
+	if err := cbor.Unmarshal(data, &tag); err != nil {
+		return err
+	}
+
+	if tag.Number != TagCustomDatetime {
+		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagCustomDatetime)
+	}
 
 	var temp [2]int64
-	err := dec.Unmarshal(data, &temp)
+	err := cbor.Unmarshal(data, &temp)
 	if err != nil {
 		return err
 	}
@@ -39,7 +44,7 @@ func (d *CustomDateTime) UnmarshalCBOR(data []byte) error {
 	s := temp[0]
 	ns := temp[1]
 
-	*d = CustomDateTime{time.Unix(s, ns)}
+	*d = CustomDateTime{time.Unix(s, ns).UTC()}
 
 	return nil
 }

--- a/pkg/models/datetime_test.go
+++ b/pkg/models/datetime_test.go
@@ -42,8 +42,8 @@ func TestDateTime_cbor_roundtrip(t *testing.T) {
 			})
 
 			t.Run("cbor.Marshal", func(t *testing.T) {
-				cborData, err := cbor.Marshal(tc.dt)
-				require.NoError(t, err)
+				cborData, marshalErr := cbor.Marshal(tc.dt)
+				require.NoError(t, marshalErr)
 				assert.Equal(t, data, cborData)
 			})
 
@@ -55,8 +55,8 @@ func TestDateTime_cbor_roundtrip(t *testing.T) {
 			})
 
 			t.Run("CborEncoder.Marshal", func(t *testing.T) {
-				surrealCborData, err := getCborEncoder().Marshal(tc.dt)
-				require.NoError(t, err)
+				surrealCborData, marshalErr := getCborEncoder().Marshal(tc.dt)
+				require.NoError(t, marshalErr)
 				assert.Equal(t, data, surrealCborData)
 			})
 

--- a/pkg/models/datetime_test.go
+++ b/pkg/models/datetime_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:funlen
 func TestDateTime_cbor_roundtrip(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/models/datetime_test.go
+++ b/pkg/models/datetime_test.go
@@ -129,6 +129,5 @@ func TestDateTime_cbor_local_time(t *testing.T) {
 }
 
 func toLocal(dt CustomDateTime) CustomDateTime {
-	localTime := dt.Time.In(time.Local)
-	return CustomDateTime{Time: localTime}
+	return CustomDateTime{Time: dt.In(time.Local)}
 }

--- a/pkg/models/datetime_test.go
+++ b/pkg/models/datetime_test.go
@@ -39,7 +39,7 @@ func TestDateTime_cbor_roundtrip(t *testing.T) {
 			t.Run("UnmarshalCBOR", func(t *testing.T) {
 				var dt CustomDateTime
 				require.NoError(t, dt.UnmarshalCBOR(data))
-				assert.Equal(t, tc.dt.Time, dt.Time)
+				assert.Equal(t, toLocal(tc.dt), dt)
 			})
 
 			t.Run("cbor.Marshal", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestDateTime_cbor_roundtrip(t *testing.T) {
 				var dt CustomDateTime
 				err = cbor.Unmarshal(data, &dt)
 				require.NoError(t, err)
-				assert.Equal(t, tc.dt.Time, dt.Time)
+				assert.Equal(t, toLocal(tc.dt), dt)
 			})
 
 			t.Run("CborEncoder.Marshal", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestDateTime_cbor_roundtrip(t *testing.T) {
 				var dt CustomDateTime
 				err = getCborDecoder().Unmarshal(data, &dt)
 				require.NoError(t, err)
-				assert.Equal(t, tc.dt.Time, dt.Time)
+				assert.Equal(t, toLocal(tc.dt), dt)
 			})
 
 			t.Run("CborDecoder.Unmarshal to time.Time", func(t *testing.T) {
@@ -78,14 +78,14 @@ func TestDateTime_cbor_roundtrip(t *testing.T) {
 				var dt any
 				err = getCborDecoder().Unmarshal(data, &dt)
 				require.NoError(t, err)
-				assert.Equal(t, tc.dt, dt)
+				assert.Equal(t, toLocal(tc.dt), dt)
 			})
 
 			t.Run("CborUnmarshaler.Unmarshal to CustomDateTime", func(t *testing.T) {
 				var dt CustomDateTime
 				err = (&CborUnmarshaler{}).Unmarshal(data, &dt)
 				require.NoError(t, err)
-				assert.Equal(t, tc.dt.Time, dt.Time)
+				assert.Equal(t, toLocal(tc.dt), dt)
 			})
 
 			t.Run("CborUnmarshaler.Unmarshal to time.Time", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestDateTime_cbor_roundtrip(t *testing.T) {
 				var dt any
 				err = (&CborUnmarshaler{}).Unmarshal(data, &dt)
 				require.NoError(t, err)
-				assert.Equal(t, tc.dt, dt)
+				assert.Equal(t, toLocal(tc.dt), dt)
 			})
 		})
 	}
@@ -125,5 +125,10 @@ func TestDateTime_cbor_local_time(t *testing.T) {
 		t.Fatalf("failed to unmarshal CustomDateTime: %v", err)
 	}
 
-	assert.Equal(t, localTime.UTC(), decoded.Time, "unmarshaled CustomDateTime does not match original")
+	assert.Equal(t, customDT, decoded, "unmarshaled CustomDateTime does not match original")
+}
+
+func toLocal(dt CustomDateTime) CustomDateTime {
+	localTime := dt.Time.In(time.Local)
+	return CustomDateTime{Time: localTime}
 }

--- a/pkg/models/datetime_test.go
+++ b/pkg/models/datetime_test.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDateTime_cbor_roundtrip(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		dt   CustomDateTime
+	}{
+		{
+			name: "current time",
+			// .UTC() ensures the monotonic clock is stripped.
+			// Otherwise, the test fails with diff like this:
+			// -(time.Time) 2025-07-14 12:31:59.611364256 +0000 UTC m=+0.000407643
+			// +(time.Time) 2025-07-14 12:31:59.611364256 +0000 UTC
+			dt: CustomDateTime{Time: time.Now().UTC()},
+		},
+		{
+			name: "specific time",
+			dt:   CustomDateTime{Time: time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.dt.MarshalCBOR()
+			require.NoError(t, err, "failed to marshal CustomDateTime")
+
+			var decoded CustomDateTime
+			require.NoError(t, decoded.UnmarshalCBOR(data), "failed to unmarshal CustomDateTime")
+			assert.Equal(t, tc.dt.Time, decoded.Time)
+
+			cborData, err := cbor.Marshal(tc.dt)
+			require.NoError(t, err, "failed to marshal CustomDateTime with cbor")
+
+			var decodedCbor CustomDateTime
+			err = cbor.Unmarshal(cborData, &decodedCbor)
+			require.NoError(t, err, "failed to unmarshal CustomDateTime with cbor")
+			assert.Equal(t, tc.dt.Time, decodedCbor.Time)
+
+			surrealCborData, err := getCborEncoder().Marshal(tc.dt)
+			require.NoError(t, err, "failed to marshal CustomDateTime with surreal cbor")
+
+			var decodedSurreal CustomDateTime
+			err = getCborDecoder().Unmarshal(surrealCborData, &decodedSurreal)
+			require.NoError(t, err, "failed to unmarshal CustomDateTime with surreal cbor")
+			assert.Equal(t, tc.dt.Time, decodedSurreal.Time)
+		})
+	}
+}
+
+// TestDateTime_cbor_local_time tests that the CustomDateTime can handle local time correctly.
+// SurrealDB stores all times in UTC without the time zone information.
+// So, all the unmarshal function can do is to parse it as UTC.
+func TestDateTime_cbor_local_time(t *testing.T) {
+	t.Parallel()
+
+	localTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.Local)
+	customDT := CustomDateTime{Time: localTime}
+
+	data, err := customDT.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("failed to marshal CustomDateTime: %v", err)
+	}
+
+	var decoded CustomDateTime
+	if err := decoded.UnmarshalCBOR(data); err != nil {
+		t.Fatalf("failed to unmarshal CustomDateTime: %v", err)
+	}
+
+	assert.Equal(t, localTime.UTC(), decoded.Time, "unmarshaled CustomDateTime does not match original")
+}

--- a/pkg/models/duration_test.go
+++ b/pkg/models/duration_test.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuration_cbor_roundtrip(t *testing.T) {
+	d := CustomDuration{time.Hour + 30*time.Minute + 15*time.Second + 1234567890*time.Nanosecond}
+	data, err := cbor.Marshal(d)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var d2 CustomDuration
+	assert.NoError(t, cbor.Unmarshal(data, &d2), "failed to unmarshal CustomDuration")
+	assert.Equal(t, d, d2, "unmarshaled CustomDuration does not match original")
+
+	surrealData, err := getCborEncoder().Marshal(d)
+	assert.NoError(t, err, "failed to marshal CustomDuration with surreal cbor")
+	var surrealDecoded CustomDuration
+	assert.NoError(t, getCborDecoder().Unmarshal(surrealData, &surrealDecoded),
+		"failed to unmarshal CustomDuration with surreal cbor")
+	assert.Equal(t, d, surrealDecoded, "unmarshaled CustomDuration with surreal cbor does not match original")
+
+	cborData, err := cbor.Marshal(d)
+	assert.NoError(t, err, "failed to marshal CustomDuration with cbor")
+	var cborDecoded CustomDuration
+	assert.NoError(t, cbor.Unmarshal(cborData, &cborDecoded), "failed to unmarshal CustomDuration with cbor")
+	assert.Equal(t, d, cborDecoded, "unmarshaled CustomDuration with cbor does not match original")
+}

--- a/pkg/models/geometry.go
+++ b/pkg/models/geometry.go
@@ -29,7 +29,7 @@ func (gp *GeometryPoint) MarshalCBOR() ([]byte, error) {
 }
 
 func (gp *GeometryPoint) UnmarshalCBOR(data []byte) error {
-	var tag cbor.Tag
+	var tag cbor.RawTag
 	if err := cbor.Unmarshal(data, &tag); err != nil {
 		return err
 	}
@@ -38,23 +38,17 @@ func (gp *GeometryPoint) UnmarshalCBOR(data []byte) error {
 		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagGeometryPoint)
 	}
 
-	content, ok := tag.Content.([]any)
-	if !ok {
-		return fmt.Errorf("unexpected content type: got %T, want [2]float64", tag.Content)
+	data, err := tag.Content.MarshalCBOR()
+	if err != nil {
+		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of GeometryPoint: %w", err)
 	}
 
-	lat, ok := content[0].(float64)
-	if !ok {
-		return fmt.Errorf("unexpected type for latitude: got %T, want float64", content[0])
+	var latlon [2]float64
+	if err := cbor.Unmarshal(data, &latlon); err != nil {
+		return fmt.Errorf("failed to unmarshal GeometryPoint coordinates: %w", err)
 	}
-
-	lon, ok := content[1].(float64)
-	if !ok {
-		return fmt.Errorf("unexpected type for longitude: got %T, want float64", content[1])
-	}
-
-	gp.Latitude = lat
-	gp.Longitude = lon
+	gp.Latitude = latlon[0]
+	gp.Longitude = latlon[1]
 
 	return nil
 }

--- a/pkg/models/geometry.go
+++ b/pkg/models/geometry.go
@@ -29,18 +29,9 @@ func (gp *GeometryPoint) MarshalCBOR() ([]byte, error) {
 }
 
 func (gp *GeometryPoint) UnmarshalCBOR(data []byte) error {
-	var tag cbor.RawTag
-	if err := cbor.Unmarshal(data, &tag); err != nil {
-		return err
-	}
-
-	if tag.Number != TagGeometryPoint {
-		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagGeometryPoint)
-	}
-
-	data, err := tag.Content.MarshalCBOR()
+	data, err := getTaggedContent(data, TagGeometryPoint)
 	if err != nil {
-		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of GeometryPoint: %w", err)
+		return fmt.Errorf("GeometryPoint: %w", err)
 	}
 
 	var latlon [2]float64

--- a/pkg/models/geometry.go
+++ b/pkg/models/geometry.go
@@ -38,14 +38,23 @@ func (gp *GeometryPoint) UnmarshalCBOR(data []byte) error {
 		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagGeometryPoint)
 	}
 
-	var temp [2]float64
-	err := cbor.Unmarshal(data, &temp)
-	if err != nil {
-		return err
+	content, ok := tag.Content.([]any)
+	if !ok {
+		return fmt.Errorf("unexpected content type: got %T, want [2]float64", tag.Content)
 	}
 
-	gp.Latitude = temp[0]
-	gp.Longitude = temp[1]
+	lat, ok := content[0].(float64)
+	if !ok {
+		return fmt.Errorf("unexpected type for latitude: got %T, want float64", content[0])
+	}
+
+	lon, ok := content[1].(float64)
+	if !ok {
+		return fmt.Errorf("unexpected type for longitude: got %T, want float64", content[1])
+	}
+
+	gp.Latitude = lat
+	gp.Longitude = lon
 
 	return nil
 }

--- a/pkg/models/geometry.go
+++ b/pkg/models/geometry.go
@@ -1,6 +1,10 @@
 package models
 
-import "github.com/fxamacker/cbor/v2"
+import (
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+)
 
 type GeometryPoint struct {
 	Latitude  float64
@@ -18,19 +22,24 @@ func (gp *GeometryPoint) GetCoordinates() [2]float64 {
 }
 
 func (gp *GeometryPoint) MarshalCBOR() ([]byte, error) {
-	enc := getCborEncoder()
-
-	return enc.Marshal(cbor.Tag{
+	return cbor.Marshal(cbor.Tag{
 		Number:  TagGeometryPoint,
 		Content: gp.GetCoordinates(),
 	})
 }
 
 func (gp *GeometryPoint) UnmarshalCBOR(data []byte) error {
-	dec := getCborDecoder()
+	var tag cbor.Tag
+	if err := cbor.Unmarshal(data, &tag); err != nil {
+		return err
+	}
+
+	if tag.Number != TagGeometryPoint {
+		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagGeometryPoint)
+	}
 
 	var temp [2]float64
-	err := dec.Unmarshal(data, &temp)
+	err := cbor.Unmarshal(data, &temp)
 	if err != nil {
 		return err
 	}

--- a/pkg/models/range.go
+++ b/pkg/models/range.go
@@ -19,7 +19,7 @@ func (bi *BoundIncluded[T]) MarshalCBOR() ([]byte, error) {
 }
 
 func (bi *BoundIncluded[T]) UnmarshalCBOR(data []byte) error {
-	var tag cbor.Tag
+	var tag cbor.RawTag
 	if err := cbor.Unmarshal(data, &tag); err != nil {
 		return err
 	}
@@ -28,9 +28,13 @@ func (bi *BoundIncluded[T]) UnmarshalCBOR(data []byte) error {
 		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagBoundIncluded)
 	}
 
-	var temp T
-	err := cbor.Unmarshal(data, &temp)
+	data, err := tag.Content.MarshalCBOR()
 	if err != nil {
+		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of BoundIncluded: %w", err)
+	}
+
+	var temp T
+	if err := cbor.Unmarshal(data, &temp); err != nil {
 		return err
 	}
 

--- a/pkg/models/range.go
+++ b/pkg/models/range.go
@@ -19,18 +19,9 @@ func (bi *BoundIncluded[T]) MarshalCBOR() ([]byte, error) {
 }
 
 func (bi *BoundIncluded[T]) UnmarshalCBOR(data []byte) error {
-	var tag cbor.RawTag
-	if err := cbor.Unmarshal(data, &tag); err != nil {
-		return err
-	}
-
-	if tag.Number != TagBoundIncluded {
-		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagBoundIncluded)
-	}
-
-	data, err := tag.Content.MarshalCBOR()
+	data, err := getTaggedContent(data, TagBoundIncluded)
 	if err != nil {
-		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of BoundIncluded: %w", err)
+		return fmt.Errorf("BoundIncluded: %w", err)
 	}
 
 	var temp T
@@ -54,29 +45,9 @@ func (be *BoundExcluded[T]) MarshalCBOR() ([]byte, error) {
 }
 
 func (be *BoundExcluded[T]) UnmarshalCBOR(data []byte) error {
-	var tag cbor.RawTag
-	if err := cbor.Unmarshal(data, &tag); err != nil {
-		return err
-	}
-
-	if tag.Number != TagBoundExcluded {
-		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagBoundExcluded)
-	}
-
-	// Note that the below is impossible due to `invalid composite literal type T`:
-	//   var tag cbor.Tag
-	//   cbor.Unmarshal(data, &tag)
-	//   ...
-	//   v, ok := tag.Content.(T)
-	// So all we can do is unmarshal once more into a temporary variable of type T.
-	// This is a workaround for the fact that cbor.Tag do not carry type information for Content.
-
-	// Although this looks marshaling the unmarshaled data againn which might be inefficient,
-	// this is actually not the case because cbor.Tag.Content(RawMessage) is already a raw byte slice
-	// and RawMessage.MarshalCBOR() just returns the raw bytes without any additional encoding.
-	data, err := tag.Content.MarshalCBOR()
+	data, err := getTaggedContent(data, TagBoundExcluded)
 	if err != nil {
-		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of BoundExcluded: %w", err)
+		return fmt.Errorf("BoundExcluded: %w", err)
 	}
 
 	var temp T
@@ -134,18 +105,9 @@ func (r *Range[T, TBeg, TEnd]) MarshalCBOR() ([]byte, error) {
 }
 
 func (r *Range[T, TBeg, TEnd]) UnmarshalCBOR(data []byte) error {
-	var tag cbor.RawTag
-	if err := cbor.Unmarshal(data, &tag); err != nil {
-		return err
-	}
-
-	if tag.Number != TagRange {
-		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagRange)
-	}
-
-	data, err := tag.Content.MarshalCBOR()
+	data, err := getTaggedContent(data, TagRange)
 	if err != nil {
-		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of Range: %w", err)
+		return fmt.Errorf("Range: %w", err)
 	}
 
 	var temp [2]cbor.RawTag

--- a/pkg/models/range.go
+++ b/pkg/models/range.go
@@ -72,7 +72,7 @@ func (be *BoundExcluded[T]) UnmarshalCBOR(data []byte) error {
 	// and RawMessage.MarshalCBOR() just returns the raw bytes without any additional encoding.
 	data, err := tag.Content.MarshalCBOR()
 	if err != nil {
-		panic("failed to extract the raw bytes from cbor.Tag.Content: " + err.Error())
+		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of BoundExcluded: %w", err)
 	}
 
 	var temp T
@@ -130,7 +130,7 @@ func (r *Range[T, TBeg, TEnd]) MarshalCBOR() ([]byte, error) {
 }
 
 func (r *Range[T, TBeg, TEnd]) UnmarshalCBOR(data []byte) error {
-	var tag cbor.Tag
+	var tag cbor.RawTag
 	if err := cbor.Unmarshal(data, &tag); err != nil {
 		return err
 	}
@@ -139,9 +139,13 @@ func (r *Range[T, TBeg, TEnd]) UnmarshalCBOR(data []byte) error {
 		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagRange)
 	}
 
-	var temp [2]cbor.RawTag
-	err := cbor.Unmarshal(data, &temp)
+	data, err := tag.Content.MarshalCBOR()
 	if err != nil {
+		return fmt.Errorf("failed to extract the raw bytes from cbor tag content of Range: %w", err)
+	}
+
+	var temp [2]cbor.RawTag
+	if err := cbor.Unmarshal(data, &temp); err != nil {
 		return err
 	}
 

--- a/pkg/models/record_id.go
+++ b/pkg/models/record_id.go
@@ -32,19 +32,24 @@ func NewRecordID(tableName string, id any) RecordID {
 }
 
 func (r *RecordID) MarshalCBOR() ([]byte, error) {
-	enc := getCborEncoder()
-
-	return enc.Marshal(cbor.Tag{
+	return cbor.Marshal(cbor.Tag{
 		Number:  TagRecordID,
 		Content: []interface{}{r.Table, r.ID},
 	})
 }
 
 func (r *RecordID) UnmarshalCBOR(data []byte) error {
-	dec := getCborDecoder()
+	var tag cbor.Tag
+	if err := cbor.Unmarshal(data, &tag); err != nil {
+		return err
+	}
+
+	if tag.Number != TagRecordID {
+		return fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, TagRecordID)
+	}
 
 	var temp []interface{}
-	err := dec.Unmarshal(data, &temp)
+	err := cbor.Unmarshal(data, &temp)
 	if err != nil {
 		return err
 	}

--- a/pkg/models/record_id_test.go
+++ b/pkg/models/record_id_test.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordID_cbor_roundtrip(t *testing.T) {
+	testcases := []struct {
+		name string
+		rid  RecordID
+	}{
+		{
+			name: "string ID",
+			rid: RecordID{
+				Table: "test_table",
+				ID:    "test_id",
+			},
+		},
+		{
+			name: "number-like string ID",
+			rid: RecordID{
+				Table: "test_table",
+				ID:    "12345",
+			},
+		},
+		{
+			name: "numeric ID",
+			rid: RecordID{
+				Table: "test_table",
+				// Note that int64(12345) result in a test failure because it is unmarshalled as uint64(0x3039)
+				ID: uint64(12345),
+			},
+		},
+		{
+			name: "numeric negative ID",
+			rid: RecordID{
+				Table: "test_table",
+				ID:    int64(-12345),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := cbor.Marshal(tc.rid)
+			require.NoError(t, err, "failed to marshal RecordID")
+
+			var decoded RecordID
+			require.NoError(t, cbor.Unmarshal(data, &decoded), "failed to unmarshal RecordID")
+			assert.Equal(t, tc.rid.Table, decoded.Table, "unmarshaled RecordID Table does not match original")
+			assert.Equal(t, tc.rid.ID, decoded.ID, "unmarshaled RecordID ID does not match original")
+
+			cborData, err := cbor.Marshal(tc.rid)
+			require.NoError(t, err, "failed to marshal RecordID with cbor")
+
+			var cborDecoded RecordID
+			err = cbor.Unmarshal(cborData, &cborDecoded)
+			require.NoError(t, err, "failed to unmarshal RecordID with cbor")
+			assert.Equal(t, tc.rid.Table, cborDecoded.Table, "unmarshaled RecordID with cbor Table does not match original")
+			assert.Equal(t, tc.rid.ID, cborDecoded.ID, "unmarshaled RecordID with cbor ID does not match original")
+
+			surrealData, err := getCborEncoder().Marshal(tc.rid)
+			require.NoError(t, err, "failed to marshal RecordID with surreal cbor")
+
+			var surrealDecoded RecordID
+			err = getCborDecoder().Unmarshal(surrealData, &surrealDecoded)
+			require.NoError(t, err, "failed to unmarshal RecordID with surreal cbor")
+			assert.Equal(t, tc.rid.Table, surrealDecoded.Table,
+				"unmarshaled RecordID with surreal cbor Table does not match original")
+			assert.Equal(t, tc.rid.ID, surrealDecoded.ID, "unmarshaled RecordID with surreal cbor ID does not match original")
+		})
+	}
+}

--- a/pkg/models/tagged_content.go
+++ b/pkg/models/tagged_content.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+func getTaggedContent(data []byte, tagNumber uint64) ([]byte, error) {
+	var tag cbor.RawTag
+	if err := cbor.Unmarshal(data, &tag); err != nil {
+		return nil, err
+	}
+
+	if tag.Number != tagNumber {
+		return nil, fmt.Errorf("unexpected tag number: got %d, want %d", tag.Number, tagNumber)
+	}
+
+	// Note that the below is impossible due to `invalid composite literal type T`:
+	//   var tag cbor.Tag
+	//   cbor.Unmarshal(data, &tag)
+	//   ...
+	//   v, ok := tag.Content.(T)
+	// So all we can do is unmarshal once more into a temporary variable of type T.
+	// This is a workaround for the fact that cbor.Tag do not carry type information for Content.
+
+	// Although this looks marshaling the unmarshaled data againn which might be inefficient,
+	// this is actually not the case because cbor.Tag.Content(RawMessage) is already a raw byte slice
+	// and RawMessage.MarshalCBOR() just returns the raw bytes without any additional encoding.
+	contentData, err := tag.Content.MarshalCBOR()
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract the raw bytes from cbor tag content: %w", err)
+	}
+
+	return contentData, nil
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -10,9 +10,7 @@ type CustomNil struct {
 }
 
 func (c *CustomNil) MarshalCBOR() ([]byte, error) {
-	enc := getCborEncoder()
-
-	return enc.Marshal(cbor.Tag{
+	return cbor.Marshal(cbor.Tag{
 		Number:  TagNone,
 		Content: nil,
 	})


### PR DESCRIPTION
Fixes #202

It turns out that we needed neither a global `cbor.{Enc,Dec}Mode` nor a local instance of it per each Marshal/UnmarshalCBOR function call.

Since we know the CBOR tag number and structure for each custom type we provided, we can use the standard `cbor.Marshal` and `cbor.Unmarshal` within the respective custom types' Marshal/UnmarshalCBOR functions.

Please see all the new and modified test cases that feature:

- `getCborEncoder().Marshal` vs `cbor.Marshal` vs `customType.MarshalCBOR()`
- `getCborDecoder().Unmarshal` vs `cbor.Unmarshal` vs `customType.UnmarshalCBOR()`

... and that all those work!

I reviewed all existing test cases and added any missing ones to ensure this change does not break anything.

~While doing so, I even found a new issue in our CustomDateTime's unmarshalling logic, where it can incorrectly unmarshal times as local times. I opted to fix that in this pull request, because otherwise I had to write tests for wrong behavior, which is correct, but not the way I love🙏~ (EDIT: This turned out to be my misunderstanding)

Reference:
- https://github.com/fxamacker/cbor?tab=readme-ov-file#cbor-tags
- https://github.com/fxamacker/cbor/blob/master/example_embedded_json_tag_for_cbor_test.go

**NOTE**: This change incurs (technically) a breaking change, where any direct uses of `CborMarshaler` need to be updated to `&CborMarshaler`, and `CborUnmarshaler` to `&CborUnmarshaler`. It will affect you only when you use it directly, which I believe is very unlikely to happen.