### PR TITLE
Fix panic on signin failure with ws

### DIFF
--- a/db.go
+++ b/db.go
@@ -558,9 +558,5 @@ func send[TResult any](ctx context.Context, db *DB, method string, params ...any
 		return nil, err
 	}
 
-	if res.Error != nil {
-		return nil, res.Error
-	}
-
 	return res.Result, nil
 }

--- a/pkg/connection/gorillaws/ws.go
+++ b/pkg/connection/gorillaws/ws.go
@@ -484,6 +484,9 @@ func (ws *Connection) Send(ctx context.Context, method string, params ...any) (*
 			return nil, errors.New("response channel closed")
 		}
 
+		if res.Error != nil {
+			return nil, res.Error
+		}
 		return &res, nil
 	}
 }

--- a/pkg/connection/gws/websocket.go
+++ b/pkg/connection/gws/websocket.go
@@ -296,6 +296,9 @@ func (c *Connection) Send(ctx context.Context, method string, params ...any) (*c
 			return nil, errors.New("response channel closed")
 		}
 
+		if rpcRes.Error != nil {
+			return nil, rpcRes.Error
+		}
 		return &rpcRes, nil
 	}
 }


### PR DESCRIPTION
This fixes an issue in the unreleased version of this SDK where a SignIn failure over WebSocket panics.