### PR TITLE
Preliminary support for context.Context

### DIFF
--- a/db.go
+++ b/db.go
@@ -25,7 +25,6 @@ type VersionData struct {
 
 // DB is a client for the SurrealDB database that holds the connection.
 type DB struct {
-	ctx context.Context
 	con connection.Connection
 }
 
@@ -70,8 +69,8 @@ func New(connectionURL string) (*DB, error) {
 // --------------------------------------------------
 
 // WithContext
+// Deprecated: WithContext is deprecated and does nothing. Use context parameters in individual method calls instead.
 func (db *DB) WithContext(ctx context.Context) *DB {
-	db.ctx = ctx
 	return db
 }
 
@@ -87,7 +86,8 @@ func (db *DB) Use(ns, database string) error {
 
 func (db *DB) Info() (map[string]interface{}, error) {
 	var info connection.RPCResponse[map[string]interface{}]
-	err := db.con.Send(&info, "info")
+	ctx := context.Background()
+	err := db.con.Send(ctx, &info, "info")
 	return *info.Result, err
 }
 
@@ -118,7 +118,8 @@ func (db *DB) Info() (map[string]interface{}, error) {
 //	})
 func (db *DB) SignUp(authData interface{}) (string, error) {
 	var token connection.RPCResponse[string]
-	if err := db.con.Send(&token, "signup", authData); err != nil {
+	ctx := context.Background()
+	if err := db.con.Send(ctx, &token, "signup", authData); err != nil {
 		return "", err
 	}
 
@@ -156,7 +157,8 @@ func (db *DB) SignUp(authData interface{}) (string, error) {
 //	})
 func (db *DB) SignIn(authData interface{}) (string, error) {
 	var token connection.RPCResponse[string]
-	if err := db.con.Send(&token, "signin", authData); err != nil {
+	ctx := context.Background()
+	if err := db.con.Send(ctx, &token, "signin", authData); err != nil {
 		return "", err
 	}
 
@@ -168,7 +170,8 @@ func (db *DB) SignIn(authData interface{}) (string, error) {
 }
 
 func (db *DB) Invalidate() error {
-	if err := db.con.Send(nil, "invalidate"); err != nil {
+	ctx := context.Background()
+	if err := db.con.Send(ctx, nil, "invalidate"); err != nil {
 		return err
 	}
 
@@ -180,7 +183,8 @@ func (db *DB) Invalidate() error {
 }
 
 func (db *DB) Authenticate(token string) error {
-	if err := db.con.Send(nil, "authenticate", token); err != nil {
+	ctx := context.Background()
+	if err := db.con.Send(ctx, nil, "authenticate", token); err != nil {
 		return err
 	}
 
@@ -261,7 +265,8 @@ func (db *DB) Send(res interface{}, method string, params ...interface{}) error 
 		return fmt.Errorf("provided method is not allowed")
 	}
 
-	return db.con.Send(&res, method, params...)
+	ctx := context.Background()
+	return db.con.Send(ctx, &res, method, params...)
 }
 
 func (db *DB) LiveNotifications(liveQueryID string) (chan connection.Notification, error) {
@@ -491,8 +496,9 @@ func QueryRaw(db *DB, queries *[]QueryStmt) error {
 // in case the expected response is a connection.RPCResponse[TResult].
 // If one expects other types of responses, use db.con.Send directly.
 func send[TResult any](db *DB, method string, params ...any) (*TResult, error) {
+	ctx := context.Background()
 	var res connection.RPCResponse[TResult]
-	if err := db.con.Send(&res, method, params...); err != nil {
+	if err := db.con.Send(ctx, &res, method, params...); err != nil {
 		return nil, err
 	}
 

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -19,12 +20,14 @@ type LiveHandler interface {
 type Connection interface {
 	Connect() error
 	Close() error
-	// Send requires `res` to be of type `*RPCResponse[T]` where T is a type that implements `cbor.Unmarshaller`.
-	// It could be more obvious if Go allowed us to write it like:
-	//   Send[T cbor.Unmarshaller](res *RPCResponse[T], method string, params ...interface{}) error
-	// But it doesn't, so we have to use `interface{}`.
-	// The caller is responsible for ensuring that `res` is of the correct type.
-	Send(res interface{}, method string, params ...interface{}) error
+	// Send sends a request to SurrealDB and expects a response.
+	//
+	// It requires `res` to be of type `*RPCResponse[T]` where T is a type that implements `cbor.Unmarshaller`,
+	// or any type that `cbor.Unmarshal` can decode into.
+	// The `method` is the SurrealDB method to call, and `params` are the parameters for the method.
+	//
+	// The `ctx` is used to cancel the request if the context is canceled.
+	Send(ctx context.Context, res interface{}, method string, params ...interface{}) error
 	Use(namespace string, database string) error
 	Let(key string, value interface{}) error
 	Unset(key string) error

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -65,7 +66,7 @@ func (s *ConnectionTestSuite) SetupSuite() {
 
 	// sign in
 	var token RPCResponse[string]
-	err = con.Send(&token, "signin", map[string]interface{}{
+	err = con.Send(context.Background(), &token, "signin", map[string]interface{}{
 		"user": "root",
 		"pass": "root",
 	})
@@ -83,7 +84,7 @@ func (s *ConnectionTestSuite) Test_CRUD() {
 	con := s.connImplementations[s.name]
 
 	var createRes RPCResponse[testUser]
-	err := con.Send(&createRes, "create", "users", map[string]interface{}{
+	err := con.Send(context.Background(), &createRes, "create", "users", map[string]interface{}{
 		"username": "remi",
 		"password": "password",
 	})
@@ -93,7 +94,7 @@ func (s *ConnectionTestSuite) Test_CRUD() {
 	s.Assert().Equal(createRes.Result.Password, "password")
 
 	var selectRes RPCResponse[testUser]
-	err = con.Send(&selectRes, "select", createRes.Result.ID)
+	err = con.Send(context.Background(), &selectRes, "select", createRes.Result.ID)
 	s.Require().NoError(err)
 
 	s.Assert().Equal(createRes.Result.Username, "remi")
@@ -102,16 +103,16 @@ func (s *ConnectionTestSuite) Test_CRUD() {
 	userToUpdate := createRes.Result
 	userToUpdate.Password = "newpassword"
 	var updateRes RPCResponse[testUser]
-	err = con.Send(&updateRes, "update", userToUpdate.ID, userToUpdate)
+	err = con.Send(context.Background(), &updateRes, "update", userToUpdate.ID, userToUpdate)
 	s.Require().NoError(err)
 
 	s.Assert().Equal(userToUpdate.ID, updateRes.Result.ID)
 	s.Assert().Equal(updateRes.Result.Password, "newpassword")
 
-	err = con.Send(nil, "delete", userToUpdate.ID)
+	err = con.Send(context.Background(), nil, "delete", userToUpdate.ID)
 	s.Require().NoError(err)
 
 	var selectRes1 RPCResponse[testUser]
-	err = con.Send(&selectRes1, "select", createRes.Result.ID)
+	err = con.Send(context.Background(), &selectRes1, "select", createRes.Result.ID)
 	s.Require().NoError(err)
 }

--- a/pkg/connection/embedded.go
+++ b/pkg/connection/embedded.go
@@ -10,6 +10,7 @@ package connection
 import "C"
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"sync"
@@ -97,7 +98,13 @@ func (h *EmbeddedConnection) Close() error {
 	return nil
 }
 
-func (h *EmbeddedConnection) Send(res interface{}, method string, params ...interface{}) error {
+func (h *EmbeddedConnection) Send(ctx context.Context, res interface{}, method string, params ...interface{}) error {
+	// Check if context is done before proceeding
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 	request := &RPCRequest{
 		ID:     rand.String(constants.RequestIDLength),
 		Method: method,
@@ -133,13 +140,13 @@ func (h *EmbeddedConnection) Send(res interface{}, method string, params ...inte
 }
 
 func (h *EmbeddedConnection) Use(namespace, database string) error {
-	return h.Send(nil, "use", namespace, database)
+	return h.Send(context.Background(), nil, "use", namespace, database)
 }
 
 func (h *EmbeddedConnection) Let(key string, value interface{}) error {
-	return h.Send(nil, "let", key, value)
+	return h.Send(context.Background(), nil, "let", key, value)
 }
 
 func (h *EmbeddedConnection) Unset(key string) error {
-	return h.Send(nil, "unset", key)
+	return h.Send(context.Background(), nil, "unset", key)
 }

--- a/pkg/connection/embedded_test.go
+++ b/pkg/connection/embedded_test.go
@@ -3,6 +3,7 @@
 package connection
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -52,7 +53,7 @@ func (s *EmbeddedConnectionTestSuite) TestSendRequest() {
 	s.Require().NoError(err)
 
 	var versionRes RPCResponse[string]
-	err = s.con.Send(&versionRes, "version")
+	err = s.con.Send(context.Background(), &versionRes, "version")
 	s.Require().NoError(err)
 }
 
@@ -61,12 +62,12 @@ func (s *EmbeddedConnectionTestSuite) TestLiveAndNotification() {
 	s.Require().NoError(err)
 
 	var liveRes RPCResponse[models.UUID]
-	err = s.con.Send(&liveRes, "live", "users", false)
+	err = s.con.Send(context.Background(), &liveRes, "live", "users", false)
 	s.Require().NoError(err, "should not return error on live request")
 
 	liveID := liveRes.Result.String()
 	defer func() {
-		err = s.con.Send(nil, "kill", liveID)
+		err = s.con.Send(context.Background(), nil, "kill", liveID)
 		s.Require().NoError(err)
 	}()
 

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -77,7 +77,7 @@ func (h *HTTPConnection) GetUnmarshaler() codec.Unmarshaler {
 	return h.unmarshaler
 }
 
-func (h *HTTPConnection) Send(dest any, method string, params ...interface{}) error {
+func (h *HTTPConnection) Send(ctx context.Context, dest any, method string, params ...interface{}) error {
 	if h.baseURL == "" {
 		return constants.ErrNoBaseURL
 	}
@@ -92,7 +92,7 @@ func (h *HTTPConnection) Send(dest any, method string, params ...interface{}) er
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, h.baseURL+"/rpc", bytes.NewBuffer(reqBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.baseURL+"/rpc", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This introduces breaking changes to `Connection.Send` to have the new `context.Context` parameter.

The HTTP connection's `Send` gains support for cancellation and timeout thanks to the context parameter, although they are not exposed to the more common public interface to this SDK, the top-level public functions like `Insert`, `Upsert`, `Query` and so on.

I will follow up with another pull request that changes every top-level function to have the context parameter before cutting v0.6.0.

Ref #100
