### PR TITLE
Enhance almost all SDK funcs to accept context.Context

### DIFF
--- a/example/connection.go
+++ b/example/connection.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -48,7 +49,7 @@ func newSurrealDBHTTPConnection(database string, tables ...string) *surrealdb.DB
 func initConnection(db *surrealdb.DB, namespace, database string, tables ...string) *surrealdb.DB {
 	var err error
 
-	if err = db.Use(namespace, database); err != nil {
+	if err = db.Use(context.Background(), namespace, database); err != nil {
 		panic(err)
 	}
 
@@ -56,12 +57,12 @@ func initConnection(db *surrealdb.DB, namespace, database string, tables ...stri
 		Username: "root",
 		Password: "root",
 	}
-	token, err := db.SignIn(authData)
+	token, err := db.SignIn(context.Background(), authData)
 	if err != nil {
 		panic(err)
 	}
 
-	if err = db.Authenticate(token); err != nil {
+	if err = db.Authenticate(context.Background(), token); err != nil {
 		panic(err)
 	}
 
@@ -80,7 +81,7 @@ func initConnection(db *surrealdb.DB, namespace, database string, tables ...stri
 		//     There was a problem with the database: Parse error: Unexpected token `a parameter`, expected an identifier
 		//     REMOVE TABLE IF EXISTS $tb
 		//							  ^^
-		if _, err = surrealdb.Query[[]any](db, "REMOVE TABLE IF EXISTS "+table, nil); err != nil {
+		if _, err = surrealdb.Query[[]any](context.Background(), db, "REMOVE TABLE IF EXISTS "+table, nil); err != nil {
 			panic(err)
 		}
 	}

--- a/example/example_create_test.go
+++ b/example/example_create_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -28,6 +29,7 @@ func ExampleCreate() {
 	// Create returns a pointer to the record itself.
 	var inserted *Person
 	inserted, err = surrealdb.Create[Person](
+		context.Background(),
 		db,
 		"persons",
 		map[string]any{
@@ -42,6 +44,7 @@ func ExampleCreate() {
 	// You can throw away the result if you don't need it,
 	// by specifying an empty struct as the type parameter.
 	_, err = surrealdb.Create[struct{}](
+		context.Background(),
 		db,
 		"persons",
 		map[string]any{
@@ -55,6 +58,7 @@ func ExampleCreate() {
 
 	// You can also create a record by passing a struct directly.
 	_, err = surrealdb.Create[struct{}](
+		context.Background(),
 		db,
 		"persons",
 		Person{
@@ -73,6 +77,7 @@ func ExampleCreate() {
 	// in other words, when the schema is not known upfront.
 	var fourthAsMap *map[string]any
 	fourthAsMap, err = surrealdb.Create[map[string]any](
+		context.Background(),
 		db,
 		"persons",
 		map[string]any{
@@ -91,6 +96,7 @@ func ExampleCreate() {
 	fmt.Printf("Create result: %+s\n", *fourthAsMap)
 
 	selected, err := surrealdb.Select[[]Person](
+		context.Background(),
 		db,
 		"persons",
 	)

--- a/example/example_db_record_user_test.go
+++ b/example/example_db_record_user_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
@@ -38,7 +39,7 @@ func ExampleDB_record_user_auth_struct() {
 			);
 	`
 
-	if _, err := surrealdb.Query[any](db, setupQuery, nil); err != nil {
+	if _, err := surrealdb.Query[any](context.Background(), db, setupQuery, nil); err != nil {
 		panic(err)
 	}
 
@@ -46,7 +47,7 @@ func ExampleDB_record_user_auth_struct() {
 
 	// Refer to the next example, `ExampleDB_record_user_custom_struct`,
 	// when you need to use fields other than `user` and `pass` in the query specified for SIGNUP.
-	_, err := db.SignUp(&surrealdb.Auth{
+	_, err := db.SignUp(context.Background(), &surrealdb.Auth{
 		Namespace: "examples",
 		Database:  "record_auth_demo",
 		Access:    "user",
@@ -63,7 +64,7 @@ func ExampleDB_record_user_auth_struct() {
 	//
 	// For example, you might want to use `email` and `password` instead of `user` and `pass`.
 	// In that case, you need to something that encodes to a cbor map containing those keys.
-	_, err = db.SignIn(&surrealdb.Auth{
+	_, err = db.SignIn(context.Background(), &surrealdb.Auth{
 		Namespace: "examples",
 		Database:  "record_auth_demo",
 		Access:    "user",
@@ -75,7 +76,7 @@ func ExampleDB_record_user_auth_struct() {
 	}
 	fmt.Println("User signed in successfully")
 
-	info, err := db.Info()
+	info, err := db.Info(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -121,7 +122,7 @@ func ExampleDB_record_user_custom_struct() {
 			);
 	`
 
-	if _, err := surrealdb.Query[any](db, setupQuery, nil); err != nil {
+	if _, err := surrealdb.Query[any](context.Background(), db, setupQuery, nil); err != nil {
 		panic(err)
 	}
 
@@ -144,7 +145,7 @@ func ExampleDB_record_user_custom_struct() {
 		Password  string `json:"password"`
 	}
 
-	_, err := db.SignUp(&User{
+	_, err := db.SignUp(context.Background(), &User{
 		// Corresponds to the SurrealDB namespace
 		Namespace: "examples",
 		// Corresponds to the SurrealDB database
@@ -163,7 +164,7 @@ func ExampleDB_record_user_custom_struct() {
 	}
 	fmt.Println("User signed up successfully")
 
-	_, err = db.SignIn(&LoginRequest{
+	_, err = db.SignIn(context.Background(), &LoginRequest{
 		Namespace: "examples",
 		Database:  "record_user_custom",
 		Access:    "user",
@@ -177,7 +178,7 @@ func ExampleDB_record_user_custom_struct() {
 	}
 	fmt.Println("User signed in successfully")
 
-	info, err := db.Info()
+	info, err := db.Info(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/example/example_db_send_select_test.go
+++ b/example/example_db_send_select_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
@@ -20,6 +21,7 @@ func ExampleDB_send_select() {
 
 	for _, p := range []Person{a, b} {
 		created, err := surrealdb.Create[Person](
+			context.Background(),
 			db,
 			p.ID,
 			map[string]any{},
@@ -32,6 +34,7 @@ func ExampleDB_send_select() {
 
 	var selectedUsingSendSelect connection.RPCResponse[Person]
 	err := db.Send(
+		context.Background(),
 		&selectedUsingSendSelect,
 		"select",
 		a.ID,
@@ -43,6 +46,7 @@ func ExampleDB_send_select() {
 
 	var selectedMultiUsingSendSelect connection.RPCResponse[[]Person]
 	err = db.Send(
+		context.Background(),
 		&selectedMultiUsingSendSelect,
 		"select",
 		"person",
@@ -84,7 +88,7 @@ func ExampleDB_send_select() {
 func customSelect[TResult any, TWhat surrealdb.TableOrRecord](db *surrealdb.DB, what TWhat) (*TResult, error) {
 	var res connection.RPCResponse[TResult]
 
-	if err := db.Send(&res, "select", what); err != nil {
+	if err := db.Send(context.Background(), &res, "select", what); err != nil {
 		return nil, err
 	}
 

--- a/example/example_insert_relation_test.go
+++ b/example/example_insert_relation_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,6 +24,7 @@ func ExampleInsertRelation() {
 	}
 
 	first, err := surrealdb.Create[Person](
+		context.Background(),
 		db,
 		"person",
 		map[string]any{
@@ -33,6 +35,7 @@ func ExampleInsertRelation() {
 	}
 
 	second, err := surrealdb.Create[Person](
+		context.Background(),
 		db,
 		"person",
 		map[string]any{
@@ -48,6 +51,7 @@ func ExampleInsertRelation() {
 	}
 
 	persons, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		"SELECT * FROM person ORDER BY id.id",
 		nil,
@@ -60,6 +64,7 @@ func ExampleInsertRelation() {
 	}
 
 	res, relateErr := surrealdb.InsertRelation[[]connection.ResponseID[models.RecordID]](
+		context.Background(),
 		db,
 		&surrealdb.Relationship{
 			ID:       &models.RecordID{Table: "follow", ID: "first_second"},
@@ -110,6 +115,7 @@ func ExampleInsertRelation() {
 		Follows []models.RecordID `json:"follows,omitempty"`
 	}
 	selected, err := surrealdb.Query[[]PersonWithFollows](
+		context.Background(),
 		db,
 		"SELECT id, name, ->follow->person AS follows FROM $id",
 		map[string]any{
@@ -127,6 +133,7 @@ func ExampleInsertRelation() {
 	// Note we can select the relationships themselves because
 	// RELATE creates a record in the relation table.
 	follows, err := surrealdb.Query[[]Follow](
+		context.Background(),
 		db,
 		"SELECT * from follow",
 		nil,

--- a/example/example_insert_test.go
+++ b/example/example_insert_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -27,6 +28,7 @@ func ExampleInsert_table() {
 	// Insert returns a pointer to the array of inserted records.
 	var inserted *[]Person
 	inserted, err = surrealdb.Insert[Person](
+		context.Background(),
 		db,
 		"persons",
 		map[string]any{
@@ -39,6 +41,7 @@ func ExampleInsert_table() {
 	fmt.Printf("Insert result: %+s\n", *inserted)
 
 	_, err = surrealdb.Insert[struct{}](
+		context.Background(),
 		db,
 		"persons",
 		map[string]any{
@@ -51,6 +54,7 @@ func ExampleInsert_table() {
 	}
 
 	_, err = surrealdb.Insert[struct{}](
+		context.Background(),
 		db,
 		"persons",
 		Person{
@@ -65,6 +69,7 @@ func ExampleInsert_table() {
 	}
 
 	fourthAsMap, err := surrealdb.Insert[map[string]any](
+		context.Background(),
 		db,
 		"persons",
 		Person{
@@ -83,6 +88,7 @@ func ExampleInsert_table() {
 	fmt.Printf("Insert result: %+s\n", *fourthAsMap)
 
 	selected, err := surrealdb.Select[[]Person](
+		context.Background(),
 		db,
 		"persons",
 	)
@@ -117,6 +123,7 @@ func ExampleInsert_bulk_isnert_record() {
 
 	var inserted *[]Person
 	inserted, err := surrealdb.Insert[Person](
+		context.Background(),
 		db,
 		"person",
 		persons,
@@ -127,6 +134,7 @@ func ExampleInsert_bulk_isnert_record() {
 	fmt.Printf("Inserted: %+s\n", *inserted)
 
 	selected, err := surrealdb.Select[[]Person](
+		context.Background(),
 		db,
 		"person",
 	)
@@ -173,6 +181,7 @@ func ExampleInsert_bulk_insert_relation_workaround_for_rpcv1() {
 
 	var insertedPersons *[]Person
 	insertedPersons, err = surrealdb.Insert[Person](
+		context.Background(),
 		db,
 		"person",
 		persons,
@@ -184,6 +193,7 @@ func ExampleInsert_bulk_insert_relation_workaround_for_rpcv1() {
 
 	var selectedPersons *[]Person
 	selectedPersons, err = surrealdb.Select[[]Person](
+		context.Background(),
 		db,
 		"person",
 	)
@@ -238,6 +248,7 @@ func ExampleInsert_bulk_insert_relation_workaround_for_rpcv1() {
 	// Here, we focus on what you could do the equivalent of
 	// batch insert relation in RPC v2, using the RPC v1 query RPC.
 	_, err = surrealdb.Query[any](
+		context.Background(),
 		db,
 		"INSERT RELATION INTO follow $content",
 		map[string]any{
@@ -250,6 +261,7 @@ func ExampleInsert_bulk_insert_relation_workaround_for_rpcv1() {
 
 	var selectedFollows *[]Follow
 	selectedFollows, err = surrealdb.Select[[]Follow](
+		context.Background(),
 		db,
 		"follow",
 	)
@@ -267,6 +279,7 @@ func ExampleInsert_bulk_insert_relation_workaround_for_rpcv1() {
 
 	var followedByA *[]surrealdb.QueryResult[[]PersonWithFollows]
 	followedByA, err = surrealdb.Query[[]PersonWithFollows](
+		context.Background(),
 		db,
 		"SELECT id, <->follow<->person AS follows FROM person ORDER BY id",
 		nil,

--- a/example/example_query_bulk_insert_upsert_test.go
+++ b/example/example_query_bulk_insert_upsert_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -67,6 +68,7 @@ func ExampleQuery_bluk_insert_upsert() {
 	}
 
 	insert, err := surrealdb.Query[any](
+		context.Background(),
 		db,
 		`INSERT INTO persons $persons RETURN NONE`,
 		map[string]any{
@@ -81,6 +83,7 @@ func ExampleQuery_bluk_insert_upsert() {
 	fmt.Printf("Result  : %+v\n", (*insert)[0].Result)
 
 	select1, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`SELECT * FROM persons ORDER BY id.id`,
 		nil)
@@ -92,6 +95,7 @@ func ExampleQuery_bluk_insert_upsert() {
 	persons = append(persons, nthPerson(2))
 
 	insertIgnore, err := surrealdb.Query[any](
+		context.Background(),
 		db,
 		`INSERT IGNORE INTO persons $persons RETURN NONE`,
 		map[string]any{
@@ -106,6 +110,7 @@ func ExampleQuery_bluk_insert_upsert() {
 	fmt.Printf("Result  : %+v\n", (*insertIgnore)[0].Result)
 
 	select2, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`SELECT * FROM persons ORDER BY id.id`,
 		nil)
@@ -127,6 +132,7 @@ func ExampleQuery_bluk_insert_upsert() {
 		vars[fmt.Sprintf("content%d", i)] = p
 	}
 	upsert, err := surrealdb.Query[any](
+		context.Background(),
 		db,
 		strings.Join(upsertQueries, ";"),
 		vars,
@@ -140,6 +146,7 @@ func ExampleQuery_bluk_insert_upsert() {
 	fmt.Printf("Result  : %+v\n", (*upsert)[0].Result)
 
 	select3, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`SELECT * FROM persons ORDER BY id.id`,
 		nil)

--- a/example/example_query_embedded_struct_test.go
+++ b/example/example_query_embedded_struct_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -35,6 +36,7 @@ func ExampleQuery_embedded_struct() {
 	}
 
 	createQueryResults, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`CREATE type::thing($tb, $id) CONTENT $content`,
 		map[string]any{
@@ -63,6 +65,7 @@ func ExampleQuery_embedded_struct() {
 		panic(err)
 	}
 	updateQueryResults, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`UPDATE $id CONTENT $content`,
 		map[string]any{
@@ -82,6 +85,7 @@ func ExampleQuery_embedded_struct() {
 	fmt.Printf("Persons contained in the update query result: %+v\n", (*updateQueryResults)[0].Result)
 
 	selectQueryResults, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`SELECT * FROM $id`,
 		map[string]any{

--- a/example/example_query_none_null_test.go
+++ b/example/example_query_none_null_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
@@ -11,6 +12,7 @@ func ExampleQuery_none_and_null_handling() {
 	db := newSurrealDBWSConnection("query", "t")
 
 	_, err := surrealdb.Query[[]any](
+		context.Background(),
 		db,
 		`DEFINE TABLE t SCHEMAFULL;
 		 DEFINE FIELD nullable ON t TYPE bool | null;
@@ -36,6 +38,7 @@ func ExampleQuery_none_and_null_handling() {
 	}
 
 	selected, err := surrealdb.Query[[]T](
+		context.Background(),
 		db,
 		`SELECT * FROM t ORDER BY id.id`,
 		nil,

--- a/example/example_query_return_test.go
+++ b/example/example_query_return_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -34,6 +35,7 @@ func ExampleQuery_return() {
 	}
 
 	insertQueryResults, err := surrealdb.Query[any](
+		context.Background(),
 		db,
 		`INSERT INTO persons [$content] RETURN NONE`,
 		map[string]any{
@@ -56,6 +58,7 @@ func ExampleQuery_return() {
 	fmt.Printf("Results contained in the first query result: %+v\n", (*insertQueryResults)[0].Result)
 
 	selectQueryResults, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`SELECT * FROM $id`, map[string]any{
 			"id": models.NewRecordID("persons", "yusuke"),

--- a/example/example_query_test.go
+++ b/example/example_query_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -30,6 +31,7 @@ func ExampleQuery() {
 	}
 
 	createQueryResults, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		`CREATE type::thing($tb, $id) CONTENT $content`,
 		map[string]any{

--- a/example/example_query_transaction_let_return_test.go
+++ b/example/example_query_transaction_let_return_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
@@ -11,6 +12,7 @@ func ExampleQuery_transaction_let_return() {
 	db := newSurrealDBWSConnection("query", "t")
 
 	createQueryResults, err := surrealdb.Query[[]any](
+		context.Background(),
 		db,
 		`BEGIN;
 		 CREATE t:1 SET name = 'test';

--- a/example/example_query_transaction_test.go
+++ b/example/example_query_transaction_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -15,6 +16,7 @@ func ExampleQuery_transaction_return() {
 
 	var a *[]surrealdb.QueryResult[bool]
 	a, err = surrealdb.Query[bool](
+		context.Background(),
 		db,
 		`BEGIN; CREATE person:1; CREATE person:2; RETURN true; COMMIT;`,
 		map[string]any{},
@@ -61,6 +63,7 @@ func ExampleQuery_transaction_throw() {
 	// The caller can check the Error field of each QueryResult to see if the query failed,
 	// or check the returned error from the Query function to see if the query failed.
 	queryResults, err = surrealdb.Query[*int](
+		context.Background(),
 		db,
 		`BEGIN; THROW "test"; RETURN 1; COMMIT;`,
 		nil,
@@ -113,7 +116,7 @@ func ExampleQuery_transaction_issue_177_return_before_commit() {
 	// SurrealDB may be enhanced to handle this, but for now,
 	// you should commit the transaction before returning the result.
 	// See the ExampleQuery_transaction_issue_177_commit function for the correct way to do this.
-	queryResults, err := surrealdb.Query[any](db,
+	queryResults, err := surrealdb.Query[any](context.Background(), db,
 		`BEGIN;
 		CREATE t:s SET name = 'test';
 		LET $i = SELECT * FROM $id;
@@ -150,7 +153,7 @@ func ExampleQuery_transaction_issue_177_commit() {
 
 	var err error
 
-	queryResults, err := surrealdb.Query[any](db,
+	queryResults, err := surrealdb.Query[any](context.Background(), db,
 		`BEGIN;
 		CREATE t:s SET name = 'test1';
 		CREATE t:t SET name = 'test2';

--- a/example/example_relate_test.go
+++ b/example/example_relate_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,6 +24,7 @@ func ExampleRelate() {
 	}
 
 	first, err := surrealdb.Create[Person](
+		context.Background(),
 		db,
 		"person",
 		map[string]any{
@@ -33,6 +35,7 @@ func ExampleRelate() {
 	}
 
 	second, err := surrealdb.Create[Person](
+		context.Background(),
 		db,
 		"person",
 		map[string]any{
@@ -48,6 +51,7 @@ func ExampleRelate() {
 	}
 
 	persons, err := surrealdb.Query[[]Person](
+		context.Background(),
 		db,
 		"SELECT * FROM person ORDER BY id.id",
 		nil,
@@ -60,6 +64,7 @@ func ExampleRelate() {
 	}
 
 	res, relateErr := surrealdb.Relate[connection.ResponseID[models.RecordID]](
+		context.Background(),
 		db,
 		&surrealdb.Relationship{
 			// ID is currently ignored, and the relation will have a generated ID.
@@ -114,6 +119,7 @@ func ExampleRelate() {
 		Follows []models.RecordID `json:"follows,omitempty"`
 	}
 	selected, err := surrealdb.Query[[]PersonWithFollows](
+		context.Background(),
 		db,
 		"SELECT id, name, ->follow->person AS follows FROM $id",
 		map[string]any{
@@ -131,6 +137,7 @@ func ExampleRelate() {
 	// Note we can select the relationships themselves because
 	// RELATE creates a record in the relation table.
 	follows, err := surrealdb.Query[[]Follow](
+		context.Background(),
 		db,
 		"SELECT * from follow",
 		nil,

--- a/example/example_select_test.go
+++ b/example/example_select_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
@@ -19,6 +20,7 @@ func ExampleSelect() {
 
 	for _, p := range []Person{a, b} {
 		created, err := surrealdb.Create[Person](
+			context.Background(),
 			db,
 			p.ID,
 			map[string]any{},
@@ -30,6 +32,7 @@ func ExampleSelect() {
 	}
 
 	selectedOneUsingSelect, err := surrealdb.Select[Person](
+		context.Background(),
 		db,
 		a.ID,
 	)
@@ -39,6 +42,7 @@ func ExampleSelect() {
 	fmt.Printf("selectedOneUsingSelect: %+v\n", *selectedOneUsingSelect)
 
 	selectedMultiUsingSelect, err := surrealdb.Select[[]Person](
+		context.Background(),
 		db,
 		"person",
 	)

--- a/example/example_update_test.go
+++ b/example/example_update_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -31,7 +32,7 @@ func ExampleUpdate() {
 	}
 
 	recordID := models.NewRecordID("persons", "yusuke")
-	created, err := surrealdb.Create[Person](db, recordID, map[string]any{
+	created, err := surrealdb.Create[Person](context.Background(), db, recordID, map[string]any{
 		"name": "Yusuke",
 		"nested_struct": NestedStruct{
 			City: "Tokyo",
@@ -50,7 +51,7 @@ func ExampleUpdate() {
 		panic(err)
 	}
 
-	updated, err := surrealdb.Update[Person](db, recordID, map[string]any{
+	updated, err := surrealdb.Update[Person](context.Background(), db, recordID, map[string]any{
 		"name": "Yusuke",
 		"nested_map": map[string]any{
 			"key1": "value1",

--- a/example/example_upsert_test.go
+++ b/example/example_upsert_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -28,6 +29,7 @@ func ExampleUpsert() {
 	}
 
 	inserted, err := surrealdb.Upsert[Person](
+		context.Background(),
 		db,
 		models.NewRecordID("persons", "yusuke"),
 		map[string]any{
@@ -40,6 +42,7 @@ func ExampleUpsert() {
 	fmt.Printf("Insert via upsert result: %+s\n", *inserted)
 
 	updated, err := surrealdb.Upsert[Person](
+		context.Background(),
 		db,
 		models.NewRecordID("persons", "yusuke"),
 		map[string]any{
@@ -59,6 +62,7 @@ func ExampleUpsert() {
 		panic(err)
 	}
 	updatedFurther, err := surrealdb.Upsert[Person](
+		context.Background(),
 		db,
 		models.NewRecordID("persons", "yusuke"),
 		map[string]any{
@@ -75,6 +79,7 @@ func ExampleUpsert() {
 	fmt.Printf("Update further via upsert result: %+s\n", *updatedFurther)
 
 	_, err = surrealdb.Upsert[struct{}](
+		context.Background(),
 		db,
 		models.NewRecordID("persons", "yusuke"),
 		map[string]any{
@@ -86,6 +91,7 @@ func ExampleUpsert() {
 	}
 
 	selected, err := surrealdb.Select[Person](
+		context.Background(),
 		db,
 		models.NewRecordID("persons", "yusuke"),
 	)
@@ -111,6 +117,7 @@ func ExampleUpsert_unmarshal_error() {
 
 	// This will fail because the record ID is not valid.
 	_, err := surrealdb.Upsert[Person](
+		context.Background(),
 		db,
 		models.Table("person"),
 		map[string]any{
@@ -147,6 +154,7 @@ func ExampleUpsert_rpc_error() {
 	// will result in an error from the database.
 
 	if _, err := surrealdb.Query[any](
+		context.Background(),
 		db,
 		`DEFINE TABLE person SCHEMAFUL;
 		 DEFINE FIELD name ON person TYPE string;`,
@@ -157,6 +165,7 @@ func ExampleUpsert_rpc_error() {
 
 	// This will fail because the record ID is not valid.
 	_, err := surrealdb.Upsert[Person](
+		context.Background(),
 		db,
 		models.Table("person"),
 		map[string]any{

--- a/example/example_version_test.go
+++ b/example/example_version_test.go
@@ -1,20 +1,21 @@
 package main
 
 import (
+	"context"
 	"fmt"
 )
 
 //nolint:lll,govet
 func ExampleDB_Version() {
 	ws := newSurrealDBWSConnection("version")
-	v, err := ws.Version()
+	v, err := ws.Version(context.Background())
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("VersionData (WebSocket): %+v\n", v)
 
 	http := newSurrealDBHTTPConnection("version")
-	v, err = http.Version()
+	v, err = http.Version(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -17,7 +18,7 @@ func main() {
 	}
 
 	// Set the namespace and database
-	if err = db.Use("testNS", "testDB"); err != nil {
+	if err = db.Use(context.Background(), "testNS", "testDB"); err != nil {
 		panic(err)
 	}
 
@@ -26,7 +27,7 @@ func main() {
 		Username: "root", // use your setup username
 		Password: "root", // use your setup password
 	}
-	token, err := db.SignIn(authData)
+	token, err := db.SignIn(context.Background(), authData)
 	if err != nil {
 		panic(err)
 	}
@@ -35,19 +36,19 @@ func main() {
 	// This is not necessary if you called `SignIn` before.
 	// This authenticates the `db` instance too if sign in was
 	// not previously called
-	if err = db.Authenticate(token); err != nil {
+	if err = db.Authenticate(context.Background(), token); err != nil {
 		panic(err)
 	}
 
 	// And we can later on invalidate the token if desired
 	defer func(_ string) {
-		if err = db.Invalidate(); err != nil {
+		if err = db.Invalidate(context.Background()); err != nil {
 			panic(err)
 		}
 	}(token)
 
 	// Create an entry
-	person1, err := surrealdb.Create[Person](db, models.Table("persons"), map[interface{}]interface{}{
+	person1, err := surrealdb.Create[Person](context.Background(), db, models.Table("persons"), map[interface{}]interface{}{
 		"Name":     "John",
 		"Surname":  "Doe",
 		"Location": models.NewGeometryPoint(-0.11, 22.00),
@@ -58,7 +59,7 @@ func main() {
 	fmt.Printf("Created person with a map: %+v\n", person1)
 
 	// Or use structs
-	person2, err := surrealdb.Create[Person](db, models.Table("persons"), Person{
+	person2, err := surrealdb.Create[Person](context.Background(), db, models.Table("persons"), Person{
 		Name:     "John",
 		Surname:  "Doe",
 		Location: models.NewGeometryPoint(-0.11, 22.00),
@@ -69,7 +70,7 @@ func main() {
 	fmt.Printf("Created person with a struvt: %+v\n", person2)
 
 	// Get entry by Record ID
-	person, err := surrealdb.Select[PersonWithCustomID, models.RecordID](db, *person1.ID)
+	person, err := surrealdb.Select[PersonWithCustomID, models.RecordID](context.Background(), db, *person1.ID)
 	if err != nil {
 		panic(err)
 	}
@@ -81,24 +82,24 @@ func main() {
 	fmt.Printf("Selected a person by record id (in JSON with custom ID JSON encoder): %s\n", string(personInJSON))
 
 	// Or retrieve the entire table
-	persons, err := surrealdb.Select[[]Person, models.Table](db, models.Table("persons"))
+	persons, err := surrealdb.Select[[]Person, models.Table](context.Background(), db, models.Table("persons"))
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Selected all in persons table: %+v\n", persons)
 
 	// Delete an entry by ID
-	if _, err = surrealdb.Delete[Person](db, *person2.ID); err != nil {
+	if _, err = surrealdb.Delete[Person](context.Background(), db, *person2.ID); err != nil {
 		panic(err)
 	}
 
 	// Delete all entries
-	if _, err = surrealdb.Delete[[]Person](db, models.Table("persons")); err != nil {
+	if _, err = surrealdb.Delete[[]Person](context.Background(), db, models.Table("persons")); err != nil {
 		panic(err)
 	}
 
 	// Confirm empty table
-	persons, err = surrealdb.Select[[]Person](db, models.Table("persons"))
+	persons, err = surrealdb.Select[[]Person](context.Background(), db, models.Table("persons"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -1,6 +1,7 @@
 package benchmark_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -37,7 +38,7 @@ func BenchmarkCreate(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// error is ignored for benchmarking purposes.
-		surrealdb.Create[testUser](db, models.Table("users"), users[i]) //nolint:errcheck
+		surrealdb.Create[testUser](context.Background(), db, models.Table("users"), users[i]) //nolint:errcheck
 	}
 }
 
@@ -50,6 +51,6 @@ func BenchmarkSelect(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// error is ignored for benchmarking purposes.
-		surrealdb.Select[testUser](db, models.NewRecordID("users", "bob")) //nolint:errcheck
+		surrealdb.Select[testUser](context.Background(), db, models.NewRecordID("users", "bob")) //nolint:errcheck
 	}
 }


### PR DESCRIPTION
This is a breaking change that updates all the major public functions exposed by this SDK to accept `context.Context`.

Under the hood, it is used by the `Connection` of your choice, either `HTTPConnection` or `WebSocket` connection, to ensure that every RPC request-response respects context cancellation, which can be done either manually or by timeout.

Existing users of this library may encounter numerous compile errors due to the missing context.Context arguments. If you see one, you can just put `context.Background()` or `context.TODO()` in the places where the compiler complains. It should be safe as a starter because it doesn't change the meaning of the code. Until SDK v0.5.0, HTTPConnection did not support timeouts and cancellations, so passing `context.Background()` does not change anything.

Similarly, WebSocketConnection's behavior is maintained even if you specified `context.Background()` to the functions, because it has been supporting timeout via `WebSocketConection.Timeout`, which is set to 30 seconds by default, that is kept as-is. The default timeout mechanism works regardless of what context you provide.

This is a follow-up to #253.

As mentioned in #253, the unification of timeout error types into `Context.DeadlineExceeded` will happen soon.

In addition to that, I've also realized that we lack contexts for the following `Connection` functions:

- Connect
- Use
- Let
- Unset

The contexts passed to `Use`, `Let`, `Unset` functions will be no-op for `HTTPConnection` because they happen on the client side, while those of `WebSocketConnection` will respect contexts because they send RPCs under the hood.

For `Connect`, we will use the context for both HTTP and WebSocket, to enable cancellation and timeouts while connecting.

Ref #100