### PR TITLE
Enhance Connect, Close, Use, Let, and Unset to accept context.Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ type Person struct {
 
 func main() {
 	// Connect to SurrealDB
-	db, err := surrealdb.New("ws://localhost:8000")
+	db, err := surrealdb.Connect(context.Background(), "ws://localhost:8000")
 	if err != nil {
 		panic(err)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -84,7 +84,7 @@ func (s *SurrealDBTestSuite) TearDownTest() {
 
 // TearDownSuite is called after the s has finished running
 func (s *SurrealDBTestSuite) TearDownSuite() {
-	err := s.db.Close()
+	err := s.db.Close(context.Background())
 	s.Require().NoError(err)
 }
 

--- a/example/connection.go
+++ b/example/connection.go
@@ -29,7 +29,7 @@ func getSurrealDBHTTPURL() string {
 }
 
 func newSurrealDBWSConnection(database string, tables ...string) *surrealdb.DB {
-	db, err := surrealdb.New(getSurrealDBWSURL())
+	db, err := surrealdb.Connect(context.Background(), getSurrealDBWSURL())
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +38,7 @@ func newSurrealDBWSConnection(database string, tables ...string) *surrealdb.DB {
 }
 
 func newSurrealDBHTTPConnection(database string, tables ...string) *surrealdb.DB {
-	db, err := surrealdb.New(getSurrealDBHTTPURL())
+	db, err := surrealdb.Connect(context.Background(), getSurrealDBHTTPURL())
 	if err != nil {
 		panic(err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -12,7 +12,7 @@ import (
 //nolint:funlen
 func main() {
 	// Connect to SurrealDB
-	db, err := surrealdb.New("ws://localhost:8000")
+	db, err := surrealdb.Connect(context.Background(), "ws://localhost:8000")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -18,7 +18,7 @@ type testUser struct {
 }
 
 func SetupMockDB() (*surrealdb.DB, error) {
-	return surrealdb.New("")
+	return surrealdb.Connect(context.Background(), "")
 }
 
 func BenchmarkCreate(b *testing.B) {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -18,8 +18,8 @@ type LiveHandler interface {
 }
 
 type Connection interface {
-	Connect() error
-	Close() error
+	Connect(ctx context.Context) error
+	Close(ctx context.Context) error
 	// Send sends a request to SurrealDB and expects a response.
 	//
 	// It requires `res` to be of type `*RPCResponse[T]` where T is a type that implements `cbor.Unmarshaller`,
@@ -28,9 +28,9 @@ type Connection interface {
 	//
 	// The `ctx` is used to cancel the request if the context is canceled.
 	Send(ctx context.Context, res interface{}, method string, params ...interface{}) error
-	Use(namespace string, database string) error
-	Let(key string, value interface{}) error
-	Unset(key string) error
+	Use(ctx context.Context, namespace string, database string) error
+	Let(ctx context.Context, key string, value interface{}) error
+	Unset(ctx context.Context, key string) error
 	LiveNotifications(id string) (chan Notification, error)
 	GetUnmarshaler() codec.Unmarshaler
 }

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -57,11 +57,11 @@ func (s *ConnectionTestSuite) SetupSuite() {
 	con := s.connImplementations[s.name]
 
 	// connect
-	err := con.Connect()
+	err := con.Connect(context.Background())
 	s.Require().NoError(err)
 
 	// set namespace, database
-	err = con.Use("test", "test")
+	err = con.Use(context.Background(), "test", "test")
 	s.Require().NoError(err)
 
 	// sign in
@@ -71,12 +71,12 @@ func (s *ConnectionTestSuite) SetupSuite() {
 		"pass": "root",
 	})
 	s.Require().NoError(err)
-	_ = con.Let(constants.AuthTokenKey, *token.Result)
+	_ = con.Let(context.Background(), constants.AuthTokenKey, *token.Result)
 }
 
 func (s *ConnectionTestSuite) TearDownSuite() {
 	con := s.connImplementations[s.name]
-	err := con.Close()
+	err := con.Close(context.Background())
 	s.Require().NoError(err)
 }
 

--- a/pkg/connection/embedded.go
+++ b/pkg/connection/embedded.go
@@ -56,7 +56,7 @@ func NewEmbeddedConnection(p NewConnectionParams) *EmbeddedConnection {
 	return &con
 }
 
-func (h *EmbeddedConnection) Connect() error {
+func (h *EmbeddedConnection) Connect(ctx context.Context) error {
 	err := h.preConnectionChecks()
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func (h *EmbeddedConnection) Connect() error {
 	return nil
 }
 
-func (h *EmbeddedConnection) Close() error {
+func (h *EmbeddedConnection) Close(ctx context.Context) error {
 	C.sr_surreal_rpc_free(h.surrealRPC)
 
 	h.surrealRPC = nil
@@ -139,14 +139,14 @@ func (h *EmbeddedConnection) Send(ctx context.Context, res interface{}, method s
 	return h.unmarshaler.Unmarshal(rpcRes, res)
 }
 
-func (h *EmbeddedConnection) Use(namespace, database string) error {
-	return h.Send(context.Background(), nil, "use", namespace, database)
+func (h *EmbeddedConnection) Use(ctx context.Context, namespace, database string) error {
+	return h.Send(ctx, nil, "use", namespace, database)
 }
 
-func (h *EmbeddedConnection) Let(key string, value interface{}) error {
-	return h.Send(context.Background(), nil, "let", key, value)
+func (h *EmbeddedConnection) Let(ctx context.Context, key string, value interface{}) error {
+	return h.Send(ctx, nil, "let", key, value)
 }
 
-func (h *EmbeddedConnection) Unset(key string) error {
-	return h.Send(context.Background(), nil, "unset", key)
+func (h *EmbeddedConnection) Unset(ctx context.Context, key string) error {
+	return h.Send(ctx, nil, "unset", key)
 }

--- a/pkg/connection/http.go
+++ b/pkg/connection/http.go
@@ -41,8 +41,7 @@ func NewHTTPConnection(p NewConnectionParams) *HTTPConnection {
 	return &con
 }
 
-func (h *HTTPConnection) Connect() error {
-	ctx := context.TODO()
+func (h *HTTPConnection) Connect(ctx context.Context) error {
 	if err := h.preConnectionChecks(); err != nil {
 		return err
 	}
@@ -59,7 +58,7 @@ func (h *HTTPConnection) Connect() error {
 	return nil
 }
 
-func (h *HTTPConnection) Close() error {
+func (h *HTTPConnection) Close(ctx context.Context) error {
 	return nil
 }
 
@@ -164,19 +163,19 @@ func (h *HTTPConnection) MakeRequest(req *http.Request) ([]byte, error) {
 	return nil, errorResponse.Error
 }
 
-func (h *HTTPConnection) Use(namespace, database string) error {
+func (h *HTTPConnection) Use(ctx context.Context, namespace, database string) error {
 	h.variables.Store("namespace", namespace)
 	h.variables.Store("database", database)
 
 	return nil
 }
 
-func (h *HTTPConnection) Let(key string, value interface{}) error {
+func (h *HTTPConnection) Let(ctx context.Context, key string, value interface{}) error {
 	h.variables.Store(key, value)
 	return nil
 }
 
-func (h *HTTPConnection) Unset(key string) error {
+func (h *HTTPConnection) Unset(ctx context.Context, key string) error {
 	h.variables.Delete(key)
 	return nil
 }


### PR DESCRIPTION
This is a breaking change that enhances the following functions for the `Connection` interface to accept `context.Context`:

- `Connect`
- `Close`
- `Use`
- `Let`
- `Unset`

This also introduces the new top-level function `func Connect(ctx context.Context, connectionURL string) (*DB, error)` to replace the existing, and now deprecated, `func New(connectionURL string) (*DB, error)`.

The existing `New` had a chance of blocking when the initial connection attempt was delayed due to, e.g., unreliable network, and having a context enables the consumer of this SDK to have more control over what to do when it took more time than the designed timeout. Additionally, the new `Connect` function should better convey that it is not a simple local-only operation that initializes the in-memory data of the client/connection, but rather incurs a network call before returning.

The behaviors of `HTTPConnection`'s `Close`, `Use`, `Let`, and `Unset` are unchanged, because they don't incur network calls to cancel. `Connect` is enhanced to respect the provided context when doing an initial health check against SurrealDB.

The behaviors of `WebSocketConnection` counterparts mostly respect the provided context now, allowing you to prevent unexpected blocking when the underlying WebSocket connection is unreliable. The only exception is WebSocketConnection `Close`, which currently ignores `context.Context`. I'll revisit it and probably add a proper context support to it later.

Follow-up to #253 and #254
Ref #100