### PR TITLE
Enhance models.ID.String() to escape number-like string IDs with ⟨⟩

### DIFF
--- a/pkg/models/cbor_test.go
+++ b/pkg/models/cbor_test.go
@@ -206,11 +206,6 @@ func TestCustomDuration_String(t *testing.T) {
 	assert.Equal(t, "1y2w6d19h15m33s333ms", cd.String())
 }
 
-func TestRecordID_String(t *testing.T) {
-	rid := RecordID{Table: "mytesttable", ID: "121212121"}
-	assert.Equal(t, "mytesttable:121212121", rid.String())
-}
-
 func TestFormatDurationAndParseDuration(t *testing.T) {
 	durationStr := "1y2w6d19h15m33s333ms"
 

--- a/pkg/models/record_id.go
+++ b/pkg/models/record_id.go
@@ -63,10 +63,6 @@ func (r *RecordID) UnmarshalCBOR(data []byte) error {
 	return nil
 }
 
-func (r *RecordID) String() string {
-	return fmt.Sprintf("%s:%s", r.Table, r.ID)
-}
-
 func (r *RecordID) SurrealString() string {
 	return fmt.Sprintf("r'%s'", r.String())
 }

--- a/pkg/models/record_id_string.go
+++ b/pkg/models/record_id_string.go
@@ -1,0 +1,84 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+)
+
+// isASCIIDigit checks if a rune is an ASCII digit (0-9)
+func isASCIIDigit(ch rune) bool {
+	return ch >= '0' && ch <= '9'
+}
+
+// isASCIIAlphanumeric checks if a rune is an ASCII letter or digit
+func isASCIIAlphanumeric(ch rune) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || isASCIIDigit(ch)
+}
+
+// escapeString escapes a string according to the delimiter character.
+// It escapes the delimiter and backslash characters.
+func escapeString(s string, delimiter rune) string {
+	var result strings.Builder
+	for _, ch := range s {
+		if ch == delimiter || ch == '\\' {
+			result.WriteRune('\\')
+		}
+		result.WriteRune(ch)
+	}
+	return result.String()
+}
+
+// isAllDigitsOrUnderscore checks if a string contains only digits and underscores
+func isAllDigitsOrUnderscore(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, ch := range s {
+		if ch != '_' && !isASCIIDigit(ch) {
+			return false
+		}
+	}
+	return true
+}
+
+// needsEscaping checks if a string needs escaping based on the Rust logic
+func needsEscaping(s string) bool {
+	// Check if contains non-alphanumeric (except underscore) characters
+	hasSpecialChars := false
+	for _, ch := range s {
+		if !isASCIIAlphanumeric(ch) && ch != '_' {
+			hasSpecialChars = true
+			break
+		}
+	}
+
+	// If has special chars OR is all digits/underscores, needs escaping
+	return hasSpecialChars || isAllDigitsOrUnderscore(s)
+}
+
+// String returns the string representation of the RecordID with proper escaping.
+//
+// The ID part is escaped following the Rust EscapeRid logic:
+//
+//	https://github.com/surrealdb/surrealdb/blob/2564e686ff8236c9ebda4f755f9913a802ff9f0f/crates/core/src/sql/escape.rs#L89-L105
+//
+// This implementation assumes ACCESSIBLE_OUTPUT is always false, using angle brackets ⟨⟩
+//
+// Beware that the format for complex ID types (like arrays or objects) does not follow
+// that of the Rust implementation.
+//
+// For example, `CREATE foo:["a","2",3]` will be formatted as `foo:['a','2',3]` in other places,
+// but here it will be `foo:[a 2 3]`
+//
+// We aren't sure if it worth to implement the same escaping and formatting logic as in Rust,
+// so we just use a simple string representation for now.
+func (r *RecordID) String() string {
+	// Format ID with escaping if needed
+	idStr := fmt.Sprintf("%v", r.ID)
+	if strID, ok := r.ID.(string); ok && needsEscaping(strID) {
+		escapedID := escapeString(strID, '⟩')
+		idStr = fmt.Sprintf("⟨%s⟩", escapedID)
+	}
+
+	return fmt.Sprintf("%s:%s", r.Table, idStr)
+}

--- a/pkg/models/record_id_string_test.go
+++ b/pkg/models/record_id_string_test.go
@@ -1,0 +1,67 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestRecordID_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		recordID RecordID
+		expected string
+	}{
+		{
+			name:     "simple alphanumeric table and ID",
+			recordID: RecordID{Table: "users", ID: "123"},
+			expected: "users:⟨123⟩",
+		},
+		{
+			name:     "ID with special characters needs escaping",
+			recordID: RecordID{Table: "users", ID: "user-123"},
+			expected: "users:⟨user-123⟩",
+		},
+		{
+			name:     "ID with special characters needs escaping",
+			recordID: RecordID{Table: "user-profiles", ID: "id-123"},
+			expected: "user-profiles:⟨id-123⟩",
+		},
+		{
+			name:     "numeric ID",
+			recordID: RecordID{Table: "users", ID: 123},
+			expected: "users:123",
+		},
+		{
+			name:     "ID with full width digits",
+			recordID: RecordID{Table: "users", ID: "０１２３"},
+			expected: "users:⟨０１２３⟩",
+		},
+		{
+			name:     "ID with emoji",
+			recordID: RecordID{Table: "users", ID: "user😀"},
+			expected: "users:⟨user😀⟩",
+		},
+		// In the following cases, we demonstrate that complex ID types are
+		// formatted differently in this SDK and in Rust.
+		{
+			name:     "complex ID with array",
+			recordID: RecordID{Table: "users", ID: []any{"a", "b", "c"}},
+			// This should be formatted as `users:['a','b','c']` in Rust.
+			expected: "users:[a b c]",
+		},
+		{
+			name:     "complex ID with map",
+			recordID: RecordID{Table: "users", ID: map[string]any{"key": "value"}},
+			// This should be formatted as `users:{key:'value'}` in Rust.
+			expected: "users:map[key:value]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.recordID.String()
+			if result != tt.expected {
+				t.Errorf("RecordID.String() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #198

Beware, though, that this SDK does not implement the formatting of complex ID types like `object`, `array`, `datetime`, and so on in `surreal sql` or in the Rust SDK.