### PR TITLE
Fix: don't panic on invalid record ID

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -174,7 +174,9 @@ func (s *SurrealDBTestSuite) TestInsert() {
 }
 
 func (s *SurrealDBTestSuite) TestPatch() {
-	_, err := surrealdb.Create[testUser](s.db, *models.ParseRecordID("users:999"), map[string]interface{}{
+	recordID, err := models.ParseRecordID("users:999")
+	s.Require().NoError(err)
+	_, err = surrealdb.Create[testUser](s.db, *recordID, map[string]interface{}{
 		"username": "john999",
 		"password": "123",
 	})
@@ -186,10 +188,10 @@ func (s *SurrealDBTestSuite) TestPatch() {
 	}
 
 	// Update the user
-	_, err = surrealdb.Patch(s.db, models.ParseRecordID("users:999"), patches)
+	_, err = surrealdb.Patch(s.db, recordID, patches)
 	s.Require().NoError(err)
 
-	user2, err := surrealdb.Select[map[string]interface{}](s.db, *models.ParseRecordID("users:999"))
+	user2, err := surrealdb.Select[map[string]interface{}](s.db, *recordID)
 	s.Require().NoError(err)
 
 	username := (*user2)["username"].(string)
@@ -401,19 +403,21 @@ func (s *SurrealDBTestSuite) TestConcurrentOperations() {
 }
 
 func (s *SurrealDBTestSuite) TestMerge() {
-	_, err := surrealdb.Create[testUser](s.db, *models.ParseRecordID("users:999"), map[string]interface{}{
+	recordID, err := models.ParseRecordID("users:999")
+	s.Require().NoError(err)
+	_, err = surrealdb.Create[testUser](s.db, *recordID, map[string]interface{}{
 		"username": "john999",
 		"password": "123",
 	})
 	s.NoError(err)
 
 	// Update the user
-	_, err = surrealdb.Merge[testUser](s.db, *models.ParseRecordID("users:999"), map[string]string{
+	_, err = surrealdb.Merge[testUser](s.db, *recordID, map[string]string{
 		"password": "456",
 	})
 	s.Require().NoError(err)
 
-	user, err := surrealdb.Select[testUser](s.db, *models.ParseRecordID("users:999"))
+	user, err := surrealdb.Select[testUser](s.db, *recordID)
 	s.Require().NoError(err)
 	s.Equal("john999", user.Username) // Ensure username hasn't change.
 	s.Equal("456", user.Password)

--- a/pkg/models/record_id.go
+++ b/pkg/models/record_id.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,15 +17,17 @@ type RecordIDType interface {
 	~int | ~string | []any | map[string]any
 }
 
-func ParseRecordID(idStr string) *RecordID {
+var ErrBadRecordID = errors.New("invalid record ID (want <table>:<identifier>)")
+
+func ParseRecordID(idStr string) (*RecordID, error) {
 	expectedLen := 2
 	bits := strings.Split(idStr, ":")
 	if len(bits) != expectedLen {
-		panic(fmt.Errorf("invalid id string. Expected format is 'tablename:indentifier'"))
+		return nil, fmt.Errorf("%w: %q", ErrBadRecordID, idStr)
 	}
 	return &RecordID{
 		Table: bits[0], ID: bits[1],
-	}
+	}, nil
 }
 
 func NewRecordID(tableName string, id any) RecordID {


### PR DESCRIPTION
### What does this change?
* Replaces the `panic` in `ParseRecordID` with a `(val, error)` return.
* Introduces a sentinel error `ErrBadRecordID` so callers can `errors.Is(..)` without relying on string matching.

### Why?
1. Invalid user input *shouldn’t* crash the entire application—only the request that supplied it.
2. A panic exposed an easy denial-of-service vector: any request with an invalid `id` could terminate the process.
3. Returning an error follows Go’s standard error-handling idioms and makes unit-testing simpler.

### How to review
* **Focus file:** `pkg/models/record_id.go`
* Call-site updates are mechanical (`_, err := ParseRecordID(...)`).

### Backwards compatibility
This change is source-breaking: callers now receive `(val, error)`. They’ll need to add an error check, but that’s a compile-time failure—far better than the previous runtime panic on invalid input.