### PR TITLE
HTTP: Fix panic after SignUp

### DIFF
--- a/db.go
+++ b/db.go
@@ -136,7 +136,7 @@ func (db *DB) SignUp(ctx context.Context, authData interface{}) (string, error) 
 		return "", err
 	}
 
-	if err := db.con.Let(ctx, constants.AuthTokenKey, token.Result); err != nil {
+	if err := db.con.Let(ctx, constants.AuthTokenKey, *token.Result); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Fixes `panic: interface conversion: interface {} is *string, not string` that happens on any RPC after a successful `SignUp`.

Fixes 262