### PR TITLE
ci: Run all tests with HTTP connection too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,11 @@ jobs:
             echo "Waiting for SurrealDB to start... ($i/30)"
             sleep 2
           done
-      - name: test
+      - name: ws test
         run: go test -v -cover ./...
         env:
           SURREALDB_URL: ws://localhost:8000/rpc
+      - name: http test
+        run: go test -v -cover ./...
+        env:
+          SURREALDB_URL: http://localhost:8000

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,6 +75,13 @@ linters:
       - linters:
           - mnd
         path: _test\.go
+      # We assume writing logs to stdout and therefore
+      # chances of blocking are very rare-
+      # Having contexts for every log write would add unnecessary
+      # complexity and overhead to the SDK.
+      - linters:
+          - noctx
+        path: pkg/logger/slog.go
     paths:
       - third_party$
       - builtin$


### PR DESCRIPTION
Previously, we have been running almost all tets only with WebSocket connection.

Running the same tests with HTTP connection would reveal compatibility issues between the two.