### PR TITLE
Prevent making query error look like unmarshal error

### DIFF
--- a/example/example_query_transaction_test.go
+++ b/example/example_query_transaction_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
@@ -31,24 +32,69 @@ func ExampleQuery_transaction_return() {
 func ExampleQuery_transaction_throw() {
 	db := newSurrealDBWSConnection("query", "person")
 
-	var err error
+	var (
+		queryResults *[]surrealdb.QueryResult[*int]
+		err          error
+	)
 
-	// Making b parameterized with `bool` type
-	// would make it fail with `cannot unmarshal UTF-8 text string into Go struct field`
-	// like reported in https://github.com/surrealdb/surrealdb.go/issues/175
-	var b *[]surrealdb.QueryResult[any]
-	b, err = surrealdb.Query[any](
+	// Up until v0.4.3, making QueryResult[T] parameterized with anything other than `any`
+	// or `string` failed with:
+	//   cannot unmarshal UTF-8 text string into Go struct field
+	// in case the query was executed on the database but failed with an error.
+	//
+	// It was due to a mismatch between the expected type and the actual type-
+	// The actual query result was a string, which provides the error message sent
+	// from the database, regardless of the type parameter specified to the Query function.
+	//
+	// Since v0.4.4, the QueryResult was enhanced to set the Error field
+	// to a QueryError if the query failed, allowing the caller to handle the error.
+	// In that case, the Result field will be empty(or nil if it is a pointer type),
+	// and the Status field will be set to "ERR".
+	//
+	// It's also worth noting that the returned error from the Query function
+	// will be nil if the query was executed successfully, in which case all the results
+	// have no Error field set.
+	//
+	// If the query failed, the returned error will be a `joinError` created by the `errors.Join` function,
+	// which contains all the errors that occurred during the query execution.
+	// The caller can check the Error field of each QueryResult to see if the query failed,
+	// or check the returned error from the Query function to see if the query failed.
+	queryResults, err = surrealdb.Query[*int](
 		db,
 		`BEGIN; THROW "test"; RETURN 1; COMMIT;`,
 		nil,
 	)
-	if err != nil {
-		panic(err)
+	fmt.Printf("# of results: %d\n", len(*queryResults))
+	fmt.Println("=== Func error ===")
+	fmt.Printf("Error: %v\n", err)
+	fmt.Printf("Error is RPCError: %v\n", errors.Is(err, &surrealdb.RPCError{}))
+	fmt.Printf("Error is QueryError: %v\n", errors.Is(err, &surrealdb.QueryError{}))
+	for i, r := range *queryResults {
+		fmt.Printf("=== QueryResult[%d] ===\n", i)
+		fmt.Printf("Status: %v\n", r.Status)
+		fmt.Printf("Result: %v\n", r.Result)
+		fmt.Printf("Error: %v\n", r.Error)
+		fmt.Printf("Error is RPCError: %v\n", errors.Is(r.Error, &surrealdb.RPCError{}))
+		fmt.Printf("Error is QueryError: %v\n", errors.Is(r.Error, &surrealdb.QueryError{}))
 	}
-	fmt.Printf("Status: %v\n", (*b)[0].Status)
-	fmt.Printf("Result: %v\n", (*b)[0].Result)
 
 	// Output:
+	// # of results: 2
+	// === Func error ===
+	// Error: An error occurred: test
+	// The query was not executed due to a failed transaction
+	// Error is RPCError: false
+	// Error is QueryError: true
+	// === QueryResult[0] ===
 	// Status: ERR
-	// Result: An error occurred: test
+	// Result: <nil>
+	// Error: An error occurred: test
+	// Error is RPCError: false
+	// Error is QueryError: true
+	// === QueryResult[1] ===
+	// Status: ERR
+	// Result: <nil>
+	// Error: The query was not executed due to a failed transaction
+	// Error is RPCError: false
+	// Error is QueryError: true
 }

--- a/example/example_upsert_test.go
+++ b/example/example_upsert_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -99,4 +100,80 @@ func ExampleUpsert() {
 	// Update via upsert result: {persons:yusuke Yusuke Updated {0001-01-01 00:00:00 +0000 UTC} 2023-10-01T12:00:00Z}
 	// Update further via upsert result: {persons:yusuke Yusuke Updated Further {2023-10-01 12:00:00 +0000 UTC} 2023-10-02T12:00:00Z}
 	// Selected person: {persons:yusuke Yusuke Updated Last {0001-01-01 00:00:00 +0000 UTC} <nil>}
+}
+
+func ExampleUpsert_unmarshal_error() {
+	db := newSurrealDBWSConnection("query", "person")
+
+	type Person struct {
+		Name string `json:"name"`
+	}
+
+	// This will fail because the record ID is not valid.
+	_, err := surrealdb.Upsert[Person](
+		db,
+		models.Table("person"),
+		map[string]any{
+			// We are trying to set the name field to a number,
+			// which is OK from the database's perspective,
+			// because the table is schemaless for this example.
+			//
+			// However, we are trying to unmarshal the result into a struct
+			// that expects the name field to be a string,
+			// which will fail when the result is unmarshaled.
+			"name": 123,
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		fmt.Printf("Error is RPCError: %v\n", errors.Is(err, &surrealdb.RPCError{}))
+	}
+
+	// Output:
+	// Error: error unmarshaing response: Send: error unmarshaling result: cbor: cannot unmarshal array into Go value of type main.Person (cannot decode CBOR array to struct without toarray option)
+	// Error is RPCError: false
+}
+
+func ExampleUpsert_rpc_error() {
+	db := newSurrealDBWSConnection("query", "person")
+
+	type Person struct {
+		Name string `json:"name"`
+	}
+
+	// For this example, we will define a SCHEMAFUL table
+	// with a name field that is a string.
+	// Trying to set the name field to a number
+	// will result in an error from the database.
+
+	if _, err := surrealdb.Query[any](
+		db,
+		`DEFINE TABLE person SCHEMAFUL;
+		 DEFINE FIELD name ON person TYPE string;`,
+		nil,
+	); err != nil {
+		panic(err)
+	}
+
+	// This will fail because the record ID is not valid.
+	_, err := surrealdb.Upsert[Person](
+		db,
+		models.Table("person"),
+		map[string]any{
+			"id": models.NewRecordID("person", "a"),
+			// Unlike ExampleUpsert_unmarshal_error,
+			// this will fail on the database side
+			// because the name field is defined as a string,
+			// and we are trying to set it to a number.
+			"name": 123,
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		fmt.Printf("Error is RPCError: %v\n", errors.Is(err, &surrealdb.RPCError{}))
+	}
+
+	// Output:
+	// Error: There was a problem with the database: Couldn't coerce value for field `name` of `person:a`: Expected `string` but found `123`
+	// Error is RPCError: true
 }

--- a/example/example_upsert_test.go
+++ b/example/example_upsert_test.go
@@ -169,11 +169,20 @@ func ExampleUpsert_rpc_error() {
 		},
 	)
 	if err != nil {
-		fmt.Printf("Error: %v\n", err)
+		switch err.Error() {
+		// As of v3.0.0-alpha.7
+		case "There was a problem with the database: Couldn't coerce value for field `name` of `person:a`: Expected `string` but found `123`":
+			fmt.Println("Encountered expected error for either v3.0.0-alpha.7 or v2.3.7")
+			// As of v2.3.7
+		case "There was a problem with the database: Found 123 for field `name`, with record `person:a`, but expected a string":
+			fmt.Println("Encountered expected error for either v3.0.0-alpha.7 or v2.3.7")
+		default:
+			fmt.Printf("Unknown Error: %v\n", err)
+		}
 		fmt.Printf("Error is RPCError: %v\n", errors.Is(err, &surrealdb.RPCError{}))
 	}
 
 	// Output:
-	// Error: There was a problem with the database: Couldn't coerce value for field `name` of `person:a`: Expected `string` but found `123`
+	// Encountered expected error for either v3.0.0-alpha.7 or v2.3.7
 	// Error is RPCError: true
 }

--- a/pkg/connection/model.go
+++ b/pkg/connection/model.go
@@ -14,6 +14,15 @@ func (r RPCError) Error() string {
 	return r.Message
 }
 
+func (r *RPCError) Is(target error) bool {
+	if target == nil {
+		return r == nil
+	}
+
+	_, ok := target.(*RPCError)
+	return ok
+}
+
 // RPCRequest represents an incoming JSON-RPC request
 type RPCRequest struct {
 	ID     interface{}   `json:"id" msgpack:"id"`

--- a/pkg/connection/ws.go
+++ b/pkg/connection/ws.go
@@ -191,7 +191,7 @@ func (ws *WebSocketConnection) Send(dest interface{}, method string, params ...i
 		// we cannot proceed with unmarshaling the Result field,
 		// because it would always fail.
 		// The only thing we can do is to return the error if any.
-		if nilOrTypedNil(dest) || res.Result == nil {
+		if nilOrTypedNil(dest) || res.Result == nil || res.Error != nil {
 			return eliminateTypedNilError(res.Error)
 		}
 

--- a/types.go
+++ b/types.go
@@ -3,9 +3,12 @@ package surrealdb
 import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/surrealdb/surrealdb.go/internal/codec"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
+
+type RPCError = connection.RPCError
 
 // Patch represents a patch object set to MODIFY a record
 type PatchData struct {
@@ -15,9 +18,35 @@ type PatchData struct {
 }
 
 type QueryResult[T any] struct {
-	Status string `json:"status"`
-	Time   string `json:"time"`
-	Result T      `json:"result"`
+	Status string      `json:"status"`
+	Time   string      `json:"time"`
+	Result T           `json:"result"`
+	Error  *QueryError `json:"-"`
+}
+
+// QueryError represents an error that occurred during a query execution.
+//
+// The caller can type-assert the return errror to QueryError to see if
+// the error is a query error or not.
+type QueryError struct {
+	Message string
+}
+
+func (e *QueryError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	return e.Message
+}
+
+func (e *QueryError) Is(target error) bool {
+	if target == nil {
+		return e == nil
+	}
+
+	_, ok := target.(*QueryError)
+	return ok
 }
 
 type QueryStmt struct {


### PR DESCRIPTION
This fixes `Query` to return an error if the was a query error.

Sounds obvious? But we missed doing so!

> Note the difference between the RPC error and Query error!
>
> A RPC request contains methods like `insert`, `update`, `query`, and so on. Each RPC request can either fail or succeed, in which case it returns an RPC error or not, respectively.
>
> Each `query` RPC contains the SurrealQL query to be executed, and the query RPC returns one or more query results, each containing (ID, Status, Result).
>
> The query Result is `string` in case the result indicates an error, OR any type that corresponds to the successful query result.
> A query error means SurrealDB processed the RPC request, although it was unable to complete the query contained in the RPC request.

Previously, this kind of error was not exposed to you, the consumer of the `Query` function. Instead, all you saw was an unmarshal error, as reported in #175.

Why? It was caused by the underlying logic trying to unmarshal the "error message" provided via "RPC Response Query Result" into a specified response type, which is not always possible.

We typically use the `Query` method in a manner like `Query[[]Person]`, and have been assuming that the RPC response sent from SurrealDB must always be unmarshalable into `[[]QueryResult[[]Person]`, which is not always the case. And we missed that. That's why it happened.

Let's call `[]Person` the query result type- The actual query result's data type sent from SurrealDB can be either something that can be unmarshaled into the specified result type, OR a string in case the response status was `ERR`. We don't have a concept like `union` in Go, so the best we can do is modify the meaning of `QueryResult` to act like a union of the `successful result` and the `error message string`.

More concretely, we now do selective unmarshaling; Unmarshal into the new "error" field on the result if the response status is`ERR`, otherwise unmarshal into the result type as before.

Anyway, you can see the updated `ExampleQuery_transaction_throw` example to see what changed and how you can look into the query error(s) without falling into an unmarshal error.

Fixes #175