### PR TITLE
Prevent panic on create with invalid record ID

### DIFF
--- a/example/example_create_test.go
+++ b/example/example_create_test.go
@@ -116,3 +116,27 @@ func ExampleCreate() {
 	// Selected person: {Third {2023-10-01 12:00:00 +0000 UTC} <nil>}
 	// Selected person: {Fourth {2023-10-01 12:00:00 +0000 UTC} <nil>}
 }
+
+func ExampleCreate_server_unmarshal_error() {
+	db := newSurrealDBWSConnection("query", "person")
+
+	type Person struct {
+		ID   models.RecordID `json:"id,omitempty"`
+		Name string          `json:"name"`
+	}
+
+	_, err := surrealdb.Create[Person](
+		context.Background(),
+		db,
+		"persons",
+		Person{
+			Name: "Test",
+		},
+	)
+	if err != nil {
+		fmt.Printf("Expected error: %v\n", err)
+	}
+
+	// Output:
+	// Expected error: cannot marshal RecordID with empty table or ID: want <table>:<identifier> but got :<nil>
+}

--- a/pkg/connection/gorillaws/ws.go
+++ b/pkg/connection/gorillaws/ws.go
@@ -556,6 +556,23 @@ func (ws *Connection) handleResponse(res []byte) {
 		}
 		defer close(responseChan)
 		responseChan <- rpcRes
+	} else if rpcRes.Result == nil && rpcRes.Error != nil {
+		// Some error cases result in the lack of an ID field in the response,
+		// so we handle the error here,
+		// rather than unintentionally treating it as a notification.
+		// See https://github.com/surrealdb/surrealdb.go/issues/273
+
+		// Note that we cannot send the response to the response channel,
+		// because the response did not have an ID field,
+		// so we cannot find the response channel to send it to.
+		// Instead, we just log the error and return,
+		// in the hope that the caller notices the programming error
+		// by the RPC timing out, and the error being logged here.
+		ws.logger.Error(
+			fmt.Sprintf("error in response: %v", rpcRes.Error),
+			"result", fmt.Sprint(rpcRes.Result),
+		)
+		return
 	} else {
 		// todo: find a surefire way to confirm a notification
 

--- a/pkg/connection/gws/websocket.go
+++ b/pkg/connection/gws/websocket.go
@@ -103,6 +103,23 @@ func (c *Connection) handleResponse(data []byte) {
 		}
 		defer close(responseChan)
 		responseChan <- rpcRes
+	} else if rpcRes.Result == nil && rpcRes.Error != nil {
+		// Some error cases result in the lack of an ID field in the response,
+		// so we handle the error here,
+		// rather than unintentionally treating it as a notification.
+		// See https://github.com/surrealdb/surrealdb.go/issues/273
+
+		// Note that we cannot send the response to the response channel,
+		// because the response did not have an ID field,
+		// so we cannot find the response channel to send it to.
+		// Instead, we just log the error and return,
+		// in the hope that the caller notices the programming error
+		// by the RPC timing out, and the error being logged here.
+		c.Logger.Error(
+			fmt.Sprintf("error in response: %v", rpcRes.Error),
+			"result", fmt.Sprint(rpcRes.Result),
+		)
+		return
 	} else {
 		// Handle notification
 		notificationRes, err := rpcRes.Result.MarshalCBOR()

--- a/pkg/models/record_id.go
+++ b/pkg/models/record_id.go
@@ -35,6 +35,15 @@ func NewRecordID(tableName string, id any) RecordID {
 }
 
 func (r *RecordID) MarshalCBOR() ([]byte, error) {
+	// We must prevent returning an invalid RecordID,
+	// because it results in SurrealDB returning an error without the response ID
+	// if the RPC is made over WebSocket, and
+	// we cannot distinguish it from a notification,
+	// nor can we return an error to the caller.
+	// See https://github.com/surrealdb/surrealdb.go/issues/273
+	if r.Table == "" || r.ID == nil {
+		return nil, fmt.Errorf("cannot marshal RecordID with empty table or ID: want <table>:<identifier> but got %s:%v", r.Table, r.ID)
+	}
 	return cbor.Marshal(cbor.Tag{
 		Number:  TagRecordID,
 		Content: []any{r.Table, r.ID},


### PR DESCRIPTION
This repeats #275 made for v0.6.1 onto the unreleased version of the SDK.

Ref #273