### PR TITLE
Let WebSocketConnection.Close respect Context for cancellation and timeout

### DIFF
--- a/pkg/connection/ws.go
+++ b/pkg/connection/ws.go
@@ -166,7 +166,13 @@ func (ws *WebSocketConnection) Close(ctx context.Context) error {
 				writeErr <- fmt.Errorf("BUG: WebSocketConnection.Close: failed to set write deadline, although it must always succeed: %w", err)
 				return
 			}
-			defer ws.Conn.SetWriteDeadline(time.Time{}) // Reset deadline
+			defer func() {
+				err := ws.Conn.SetWriteDeadline(time.Time{})
+				if err != nil {
+					writeErr <- fmt.Errorf("BUG: WebSocketConnection.Close: failed to reset write deadline, although it must always succeed: %w", err)
+					return
+				}
+			}()
 		}
 
 		err := ws.Conn.WriteMessage(gorilla.CloseMessage, gorilla.FormatCloseMessage(constants.CloseMessageCode, ""))

--- a/pkg/connection/ws.go
+++ b/pkg/connection/ws.go
@@ -161,7 +161,11 @@ func (ws *WebSocketConnection) Close(ctx context.Context) error {
 	go func() {
 		// Set write deadline based on context to prevent indefinite blocking
 		if deadline, ok := ctx.Deadline(); ok {
-			_ = ws.Conn.SetWriteDeadline(deadline)
+			err := ws.Conn.SetWriteDeadline(deadline)
+			if err != nil {
+				writeErr <- fmt.Errorf("BUG: WebSocketConnection.Close: failed to set write deadline, although it must always succeed: %w", err)
+				return
+			}
 			defer ws.Conn.SetWriteDeadline(time.Time{}) // Reset deadline
 		}
 


### PR DESCRIPTION
This resolves the issue that `WebSocketConnection.Close` was not respecting the provided context, which could have led to indefinite blocking in the worst case.

It turned out to be far more complex and sensitive than I thought initially, but here it is.
Please see the bunch of comments I left to describe whys.

Follow-up to #253, #254, and #256.
Ref #100