### PR TITLE
HTTP: Fix unmarshaling

### DIFF
--- a/pkg/connection/model.go
+++ b/pkg/connection/model.go
@@ -32,6 +32,8 @@ type RPCRequest struct {
 
 // RPCResponse represents an outgoing JSON-RPC response
 type RPCResponse[T any] struct {
+	// ID is the ID of the request this response corresponds to.
+	// Note that this is always nil in case of HTTPConnection.
 	ID     interface{} `json:"id" msgpack:"id"`
 	Error  *RPCError   `json:"error,omitempty" msgpack:"error,omitempty"`
 	Result *T          `json:"result,omitempty" msgpack:"result,omitempty"`


### PR DESCRIPTION
After fixing #262, I discovered that some RPC responses using the Send function over HTTP are silently unmarshaled into nil, resulting in nil pointer dereference errors in one of our testable examples that run fine over WebSocket.

This addresses that issue by essentially reapplying recent WebSocketConnection enhancements #231 and #247 to HTTPConnection, ensuring it plays nicely when unmarshaling complex types.

This might be related to #246, which happened for WebSocketConnection since v0.4.3 and fixed in v0.4.4.

Ref https://github.com/surrealdb/surrealdb.go/pull/263#issuecomment-3101009033
Ref #262