### PR TITLE
Unify timeout error type to context.DeadlineExceeded

### DIFF
--- a/pkg/connection/ws.go
+++ b/pkg/connection/ws.go
@@ -177,9 +177,6 @@ func (ws *WebSocketConnection) Send(ctx context.Context, dest interface{}, metho
 	case <-ws.closeChan:
 		return ws.closeError
 	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return constants.ErrTimeout
-		}
 		return ctx.Err()
 	default:
 	}
@@ -203,9 +200,6 @@ func (ws *WebSocketConnection) Send(ctx context.Context, dest interface{}, metho
 
 	select {
 	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return constants.ErrTimeout
-		}
 		return ctx.Err()
 	case res, open := <-responseChan:
 		if !open {

--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -10,7 +10,6 @@ var (
 )
 var (
 	ErrIDInUse            = errors.New("id already in use")
-	ErrTimeout            = errors.New("timeout")
 	ErrNoBaseURL          = errors.New("base url not set")
 	ErrNoMarshaler        = errors.New("marshaler is not set")
 	ErrNoUnmarshaler      = errors.New("unmarshaler is not set")


### PR DESCRIPTION
This unifies how we handle timeout errors in two `Connection` implementations, HTTP and WebSocket, so that they both return `context.DeadlineExceeded`.

Previously, the only WebSocketConnection.Send returned constants.ErrTimeout on timeout, whereas the HTTPConnection.Send had no timeout mechanism until v0.5.0, and returned context.DeadlineExceeded since #253 (unreleased).

Follow-up to #254
Ref #100