### PR TITLE
Move session related RPC methods to Connection

### DIFF
--- a/db.go
+++ b/db.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/http"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/rews"
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
@@ -63,7 +64,7 @@ func Connect(ctx context.Context, connectionURL string, opts ...ConnectOption) (
 
 	switch newParams.URL.Scheme {
 	case "http", "https":
-		con = connection.NewHTTPConnection(newParams)
+		con = http.New(newParams)
 	case "ws", "wss":
 		if newParams.ReconnectInterval > 0 {
 			con = rews.New(func(ctx context.Context) (*gorillaws.Connection, error) {
@@ -238,15 +239,7 @@ func (db *DB) Invalidate(ctx context.Context) error {
 }
 
 func (db *DB) Authenticate(ctx context.Context, token string) error {
-	if err := connection.Send[any](db.con, ctx, nil, "authenticate", token); err != nil {
-		return err
-	}
-
-	if err := db.con.Let(ctx, constants.AuthTokenKey, token); err != nil {
-		return err
-	}
-
-	return nil
+	return db.con.Authenticate(ctx, token)
 }
 
 func (db *DB) Let(ctx context.Context, key string, val any) error {

--- a/db.go
+++ b/db.go
@@ -218,15 +218,7 @@ func (db *DB) SignIn(ctx context.Context, authData any) (string, error) {
 }
 
 func (db *DB) Invalidate(ctx context.Context) error {
-	if err := connection.Send[any](db.con, ctx, nil, "invalidate"); err != nil {
-		return err
-	}
-
-	if err := db.con.Unset(ctx, constants.AuthTokenKey); err != nil {
-		return err
-	}
-
-	return nil
+	return db.con.Invalidate(ctx)
 }
 
 func (db *DB) Authenticate(ctx context.Context, token string) error {

--- a/db.go
+++ b/db.go
@@ -16,7 +16,6 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/http"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/rews"
-	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
@@ -205,16 +204,7 @@ func (db *DB) SignUp(ctx context.Context, authData any) (string, error) {
 //	  "pass": "VerySecurePassword123!",
 //	})
 func (db *DB) SignIn(ctx context.Context, authData any) (string, error) {
-	var token connection.RPCResponse[string]
-	if err := connection.Send(db.con, ctx, &token, "signin", authData); err != nil {
-		return "", err
-	}
-
-	if err := db.con.Let(ctx, constants.AuthTokenKey, *token.Result); err != nil {
-		return "", err
-	}
-
-	return *token.Result, nil
+	return db.con.SignIn(ctx, authData)
 }
 
 func (db *DB) Invalidate(ctx context.Context) error {

--- a/db.go
+++ b/db.go
@@ -176,16 +176,7 @@ func (db *DB) Info(ctx context.Context) (map[string]any, error) {
 //	  "pass": "VerySecurePassword123!",
 //	})
 func (db *DB) SignUp(ctx context.Context, authData any) (string, error) {
-	var token connection.RPCResponse[string]
-	if err := connection.Send(db.con, ctx, &token, "signup", authData); err != nil {
-		return "", err
-	}
-
-	if err := db.con.Let(ctx, constants.AuthTokenKey, *token.Result); err != nil {
-		return "", err
-	}
-
-	return *token.Result, nil
+	return db.con.SignUp(ctx, authData)
 }
 
 // SignIn signs in an existing user.

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -32,6 +32,7 @@ type Connection interface {
 	Let(ctx context.Context, key string, value any) error
 	Authenticate(ctx context.Context, token string) error
 	SignUp(ctx context.Context, authData any) (string, error)
+	SignIn(ctx context.Context, authData any) (string, error)
 	Invalidate(ctx context.Context) error
 	Unset(ctx context.Context, key string) error
 	LiveNotifications(id string) (chan Notification, error)

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -32,6 +32,7 @@ type Connection interface {
 	Let(ctx context.Context, key string, value any) error
 	Authenticate(ctx context.Context, token string) error
 	SignUp(ctx context.Context, authData any) (string, error)
+	Invalidate(ctx context.Context) error
 	Unset(ctx context.Context, key string) error
 	LiveNotifications(id string) (chan Notification, error)
 	GetUnmarshaler() codec.Unmarshaler

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -31,6 +31,7 @@ type Connection interface {
 	Use(ctx context.Context, namespace string, database string) error
 	Let(ctx context.Context, key string, value any) error
 	Authenticate(ctx context.Context, token string) error
+	SignUp(ctx context.Context, authData any) (string, error)
 	Unset(ctx context.Context, key string) error
 	LiveNotifications(id string) (chan Notification, error)
 	GetUnmarshaler() codec.Unmarshaler

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -30,6 +30,7 @@ type Connection interface {
 	Send(ctx context.Context, method string, params ...any) (*RPCResponse[cbor.RawMessage], error)
 	Use(ctx context.Context, namespace string, database string) error
 	Let(ctx context.Context, key string, value any) error
+	Authenticate(ctx context.Context, token string) error
 	Unset(ctx context.Context, key string) error
 	LiveNotifications(id string) (chan Notification, error)
 	GetUnmarshaler() codec.Unmarshaler

--- a/pkg/connection/gorillaws/ws.go
+++ b/pkg/connection/gorillaws/ws.go
@@ -433,6 +433,10 @@ func (ws *Connection) SignUp(ctx context.Context, authData any) (string, error) 
 	return rpc.SignUp(ws, ctx, authData)
 }
 
+func (ws *Connection) SignIn(ctx context.Context, authData any) (string, error) {
+	return rpc.SignIn(ws, ctx, authData)
+}
+
 func (ws *Connection) Invalidate(ctx context.Context) error {
 	return rpc.Invalidate(ws, ctx)
 }

--- a/pkg/connection/gorillaws/ws.go
+++ b/pkg/connection/gorillaws/ws.go
@@ -433,6 +433,10 @@ func (ws *Connection) SignUp(ctx context.Context, authData any) (string, error) 
 	return rpc.SignUp(ws, ctx, authData)
 }
 
+func (ws *Connection) Invalidate(ctx context.Context) error {
+	return rpc.Invalidate(ws, ctx)
+}
+
 func (ws *Connection) Unset(ctx context.Context, key string) error {
 	return connection.Send[any](ws, ctx, nil, "unset", key)
 }

--- a/pkg/connection/gorillaws/ws.go
+++ b/pkg/connection/gorillaws/ws.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/surrealdb/surrealdb.go/internal/rand"
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/rpc"
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
 
@@ -422,6 +423,10 @@ func (ws *Connection) Use(ctx context.Context, namespace, database string) error
 
 func (ws *Connection) Let(ctx context.Context, key string, value any) error {
 	return connection.Send[any](ws, ctx, nil, "let", key, value)
+}
+
+func (ws *Connection) Authenticate(ctx context.Context, token string) error {
+	return rpc.Authenticate(ws, ctx, token)
 }
 
 func (ws *Connection) Unset(ctx context.Context, key string) error {

--- a/pkg/connection/gorillaws/ws.go
+++ b/pkg/connection/gorillaws/ws.go
@@ -429,6 +429,10 @@ func (ws *Connection) Authenticate(ctx context.Context, token string) error {
 	return rpc.Authenticate(ws, ctx, token)
 }
 
+func (ws *Connection) SignUp(ctx context.Context, authData any) (string, error) {
+	return rpc.SignUp(ws, ctx, authData)
+}
+
 func (ws *Connection) Unset(ctx context.Context, key string) error {
 	return connection.Send[any](ws, ctx, nil, "unset", key)
 }

--- a/pkg/connection/gws/websocket.go
+++ b/pkg/connection/gws/websocket.go
@@ -276,6 +276,10 @@ func (c *Connection) SignUp(ctx context.Context, authData any) (string, error) {
 	return rpc.SignUp(c, ctx, authData)
 }
 
+func (c *Connection) SignIn(ctx context.Context, authData any) (string, error) {
+	return rpc.SignIn(c, ctx, authData)
+}
+
 func (c *Connection) Invalidate(ctx context.Context) error {
 	return rpc.Invalidate(c, ctx)
 }

--- a/pkg/connection/gws/websocket.go
+++ b/pkg/connection/gws/websocket.go
@@ -276,6 +276,10 @@ func (c *Connection) SignUp(ctx context.Context, authData any) (string, error) {
 	return rpc.SignUp(c, ctx, authData)
 }
 
+func (c *Connection) Invalidate(ctx context.Context) error {
+	return rpc.Invalidate(c, ctx)
+}
+
 // LiveNotifications implements connection.Connection.
 func (c *Connection) LiveNotifications(id string) (chan connection.Notification, error) {
 	return c.CreateNotificationChannel(id)

--- a/pkg/connection/gws/websocket.go
+++ b/pkg/connection/gws/websocket.go
@@ -13,6 +13,7 @@ import (
 	"github.com/surrealdb/surrealdb.go/internal/codec"
 	"github.com/surrealdb/surrealdb.go/internal/rand"
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/rpc"
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 )
 
@@ -265,6 +266,10 @@ func (c *Connection) GetUnmarshaler() codec.Unmarshaler {
 // Let implements connection.Connection.
 func (c *Connection) Let(ctx context.Context, key string, value any) error {
 	return connection.Send[any](c, ctx, nil, "let", key, value)
+}
+
+func (c *Connection) Authenticate(ctx context.Context, token string) error {
+	return rpc.Authenticate(c, ctx, token)
 }
 
 // LiveNotifications implements connection.Connection.

--- a/pkg/connection/gws/websocket.go
+++ b/pkg/connection/gws/websocket.go
@@ -272,6 +272,10 @@ func (c *Connection) Authenticate(ctx context.Context, token string) error {
 	return rpc.Authenticate(c, ctx, token)
 }
 
+func (c *Connection) SignUp(ctx context.Context, authData any) (string, error) {
+	return rpc.SignUp(c, ctx, authData)
+}
+
 // LiveNotifications implements connection.Connection.
 func (c *Connection) LiveNotifications(id string) (chan connection.Notification, error) {
 	return c.CreateNotificationChannel(id)

--- a/pkg/connection/http/http.go
+++ b/pkg/connection/http/http.go
@@ -195,6 +195,19 @@ func (h *HTTPConnection) SignUp(ctx context.Context, authData any) (string, erro
 	return token, nil
 }
 
+func (h *HTTPConnection) SignIn(ctx context.Context, authData any) (string, error) {
+	token, err := rpc.SignIn(h, ctx, authData)
+	if err != nil {
+		return "", err
+	}
+
+	if err := h.Let(ctx, constants.AuthTokenKey, token); err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
 func (h *HTTPConnection) Invalidate(ctx context.Context) error {
 	if err := rpc.Invalidate(h, ctx); err != nil {
 		return err

--- a/pkg/connection/http/http.go
+++ b/pkg/connection/http/http.go
@@ -195,6 +195,18 @@ func (h *HTTPConnection) SignUp(ctx context.Context, authData any) (string, erro
 	return token, nil
 }
 
+func (h *HTTPConnection) Invalidate(ctx context.Context) error {
+	if err := rpc.Invalidate(h, ctx); err != nil {
+		return err
+	}
+
+	if err := h.Unset(ctx, constants.AuthTokenKey); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (h *HTTPConnection) Unset(ctx context.Context, key string) error {
 	h.variables.Delete(key)
 	return nil

--- a/pkg/connection/http/http.go
+++ b/pkg/connection/http/http.go
@@ -182,6 +182,19 @@ func (h *HTTPConnection) Authenticate(ctx context.Context, token string) error {
 	return nil
 }
 
+func (h *HTTPConnection) SignUp(ctx context.Context, authData any) (string, error) {
+	token, err := rpc.SignUp(h, ctx, authData)
+	if err != nil {
+		return "", err
+	}
+
+	if err := h.Let(ctx, constants.AuthTokenKey, token); err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
 func (h *HTTPConnection) Unset(ctx context.Context, key string) error {
 	h.variables.Delete(key)
 	return nil

--- a/pkg/connection/http/http_test.go
+++ b/pkg/connection/http/http_test.go
@@ -1,4 +1,4 @@
-package connection
+package http
 
 import (
 	"bytes"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
@@ -61,13 +62,13 @@ func (s *HTTPTestSuite) TestMockClientEngine_MakeRequest() {
 		}
 	})
 
-	p := &Config{
+	p := &connection.Config{
 		BaseURL:     "http://test.surreal",
 		Marshaler:   &models.CborMarshaler{},
 		Unmarshaler: &models.CborUnmarshaler{},
 	}
 
-	httpEngine := NewHTTPConnection(p)
+	httpEngine := New(p)
 	httpEngine.SetHTTPClient(httpClient)
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.surreal/rpc", http.NoBody)

--- a/pkg/connection/integration/connection_test.go
+++ b/pkg/connection/integration/connection_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/http"
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
@@ -38,7 +39,7 @@ func TestConnectionTestSuite(t *testing.T) {
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
 	})
 
-	ts.connImplementations["http"] = connection.NewHTTPConnection(&connection.Config{
+	ts.connImplementations["http"] = http.New(&connection.Config{
 		BaseURL:     "http://localhost:8000",
 		Marshaler:   &models.CborMarshaler{},
 		Unmarshaler: &models.CborUnmarshaler{},

--- a/pkg/connection/rpc/authenticate.go
+++ b/pkg/connection/rpc/authenticate.go
@@ -1,0 +1,15 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+func Authenticate(c connection.Connection, ctx context.Context, token string) error {
+	if err := connection.Send[any](c, ctx, nil, "authenticate", token); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/connection/rpc/invalidate.go
+++ b/pkg/connection/rpc/invalidate.go
@@ -1,0 +1,15 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+func Invalidate(c connection.Connection, ctx context.Context) error {
+	if err := connection.Send[any](c, ctx, nil, "invalidate"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/connection/rpc/signin.go
+++ b/pkg/connection/rpc/signin.go
@@ -1,0 +1,16 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+func SignIn(c connection.Connection, ctx context.Context, authData any) (string, error) {
+	var token connection.RPCResponse[string]
+	if err := connection.Send(c, ctx, &token, "signin", authData); err != nil {
+		return "", err
+	}
+
+	return *token.Result, nil
+}

--- a/pkg/connection/rpc/signup.go
+++ b/pkg/connection/rpc/signup.go
@@ -1,0 +1,16 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+func SignUp(c connection.Connection, ctx context.Context, authData any) (string, error) {
+	var token connection.RPCResponse[string]
+	if err := connection.Send(c, ctx, &token, "signup", authData); err != nil {
+		return "", err
+	}
+
+	return *token.Result, nil
+}


### PR DESCRIPTION
This enhances the `Connection` interface so that its implementations can have custom implementations the following RPC methods:

- SignUp
- SignIn
- Authenticate
- Invalidate

This proved necessary for auto-reconnection, as it needs to restore the session.

Without session restoration, the consumer of the auto-reconnecting WebSocket connection can observe confusing behaviors like the following:

- Some session variables previously set using `Let` suddenly disappear (due to the auto-reconnection ,which is transparent to the user)
- Some sessions suddenly become unauthenticated and require re-authentication (due to the auto-reconnection results in a new SurrealDB-side session bound to a new WebSocket connection, and the user has no way to know beforehand that when to reauthenticate

I've also taken this as a good chance to avoid setting an unnecessary session variable `auth_token` for WebSocket, which I believe was due to the implementation details of SurrealDB RPC over HTTP leaked into `surrealdb.DB` struct's SignUp, SignIn, and Authenticate methods.

Ref #110 
Follow-up to #269
