### PR TITLE
Tweak linter exclusions on testable examples

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,11 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      - path: _test\.go
+        linters:
+          - dupl
+          - funlen
+          - lll
       - linters:
           - mnd
         path: _test\.go

--- a/example/example_insert_relation_test.go
+++ b/example/example_insert_relation_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
-//nolint:funlen
 func ExampleInsertRelation() {
 	db := newSurrealDBWSConnection("query", "person", "follow")
 

--- a/example/example_relate_test.go
+++ b/example/example_relate_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
-//nolint:funlen
 func ExampleRelate() {
 	db := newSurrealDBWSConnection("query", "person", "follow")
 


### PR DESCRIPTION
We are seeing unnecessary linter errors on testable examples.
Let me tweak the configuration so that we no longer need to add bunch of `nolint` comments!