### PR TITLE
Enhance WS auto-reconnection to support session restoration

### DIFF
--- a/internal/fakesdb/example_test.go
+++ b/internal/fakesdb/example_test.go
@@ -1,0 +1,148 @@
+package fakesdb_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/internal/fakesdb"
+)
+
+func ExampleServer() {
+	// Create a new fake SurrealDB server
+	server := fakesdb.NewServer("127.0.0.1:18080")
+
+	// Add a stub with custom matcher for query method
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher: fakesdb.MatchMethodWithParams("query", func(params []interface{}) bool {
+			// Match only queries for users table
+			if len(params) > 0 {
+				if query, ok := params[0].(string); ok {
+					return contains(query, "users")
+				}
+			}
+			return false
+		}),
+		Response: map[string]interface{}{
+			"result": []interface{}{
+				map[string]interface{}{"id": "user:1", "name": "Alice"},
+				map[string]interface{}{"id": "user:2", "name": "Bob"},
+			},
+		},
+	})
+
+	// Add failure injection for testing resilience
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher:  fakesdb.MatchMethod("create"),
+		Response: map[string]interface{}{"id": "record:1"},
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureResponseDelay,
+				Probability: 0.3, // 30% chance of delay
+				MinDelay:    100 * time.Millisecond,
+				MaxDelay:    500 * time.Millisecond,
+			},
+		},
+	})
+
+	// Set global failures that apply to all requests
+	server.SetGlobalFailures([]fakesdb.FailureConfig{
+		{
+			Type:        fakesdb.FailureRequestDelay,
+			Probability: 0.1, // 10% chance of request delay
+			MinDelay:    50 * time.Millisecond,
+			MaxDelay:    150 * time.Millisecond,
+		},
+	})
+
+	// Start the server
+	if err := server.Start(); err != nil {
+		panic(err)
+	}
+	defer server.Stop()
+
+	// Get the server address for client connection
+	addr := server.Address()
+	wsURL := fmt.Sprintf("ws://%s/rpc", addr)
+	fmt.Printf("Fake SurrealDB server running at: %s\n", wsURL)
+
+	// Create your WebSocket client with auto-reconnection enabled
+	// and test that it properly handles the connection drops
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Your test code here that uses the WebSocket connection
+	// The fake server will randomly drop connections to test reconnection logic
+	_ = ctx
+
+	// Output:
+	// Fake SurrealDB server running at: ws://127.0.0.1:18080/rpc
+}
+
+func ExampleServer_connectionFailures() {
+	server := fakesdb.NewServer("127.0.0.1:18081")
+
+	// Simulate WebSocket close on query requests
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher:  fakesdb.MatchMethod("query"),
+		Response: map[string]interface{}{"result": []interface{}{}},
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureWebSocketClose,
+				Probability: 1.0, // Always close connection
+				CloseCode:   1001,
+				CloseReason: "Server going away",
+			},
+		},
+	})
+
+	// Simulate TCP reset
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher:  fakesdb.MatchMethod("delete"),
+		Response: map[string]interface{}{"ok": true},
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureTCPReset,
+				Probability: 0.5, // 50% chance of TCP reset
+			},
+		},
+	})
+
+	// Simulate corrupted messages
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher:  fakesdb.MatchMethod("update"),
+		Response: map[string]interface{}{"updated": true},
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureCorruptedMessage,
+				Probability: 0.2, // 20% chance of corruption
+			},
+		},
+	})
+
+	if err := server.Start(); err != nil {
+		panic(err)
+	}
+	defer server.Stop()
+
+	// Get the server address for client connection
+	addr := server.Address()
+	wsURL := fmt.Sprintf("ws://%s/rpc", addr)
+	fmt.Printf("Fake SurrealDB server running at: %s\n", wsURL)
+
+	// Create your WebSocket client with auto-reconnection enabled
+	// and test that it properly handles the connection drops
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Your test code here that uses the WebSocket connection
+	// The fake server will randomly drop connections to test reconnection logic
+	_ = ctx
+
+	// Output:
+	// Fake SurrealDB server running at: ws://127.0.0.1:18081/rpc
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && s[:len(substr)] == substr
+}

--- a/internal/fakesdb/example_test.go
+++ b/internal/fakesdb/example_test.go
@@ -3,6 +3,7 @@ package fakesdb_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/surrealdb/surrealdb.go/internal/fakesdb"
@@ -59,7 +60,11 @@ func ExampleServer() {
 	if err := server.Start(); err != nil {
 		panic(err)
 	}
-	defer server.Stop()
+	defer func() {
+		if err := server.Stop(); err != nil {
+			log.Printf("Failed to stop server: %v", err)
+		}
+	}()
 
 	// Get the server address for client connection
 	addr := server.Address()
@@ -123,7 +128,11 @@ func ExampleServer_connectionFailures() {
 	if err := server.Start(); err != nil {
 		panic(err)
 	}
-	defer server.Stop()
+	defer func() {
+		if err := server.Stop(); err != nil {
+			log.Printf("Failed to stop server: %v", err)
+		}
+	}()
 
 	// Get the server address for client connection
 	addr := server.Address()

--- a/internal/fakesdb/integration/server_response_delay_test.go
+++ b/internal/fakesdb/integration/server_response_delay_test.go
@@ -50,7 +50,11 @@ func TestServerFailureResponseDelay(t *testing.T) {
 	// Start server
 	err := server.Start()
 	require.NoError(t, err)
-	defer server.Stop()
+	defer func() {
+		if stopErr := server.Stop(); stopErr != nil {
+			t.Fatalf("Failed to stop server: %v", stopErr)
+		}
+	}()
 
 	wsURL := "ws://" + server.Address()
 

--- a/internal/fakesdb/integration/server_response_delay_test.go
+++ b/internal/fakesdb/integration/server_response_delay_test.go
@@ -1,0 +1,117 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/internal/fakesdb"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// TestServerFailureResponseDelay demonstrates how simulated server delays work
+func TestServerFailureResponseDelay(t *testing.T) {
+	// Create fake SurrealDB server
+	server := fakesdb.NewServer("127.0.0.1:0")
+	server.TokenSignIn = "test_token_signin"
+
+	// Count requests to introduce delays
+	requestCount := 0
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher: fakesdb.MatchMethodWithParams("select", func(params []any) bool {
+			requestCount++
+			t.Logf("Select request #%d", requestCount)
+			// Delay every 3rd request
+			return requestCount%3 == 0
+		}),
+		Response: map[string]any{
+			"id": cbor.Tag{Number: 8, Content: []any{"test", "1"}},
+		},
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureResponseDelay,
+				Probability: 1.0,
+				MinDelay:    200 * time.Millisecond, // Longer than request timeout
+				MaxDelay:    300 * time.Millisecond,
+			},
+		},
+	})
+
+	// Normal response
+	server.AddStubResponse(fakesdb.SimpleStubResponse("select", map[string]any{
+		"id": cbor.Tag{Number: 8, Content: []any{"test", "1"}},
+	}))
+
+	// Start server
+	err := server.Start()
+	require.NoError(t, err)
+	defer server.Stop()
+
+	wsURL := "ws://" + server.Address()
+
+	p, err := surrealdb.Configure(wsURL)
+	require.NoError(t, err)
+
+	ws := gorillaws.New(p).
+		SetTimeOut(100 * time.Millisecond) // Short request timeout
+
+	err = ws.Connect(context.Background())
+	require.NoError(t, err)
+
+	db := surrealdb.New(ws)
+	defer db.Close(context.Background())
+
+	// Setup
+	err = db.Use(context.Background(), "test", "test")
+	require.NoError(t, err)
+
+	token, err := db.SignIn(context.Background(), &surrealdb.Auth{
+		Username: "root",
+		Password: "root",
+	})
+	require.NoError(t, err)
+	require.Equal(t, server.TokenSignIn, token)
+
+	err = db.Authenticate(context.Background(), token)
+	require.NoError(t, err)
+
+	type TestRecord struct {
+		ID models.RecordID `json:"id"`
+	}
+
+	// Run multiple selects
+	successCount := 0
+	timeoutCount := 0
+
+	for i := 0; i < 10; i++ {
+		result, err := surrealdb.Select[TestRecord](
+			context.Background(),
+			db,
+			models.NewRecordID("test", "1"),
+		)
+
+		if err != nil {
+			if err.Error() == "context deadline exceeded" {
+				timeoutCount++
+				t.Logf("Request %d timed out (expected for every 3rd)", i+1)
+			} else {
+				t.Logf("Request %d failed with: %v", i+1, err)
+			}
+		} else {
+			successCount++
+			assert.NotNil(t, result)
+			assert.Equal(t, "test", result.ID.Table)
+		}
+	}
+
+	// We should have some timeouts (roughly 3 out of 10)
+	assert.Greater(t, timeoutCount, 0, "Should have some timeouts")
+	assert.Greater(t, successCount, 5, "Should have mostly successes")
+
+	t.Logf("Results: %d successes, %d timeouts", successCount, timeoutCount)
+}

--- a/internal/fakesdb/server.go
+++ b/internal/fakesdb/server.go
@@ -1,0 +1,852 @@
+// Package fakesdb provides a fake SurrealDB WebSocket server for testing purposes.
+// It speaks the SurrealDB RPC protocol over WebSocket using CBOR encoding and includes
+// various failure injection capabilities.
+//
+// We don't currently have an executable binary for this package,
+// but it can be used as a library to create a fake SurrealDB server
+// for integration tests.
+//
+// The WebSocket server is implemented using the `gws` library.
+//
+// To flexibly inject failures, you can configure stub responses
+// that match specific RPC methods and parameters, along with failure configurations
+// that specify how it fails (e.g., delays, invalid responses, TCP resets).
+package fakesdb
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"log"
+	mathrand "math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/lxzan/gws"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+// FailureType represents the type of failure to inject during request processing
+type FailureType string
+
+const (
+	// FailureNone indicates no failure injection
+	FailureNone FailureType = "none"
+	// FailureRequestDelay delays before processing the request
+	FailureRequestDelay FailureType = "request_delay"
+	// FailureResponseDelay delays the response (sent in background)
+	FailureResponseDelay FailureType = "response_delay"
+	// FailureInvalidResponse sends random binary data instead of valid response
+	FailureInvalidResponse FailureType = "invalid_response"
+	// FailureTCPTimeout sets TCP read/write deadline to immediate timeout
+	FailureTCPTimeout FailureType = "tcp_timeout"
+	// FailureTCPReset forcefully resets the TCP connection
+	FailureTCPReset FailureType = "tcp_reset"
+	// FailureWebSocketClose sends WebSocket close frame with configurable code/reason
+	FailureWebSocketClose FailureType = "websocket_close"
+	// FailureRandomDelay applies random delay up to 5 seconds
+	FailureRandomDelay FailureType = "random_delay"
+	// FailureDropConnection immediately closes the underlying network connection
+	FailureDropConnection FailureType = "drop_connection"
+	// FailurePartialMessage sends only half of the response message
+	FailurePartialMessage FailureType = "partial_message"
+	// FailureCorruptedMessage corrupts random bytes in the response
+	FailureCorruptedMessage FailureType = "corrupted_message"
+)
+
+// RequestMatcher defines criteria for matching incoming RPC requests.
+// It can match by method name and optionally by parameter values.
+type RequestMatcher struct {
+	// Method is the RPC method name to match
+	Method string
+	// Matcher is an optional function to match based on request parameters.
+	// If nil, only the method name is used for matching.
+	Matcher func(params []any) bool
+}
+
+// StubResponse defines a pre-configured response for matching requests.
+// It can return either a successful response or an error, and optionally
+// inject failures during processing.
+type StubResponse struct {
+	// Matcher determines which requests this stub should handle
+	Matcher RequestMatcher
+	// Response is the successful response to return (mutually exclusive with Error)
+	Response any
+	// Error is the error response to return (mutually exclusive with Response)
+	Error *connection.RPCError
+	// Failures defines failure injection configurations for this response
+	Failures []FailureConfig
+}
+
+// FailureConfig defines how and when to inject a specific failure type
+type FailureConfig struct {
+	// Type specifies the type of failure to inject
+	Type FailureType
+	// Probability of triggering this failure (0.0 to 1.0)
+	Probability float64
+	// MinDelay is the minimum delay for delay-based failures
+	MinDelay time.Duration
+	// MaxDelay is the maximum delay for delay-based failures
+	MaxDelay time.Duration
+	// CloseCode is the WebSocket close code for FailureWebSocketClose
+	CloseCode int
+	// CloseReason is the WebSocket close reason for FailureWebSocketClose
+	CloseReason string
+}
+
+// AuthType represents the type of authentication used in a session
+type AuthType string
+
+const (
+	// AuthTypeToken indicates token-based authentication
+	AuthTypeToken AuthType = "token"
+	// AuthTypePassword indicates password-based authentication
+	AuthTypePassword AuthType = "password"
+)
+
+// Session represents an authenticated connection session with namespace/database context
+type Session struct {
+	// ID is the unique session identifier
+	ID string
+	// Namespace is the SurrealDB namespace for this session
+	Namespace string
+	// Database is the SurrealDB database for this session
+	Database string
+	// AuthType indicates how the session was authenticated
+	AuthType AuthType
+	// Token is the authentication token for this session
+	Token string
+	// Username is the authenticated user's name
+	Username string
+	// ExpiresAt is when the session expires (nil means no expiration)
+	ExpiresAt *time.Time // nil means no expiration
+	// Variables can be set using `Let` RPC method
+	// and unset using `Unset` RPC method
+	Vars map[string]any
+}
+
+// Server is a fake SurrealDB WebSocket server that implements the RPC protocol
+// with support for stub responses and failure injection
+type Server struct {
+	addr           string
+	listener       net.Listener
+	server         *gws.Server
+	mu             sync.RWMutex
+	stubResponses  []StubResponse
+	globalFailures []FailureConfig
+	connections    map[*gws.Conn]bool
+	connSessions   map[*gws.Conn]*Session
+	sessions       []*Session
+	ctx            context.Context
+	cancel         context.CancelFunc
+
+	// TokenSignUp is the token returned by any successful SignUp operation
+	// This is used to verify that the SignUp operation works correctly.
+	TokenSignUp string
+
+	// TokenSignIn is the token returned by any successful SignIn operation
+	// This is used to verify that the SignIn operation works correctly.
+	TokenSignIn string
+
+	// sessionIdCounter is used to generate unique session IDs
+	sessionIdCounter int
+}
+
+// Handler implements the gws.Handler interface for WebSocket connections
+type Handler struct {
+	server *Server
+}
+
+// NewServer creates a new fake SurrealDB server.
+// Use "127.0.0.1:0" to bind to a random available port.
+func NewServer(addr string) *Server {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Server{
+		addr:         addr,
+		connections:  make(map[*gws.Conn]bool),
+		connSessions: make(map[*gws.Conn]*Session),
+		sessions:     make([]*Session, 0),
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+
+	handler := &Handler{server: s}
+	s.server = gws.NewServer(handler, &gws.ServerOption{
+		// Don't enforce sub-protocol for testing flexibility
+	})
+	s.server.OnError = func(_ net.Conn, err error) {
+		if !errors.Is(err, net.ErrClosed) && !isUseOfClosedNetworkError(err) {
+			log.Printf("Server error: %v", err)
+		}
+	}
+
+	return s
+}
+
+// AddStubResponse adds a stub response configuration to the server.
+// Stub responses are matched in the order they were added.
+func (s *Server) AddStubResponse(stub StubResponse) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stubResponses = append(s.stubResponses, stub)
+}
+
+// GenerateTokenWithExpiration creates a new token session with specified expiration.
+// This is useful for testing authentication flows and token expiration scenarios.
+func (s *Server) GenerateTokenWithExpiration(username string, token string, duration time.Duration) (string, error) {
+	if token == "" {
+		return "", fmt.Errorf("GenerateTokenWithExpiration: token cannot be empty")
+	}
+
+	expiresAt := time.Now().Add(duration)
+	session := &Session{
+		ID:        fmt.Sprintf("session_%d", s.sessionIdCounter),
+		AuthType:  AuthTypeToken,
+		Token:     token,
+		Username:  username,
+		ExpiresAt: &expiresAt,
+	}
+
+	s.mu.Lock()
+	s.sessions = append(s.sessions, session)
+	s.sessionIdCounter++
+	s.mu.Unlock()
+
+	return token, nil
+}
+
+// SetGlobalFailures sets failure configurations that apply to all requests.
+// These are checked before stub-specific failures.
+func (s *Server) SetGlobalFailures(failures []FailureConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.globalFailures = failures
+}
+
+// Start starts the server and begins accepting WebSocket connections.
+// Returns an error if the server cannot bind to the specified address.
+func (s *Server) Start() error {
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	s.listener = listener
+
+	go func() {
+		if err := s.server.RunListener(listener); err != nil {
+			// Ignore "use of closed network connection" errors which are expected on shutdown
+			if !errors.Is(err, net.ErrClosed) && !isUseOfClosedNetworkError(err) {
+				log.Printf("Server error: %v", err)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Stop gracefully shuts down the server and closes all connections
+func (s *Server) Stop() error {
+	s.cancel()
+	if s.listener != nil {
+		return s.listener.Close()
+	}
+	return nil
+}
+
+// Address returns the actual address the server is listening on.
+// This is useful when using "127.0.0.1:0" to get the assigned port.
+func (s *Server) Address() string {
+	if s.listener != nil {
+		return s.listener.Addr().String()
+	}
+	return s.addr
+}
+
+func (h *Handler) OnOpen(socket *gws.Conn) {
+	h.server.mu.Lock()
+	h.server.connections[socket] = true
+	// Connection starts without a session until Use is called
+	h.server.mu.Unlock()
+
+	socket.SetDeadline(time.Time{})
+}
+
+func (h *Handler) OnClose(socket *gws.Conn, err error) {
+	h.server.mu.Lock()
+	delete(h.server.connSessions, socket)
+	delete(h.server.connections, socket)
+	h.server.mu.Unlock()
+}
+
+func (h *Handler) OnPing(socket *gws.Conn, payload []byte) {
+	socket.WritePong(payload)
+}
+
+func (h *Handler) OnPong(socket *gws.Conn, payload []byte) {
+}
+
+func (h *Handler) OnMessage(socket *gws.Conn, message *gws.Message) {
+	defer message.Close()
+
+	h.server.mu.RLock()
+	globalFailures := h.server.globalFailures
+	h.server.mu.RUnlock()
+
+	for _, failure := range globalFailures {
+		if shouldTriggerFailure(failure.Probability) {
+			if err := h.applyFailure(socket, failure, nil, nil); err != nil {
+				return
+			}
+		}
+	}
+
+	var req connection.RPCRequest
+	if err := cbor.Unmarshal(message.Bytes(), &req); err != nil {
+		h.sendError(socket, nil, -32700, "Parse error")
+		return
+	}
+
+	// Check for stubbed responses first
+	h.server.mu.RLock()
+	var matchedStub *StubResponse
+	for _, stub := range h.server.stubResponses {
+		if stub.Matcher.Method == req.Method {
+			if stub.Matcher.Matcher == nil || stub.Matcher.Matcher(req.Params) {
+				matchedStub = &stub
+				break
+			}
+		}
+	}
+	h.server.mu.RUnlock()
+
+	// Handle authentication-related methods with default behavior
+	switch req.Method {
+	case "use":
+		h.handleUse(socket, &req)
+		return
+	case "signin":
+		h.handleSignIn(socket, &req)
+		return
+	case "signup":
+		h.handleSignUp(socket, &req)
+		return
+	case "authenticate":
+		h.handleAuthenticate(socket, &req)
+		return
+	case "let":
+		h.handleLet(socket, &req)
+		return
+	case "unset":
+		h.handleUnset(socket, &req)
+		return
+	}
+
+	// For other methods, check if namespace/database is set and authenticated
+	h.server.mu.RLock()
+	session, authenticated := h.server.connSessions[socket]
+	h.server.mu.RUnlock()
+
+	if !authenticated {
+		h.sendError(socket, req.ID, -32000, "There was a problem with the database: There was a problem with authentication: Session not found")
+		return
+	}
+
+	if session.Namespace == "" || session.Database == "" {
+		h.sendError(socket, req.ID, -32000, "There was a problem with the database: There was a problem with authentication: Specify a namespace and database")
+		return
+	}
+
+	if session.Username == "" {
+		h.sendError(socket, req.ID, -32000, "There was a problem with the database: There was a problem with authentication: Not signed in")
+		return
+	}
+
+	// Check if session is expired
+	if session.ExpiresAt != nil && time.Now().After(*session.ExpiresAt) {
+		h.sendError(socket, req.ID, -32000, "There was a problem with the database: There was a problem with authentication: Expired")
+		return
+	}
+
+	// If we have a stub, use it regardless of the method
+	if matchedStub != nil {
+		for _, failure := range matchedStub.Failures {
+			if shouldTriggerFailure(failure.Probability) {
+				if err := h.applyFailure(socket, failure, &req, matchedStub); err != nil {
+					return
+				}
+			}
+		}
+
+		if matchedStub.Error != nil {
+			h.sendError(socket, req.ID, matchedStub.Error.Code, matchedStub.Error.Message)
+		} else {
+			h.sendResponse(socket, req.ID, matchedStub.Response)
+		}
+		return
+	}
+
+	// If no stub was found, return a default response
+	h.sendResponse(socket, req.ID, map[string]any{
+		"default": "response",
+		"method":  req.Method,
+		"params":  req.Params,
+	})
+}
+
+func (h *Handler) applyFailure(socket *gws.Conn, failure FailureConfig, req *connection.RPCRequest, stub *StubResponse) error {
+	switch failure.Type {
+	case FailureRequestDelay:
+		delay := randomDuration(failure.MinDelay, failure.MaxDelay)
+		time.Sleep(delay)
+
+	case FailureResponseDelay:
+		go func() {
+			delay := randomDuration(failure.MinDelay, failure.MaxDelay)
+			time.Sleep(delay)
+			if req != nil && stub != nil {
+				if stub.Error != nil {
+					h.sendError(socket, req.ID, stub.Error.Code, stub.Error.Message)
+				} else {
+					h.sendResponse(socket, req.ID, stub.Response)
+				}
+			}
+		}()
+		return fmt.Errorf("response delayed")
+
+	case FailureInvalidResponse:
+		data := make([]byte, 100)
+		rand.Read(data)
+		socket.WriteMessage(gws.OpcodeBinary, data)
+		return fmt.Errorf("invalid response sent")
+
+	case FailureTCPTimeout:
+		if conn, ok := socket.NetConn().(net.Conn); ok {
+			conn.SetReadDeadline(time.Now())
+			conn.SetWriteDeadline(time.Now())
+		}
+		return fmt.Errorf("tcp timeout")
+
+	case FailureTCPReset:
+		if conn, ok := socket.NetConn().(net.Conn); ok {
+			if tcpConn, ok := conn.(*net.TCPConn); ok {
+				tcpConn.SetLinger(0)
+			}
+			conn.Close()
+		}
+		return fmt.Errorf("tcp reset")
+
+	case FailureWebSocketClose:
+		code := failure.CloseCode
+		if code == 0 {
+			code = 1001
+		}
+		reason := failure.CloseReason
+		if reason == "" {
+			reason = "failure injection"
+		}
+		socket.WriteClose(uint16(code), []byte(reason))
+		return fmt.Errorf("websocket close")
+
+	case FailureRandomDelay:
+		delay := time.Duration(mathrand.Int63n(int64(5 * time.Second)))
+		time.Sleep(delay)
+
+	case FailureDropConnection:
+		socket.NetConn().Close()
+		return fmt.Errorf("connection dropped")
+
+	case FailurePartialMessage:
+		if req != nil && stub != nil {
+			var resp connection.RPCResponse[any]
+			resp.ID = req.ID
+			resp.Result = &stub.Response
+
+			data, _ := cbor.Marshal(resp)
+			partialLen := len(data) / 2
+			socket.WriteMessage(gws.OpcodeBinary, data[:partialLen])
+			return fmt.Errorf("partial message sent")
+		}
+
+	case FailureCorruptedMessage:
+		if req != nil && stub != nil {
+			var resp connection.RPCResponse[any]
+			resp.ID = req.ID
+			resp.Result = &stub.Response
+
+			data, _ := cbor.Marshal(resp)
+			for i := 0; i < len(data) && i < 10; i++ {
+				data[mathrand.Intn(len(data))] = byte(mathrand.Intn(256))
+			}
+			socket.WriteMessage(gws.OpcodeBinary, data)
+			return fmt.Errorf("corrupted message sent")
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) sendResponse(socket *gws.Conn, id any, result any) {
+	var resp connection.RPCResponse[any]
+	resp.ID = id
+	resp.Result = &result
+
+	data, err := cbor.Marshal(resp)
+	if err != nil {
+		h.sendError(socket, id, -32603, fmt.Sprintf("sendResponse: %v", err))
+		return
+	}
+
+	socket.WriteMessage(gws.OpcodeBinary, data)
+}
+
+func (h *Handler) sendError(socket *gws.Conn, id any, code int, message string) {
+	var resp connection.RPCResponse[any]
+	resp.ID = id
+	resp.Error = &connection.RPCError{
+		Code:    code,
+		Message: message,
+	}
+
+	responseData, err := cbor.Marshal(resp)
+	if err != nil {
+		log.Printf("Failed to marshal error response: %v", err)
+		return
+	}
+
+	socket.WriteMessage(gws.OpcodeBinary, responseData)
+}
+
+func shouldTriggerFailure(probability float64) bool {
+	if probability <= 0 {
+		return false
+	}
+	if probability >= 1 {
+		return true
+	}
+	return mathrand.Float64() < probability
+}
+
+func randomDuration(min, max time.Duration) time.Duration {
+	if min >= max {
+		return min
+	}
+	return min + time.Duration(mathrand.Int63n(int64(max-min)))
+}
+
+// MatchMethod creates a RequestMatcher that matches only by method name
+func MatchMethod(method string) RequestMatcher {
+	return RequestMatcher{
+		Method:  method,
+		Matcher: nil,
+	}
+}
+
+// MatchMethodWithParams creates a RequestMatcher that matches by method name
+// and parameter values using a custom matcher function
+func MatchMethodWithParams(method string, matcher func(params []any) bool) RequestMatcher {
+	return RequestMatcher{
+		Method:  method,
+		Matcher: matcher,
+	}
+}
+
+// SimpleStubResponse creates a basic stub response for a method without failure injection
+func SimpleStubResponse(method string, response any) StubResponse {
+	return StubResponse{
+		Matcher:  MatchMethod(method),
+		Response: response,
+	}
+}
+
+// ErrorStubResponse creates a stub response that returns an RPC error
+func ErrorStubResponse(method string, code int, message string) StubResponse {
+	return StubResponse{
+		Matcher: MatchMethod(method),
+		Error: &connection.RPCError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+func (h *Handler) handleUse(socket *gws.Conn, req *connection.RPCRequest) {
+	if len(req.Params) < 2 {
+		h.sendError(socket, req.ID, -32602, "handleUse: invalid params: use requires namespace and database parameters")
+		return
+	}
+
+	namespace, ok := req.Params[0].(string)
+	if !ok {
+		h.sendError(socket, req.ID, -32602, "handleUse: invalid params: namespace must be a string")
+		return
+	}
+
+	database, ok := req.Params[1].(string)
+	if !ok {
+		h.sendError(socket, req.ID, -32602, "handleUse: invalid params: database must be a string")
+		return
+	}
+
+	h.server.mu.Lock()
+	session := h.server.connSessions[socket]
+	if session == nil {
+		session = &Session{}
+		h.server.connSessions[socket] = session
+	}
+	session.Namespace = namespace
+	session.Database = database
+	h.server.mu.Unlock()
+
+	h.sendResponse(socket, req.ID, nil)
+}
+
+func (h *Handler) handleSignUp(socket *gws.Conn, req *connection.RPCRequest) {
+	if len(req.Params) < 1 {
+		h.sendError(socket, req.ID, -32602, "handleSignUp: invalid params: signup requires auth data")
+		return
+	}
+
+	// Extract username from auth data if available
+	username := ""
+	if authData, ok := req.Params[0].(map[any]any); ok {
+		if user, ok := authData["user"].(string); ok {
+			username = user
+		} else if user, ok := authData["username"].(string); ok {
+			username = user
+		}
+	}
+	if username == "" {
+		h.sendError(socket, req.ID, -32602, "UpIn: Signin requires username in auth data")
+		return
+	}
+
+	ns := ""
+	if session, ok := req.Params[0].(map[any]any); ok {
+		if n, ok := session["NS"].(string); ok {
+			ns = n
+		}
+	}
+	if ns == "" {
+		h.sendError(socket, req.ID, -32602, "handleSignIn: Signin requires namespace in auth data")
+		return
+	}
+	db := ""
+	if session, ok := req.Params[0].(map[any]any); ok {
+		if d, ok := session["DB"].(string); ok {
+			db = d
+		}
+	}
+	if db == "" {
+		h.sendError(socket, req.ID, -32602, "handleSignIn: Signin requires database in auth data")
+		return
+	}
+
+	token, err := h.server.GenerateTokenWithExpiration(username, h.server.TokenSignUp, 1*time.Hour)
+	if err != nil {
+		h.sendError(socket, req.ID, -32000, "handleSignUp: "+err.Error())
+		return
+	}
+
+	h.server.mu.Lock()
+	session := h.server.connSessions[socket]
+	if session == nil {
+		session = &Session{
+			ID:        fmt.Sprintf("session_%x", h.server.sessionIdCounter),
+			Namespace: ns,
+			Database:  db,
+			AuthType:  AuthTypeToken,
+			Token:     token,
+			Username:  username,
+		}
+		h.server.connSessions[socket] = session
+	} else {
+		session.Namespace = ns
+		session.Database = db
+		session.AuthType = AuthTypeToken
+		session.Token = token
+		session.Username = username
+	}
+	h.server.mu.Unlock()
+
+	h.sendResponse(socket, req.ID, token)
+}
+
+func (h *Handler) handleSignIn(socket *gws.Conn, req *connection.RPCRequest) {
+	if len(req.Params) < 1 {
+		h.sendError(socket, req.ID, -32602, "handleSignIn: invalid params: signin requires auth data")
+		return
+	}
+
+	// Extract username from auth data if available
+	username := ""
+	if authData, ok := req.Params[0].(map[any]any); ok {
+		if user, ok := authData["user"].(string); ok {
+			username = user
+		} else if user, ok := authData["username"].(string); ok {
+			username = user
+		}
+	}
+	if username == "" {
+		h.sendError(socket, req.ID, -32602, "handleSignIn: Signin requires username in auth data")
+		return
+	}
+
+	token, err := h.server.GenerateTokenWithExpiration(username, h.server.TokenSignIn, 1*time.Hour)
+	if err != nil {
+		h.sendError(socket, req.ID, -32000, "handleSignIn: "+err.Error())
+		h.server.mu.Unlock()
+		return
+	}
+
+	h.server.mu.Lock()
+	session := h.server.connSessions[socket]
+	if session == nil {
+		h.sendError(socket, req.ID, -32000, "handleSignIn: Specify a namespace and database to use")
+		h.server.mu.Unlock()
+		return
+	}
+
+	// Create authenticated session
+	session.AuthType = AuthTypePassword
+	session.Token = token
+	session.Username = username
+	session.ID = fmt.Sprintf("session_%x", h.server.sessionIdCounter)
+	// Password auth doesn't expire
+	session.ExpiresAt = nil
+
+	// Add to global sessions
+	h.server.sessions = append(h.server.sessions, session)
+	h.server.sessionIdCounter++
+	h.server.mu.Unlock()
+
+	h.sendResponse(socket, req.ID, token)
+}
+
+func (h *Handler) handleAuthenticate(socket *gws.Conn, req *connection.RPCRequest) {
+	if len(req.Params) < 1 {
+		h.sendError(socket, req.ID, -32602, "handleAuthenticate: invalid params: authenticate requires token parameter")
+		return
+	}
+
+	token, ok := req.Params[0].(string)
+	if !ok {
+		h.sendError(socket, req.ID, -32602, "handleAuthenticate: invalid params: token must be a string")
+		return
+	}
+
+	h.server.mu.Lock()
+	defer h.server.mu.Unlock()
+
+	// Check if we have a session for this connection with namespace/database set
+	connSession := h.server.connSessions[socket]
+	if connSession == nil || connSession.Namespace == "" || connSession.Database == "" {
+		h.sendError(socket, req.ID, -32000, "handleAuthenticate: Specify a namespace and database to use")
+		return
+	}
+
+	// Find the session by token
+	var foundSession *Session
+	now := time.Now()
+	for _, s := range h.server.sessions {
+		if s.Token == token {
+			// Check if token is expired
+			if s.ExpiresAt != nil && now.After(*s.ExpiresAt) {
+				h.sendError(socket, req.ID, -32000, "handleAuthenticate: Authentication failed: Token expired")
+				return
+			}
+			foundSession = s
+			break
+		}
+	}
+
+	if foundSession == nil {
+		h.sendError(socket, req.ID, -32000, "handleAuthenticate: Authentication failed: Not session found for token")
+		return
+	}
+
+	// Update connection session with auth info
+	connSession.AuthType = AuthTypeToken
+	connSession.Token = token
+	connSession.Username = foundSession.Username
+	connSession.ID = foundSession.ID
+	connSession.ExpiresAt = foundSession.ExpiresAt
+
+	h.sendResponse(socket, req.ID, nil)
+}
+
+func (h *Handler) handleLet(socket *gws.Conn, req *connection.RPCRequest) {
+	if len(req.Params) < 1 {
+		h.sendError(socket, req.ID, -32602, "handleLet: invalid params: let requires key-value pairs")
+		return
+	}
+
+	if len(req.Params)%2 != 0 {
+		h.sendError(socket, req.ID, -32602, "handleLet: invalid params: let requires even number of parameters (key-value pairs)")
+		return
+	}
+
+	h.server.mu.Lock()
+	defer h.server.mu.Unlock()
+
+	session := h.server.connSessions[socket]
+	if session == nil {
+		h.sendError(socket, req.ID, -32000, "handleLet: Specify a namespace and database to use")
+		return
+	}
+
+	if session.Vars == nil {
+		session.Vars = make(map[string]any)
+	}
+
+	for i := 0; i < len(req.Params); i += 2 {
+		key, ok := req.Params[i].(string)
+		if !ok {
+			h.sendError(socket, req.ID, -32602, "handleLet: invalid params: let key must be a string")
+			return
+		}
+		value := req.Params[i+1]
+		session.Vars[key] = value
+	}
+
+	h.sendResponse(socket, req.ID, nil)
+}
+
+func (h *Handler) handleUnset(socket *gws.Conn, req *connection.RPCRequest) {
+	if len(req.Params) < 1 {
+		h.sendError(socket, req.ID, -32602, "handleUnset: invalid params: unset requires at least one key")
+		return
+	}
+
+	h.server.mu.Lock()
+	defer h.server.mu.Unlock()
+
+	session := h.server.connSessions[socket]
+	if session == nil {
+		h.sendError(socket, req.ID, -32000, "handleUnset: Specify a namespace and database to use")
+		return
+	}
+
+	for _, key := range req.Params {
+		if keyStr, ok := key.(string); ok {
+			delete(session.Vars, keyStr)
+		} else {
+			h.sendError(socket, req.ID, -32602, "handleUnset: invalid params: unset keys must be strings")
+			return
+		}
+	}
+
+	h.sendResponse(socket, req.ID, nil)
+}
+
+func isUseOfClosedNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return errStr == "use of closed network connection" ||
+		errStr == "accept tcp 127.0.0.1:0: use of closed network connection" ||
+		(len(errStr) > 30 && errStr[len(errStr)-30:] == "use of closed network connection")
+}

--- a/internal/fakesdb/server.go
+++ b/internal/fakesdb/server.go
@@ -253,7 +253,8 @@ func (s *Server) SetGlobalFailures(failures []FailureConfig) {
 // Start starts the server and begins accepting WebSocket connections.
 // Returns an error if the server cannot bind to the specified address.
 func (s *Server) Start() error {
-	listener, err := net.Listen("tcp", s.addr)
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", s.addr)
 	if err != nil {
 		return err
 	}

--- a/internal/fakesdb/server_test.go
+++ b/internal/fakesdb/server_test.go
@@ -42,7 +42,11 @@ func TestAuthenticationFlow(t *testing.T) {
 
 		err := server.Start()
 		require.NoError(t, err)
-		defer server.Stop()
+		defer func() {
+			if stopErr := server.Stop(); stopErr != nil {
+				t.Fatalf("Failed to stop server: %v", stopErr)
+			}
+		}()
 
 		// Connect to server
 		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())
@@ -98,7 +102,11 @@ func TestAuthenticationFlow(t *testing.T) {
 
 		err := server.Start()
 		require.NoError(t, err)
-		defer server.Stop()
+		defer func() {
+			if stopErr := server.Stop(); stopErr != nil {
+				t.Fatalf("Failed to stop server: %v", stopErr)
+			}
+		}()
 
 		// Connect first client and sign in
 		db1, err := surrealdb.Connect(ctx, "ws://"+server.Address())
@@ -152,7 +160,11 @@ func TestAuthenticationFlow(t *testing.T) {
 
 		err := server.Start()
 		require.NoError(t, err)
-		defer server.Stop()
+		defer func() {
+			if stopErr := server.Stop(); stopErr != nil {
+				t.Fatalf("Failed to stop server: %v", stopErr)
+			}
+		}()
 
 		// Generate token with short expiration
 		token, err := server.GenerateTokenWithExpiration("testuser", "mytoken", 100*time.Millisecond)
@@ -189,7 +201,11 @@ func TestAuthenticationFlow(t *testing.T) {
 
 		err := server.Start()
 		require.NoError(t, err)
-		defer server.Stop()
+		defer func() {
+			if stopErr := server.Stop(); stopErr != nil {
+				t.Fatalf("Failed to stop server: %v", stopErr)
+			}
+		}()
 
 		// Connect to server
 		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())

--- a/internal/fakesdb/server_test.go
+++ b/internal/fakesdb/server_test.go
@@ -1,0 +1,209 @@
+package fakesdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+)
+
+func TestServer(t *testing.T) {
+	server := NewServer("127.0.0.1:0")
+
+	server.AddStubResponse(SimpleStubResponse("query", map[string]interface{}{
+		"result": []interface{}{
+			map[string]interface{}{
+				"id":   "user:1",
+				"name": "John Doe",
+			},
+		},
+	}))
+
+	require.NoError(t, server.Start())
+	assert.NotEmpty(t, server.Address())
+	require.NoError(t, server.Stop())
+}
+
+func TestAuthenticationFlow(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("SignIn flow", func(t *testing.T) {
+		// Create and start server
+		server := NewServer("127.0.0.1:0")
+		server.TokenSignIn = "test_token_signin"
+
+		server.AddStubResponse(SimpleStubResponse("select", map[string]any{
+			"id":   "test:1",
+			"name": "Test Record",
+		}))
+
+		err := server.Start()
+		require.NoError(t, err)
+		defer server.Stop()
+
+		// Connect to server
+		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		require.NoError(t, err)
+		defer db.Close(ctx)
+
+		// Try to sign in without namespace/database - should fail
+		_, err = db.SignIn(ctx, surrealdb.Auth{
+			Username: "root",
+			Password: "root",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Specify a namespace and database")
+
+		// Query should fail before use and sign in
+		_, err = surrealdb.Select[map[string]any](ctx, db, "test:1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "There was a problem with the database: There was a problem with authentication: Session not found")
+
+		// Set namespace and database
+		err = db.Use(ctx, "test", "test")
+		require.NoError(t, err)
+
+		// Query should fail before sign in
+		_, err = surrealdb.Select[map[string]any](ctx, db, "test:1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "There was a problem with the database: There was a problem with authentication: Not signed in")
+
+		// SignIn should succeed
+		token, err := db.SignIn(ctx, surrealdb.Auth{
+			Username: "root",
+			Password: "root",
+		})
+		require.NoError(t, err)
+		require.Equal(t, server.TokenSignIn, token)
+
+		// Query should work after signin
+		_, err = surrealdb.Select[map[string]any](ctx, db, "test:1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Authenticate flow", func(t *testing.T) {
+		// Create and start server
+		server := NewServer("127.0.0.1:0")
+		server.TokenSignIn = "test_token_signin"
+
+		// Add stub responses - don't stub signin/authenticate to test the built-in behavior
+		server.AddStubResponse(SimpleStubResponse("let", nil))
+		server.AddStubResponse(SimpleStubResponse("select", map[string]any{
+			"id":   "test:1",
+			"name": "Test Record",
+		}))
+
+		err := server.Start()
+		require.NoError(t, err)
+		defer server.Stop()
+
+		// Connect first client and sign in
+		db1, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		require.NoError(t, err)
+		defer db1.Close(ctx)
+
+		err = db1.Use(ctx, "test", "test")
+		require.NoError(t, err)
+
+		token, err := db1.SignIn(ctx, surrealdb.Auth{
+			Username: "user1",
+			Password: "pass1",
+		})
+		require.NoError(t, err)
+		require.Equal(t, server.TokenSignIn, token)
+
+		// Connect second client and authenticate with token
+		db2, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		require.NoError(t, err)
+		defer db2.Close(ctx)
+
+		// Should fail without namespace/database
+		err = db2.Authenticate(ctx, token)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Specify a namespace and database")
+
+		// Set namespace and database
+		err = db2.Use(ctx, "test", "test")
+		require.NoError(t, err)
+
+		// Authenticate with token
+		err = db2.Authenticate(ctx, token)
+		require.NoError(t, err)
+
+		// Query should work after authentication
+		_, err = surrealdb.Select[map[string]any, string](ctx, db2, "test:1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Token expiration", func(t *testing.T) {
+		// Create and start server
+		server := NewServer("127.0.0.1:0")
+		server.TokenSignUp = "test_token_signup"
+
+		// Add stub responses - don't stub authenticate to test the built-in behavior
+		server.AddStubResponse(SimpleStubResponse("let", nil))
+		server.AddStubResponse(SimpleStubResponse("select", map[string]any{
+			"id":   "test:1",
+			"name": "Test Record",
+		}))
+
+		err := server.Start()
+		require.NoError(t, err)
+		defer server.Stop()
+
+		// Generate token with short expiration
+		token, err := server.GenerateTokenWithExpiration("testuser", "mytoken", 100*time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, "mytoken", token)
+
+		// Connect and authenticate
+		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		require.NoError(t, err)
+		defer db.Close(ctx)
+
+		err = db.Use(ctx, "test", "test")
+		require.NoError(t, err)
+
+		err = db.Authenticate(ctx, token)
+		require.NoError(t, err)
+
+		// Query should work
+		_, err = surrealdb.Select[map[string]any, string](ctx, db, "test:1")
+		assert.NoError(t, err)
+
+		// Wait for token to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Query should fail with expired token
+		_, err = surrealdb.Select[map[string]any, string](ctx, db, "test:2")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "There was a problem with the database: There was a problem with authentication: Expired")
+	})
+
+	t.Run("Query without authentication", func(t *testing.T) {
+		// Create and start server
+		server := NewServer("127.0.0.1:0")
+
+		err := server.Start()
+		require.NoError(t, err)
+		defer server.Stop()
+
+		// Connect to server
+		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		require.NoError(t, err)
+		defer db.Close(ctx)
+
+		// Set namespace and database
+		err = db.Use(ctx, "test", "test")
+		require.NoError(t, err)
+
+		// Query should fail without authentication
+		_, err = surrealdb.Select[map[string]any, string](ctx, db, "test:1")
+		require.Error(t, err)
+		// Should fail because there's no authenticated session
+		assert.Contains(t, err.Error(), `There was a problem with the database: There was a problem with authentication: Not signed in`)
+	})
+}

--- a/pkg/connection/integration/connection_test.go
+++ b/pkg/connection/integration/connection_test.go
@@ -1,4 +1,4 @@
-package connection
+package integration
 
 import (
 	"context"

--- a/pkg/connection/integration/rews_test.go
+++ b/pkg/connection/integration/rews_test.go
@@ -1,0 +1,321 @@
+package integration
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/internal/fakesdb"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/rews"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestRewsGorillaWsDoReconnect(t *testing.T) {
+	testDoReconnect(t, func(wsURL string) func(context.Context) (*gorillaws.Connection, error) {
+		return func(ctx context.Context) (*gorillaws.Connection, error) {
+			p, err := surrealdb.Configure(wsURL)
+			if err != nil {
+				return nil, err
+			}
+			ws := gorillaws.New(p)
+
+			if err := ws.Connect(ctx); err != nil {
+				return nil, err
+			}
+			return ws, nil
+		}
+	})
+}
+
+func TestRewsGwsDoReconnect(t *testing.T) {
+	testDoReconnect(t, func(wsURL string) func(context.Context) (*gws.Connection, error) {
+		return func(ctx context.Context) (*gws.Connection, error) {
+			p, err := surrealdb.Configure(wsURL)
+			if err != nil {
+				return nil, err
+			}
+			ws := gws.New(p)
+			ws.Logger = logger.New(slog.NewTextHandler(os.Stdout, nil))
+
+			if err := ws.Connect(ctx); err != nil {
+				return nil, err
+			}
+			return ws, nil
+		}
+	})
+}
+
+// testDoReconnect tests the auto-reconnection feature
+// against the WebSocket connection implementation provided by connectFunc.
+//
+// It simulates a connection drop and verifies that the rews package
+// automatically reconnects and resumes operations,
+// with any underlying connection implementation that supports the WebSocketConnection interface.
+func testDoReconnect[C connection.WebSocketConnection](t *testing.T, connectFunc func(wsURL string) func(context.Context) (C, error)) {
+	t.Helper()
+
+	server := fakesdb.NewServer("127.0.0.1:0")
+	server.TokenSignIn = "test_token_signin"
+
+	var selectCount int32
+	var retryRequired bool
+
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher: fakesdb.MatchMethodWithParams("select", func(params []interface{}) bool {
+			count := atomic.AddInt32(&selectCount, 1)
+			t.Logf("Select request #%d", count)
+
+			// Drop connection on 3rd select request only once
+			if count == 3 && !retryRequired {
+				retryRequired = true
+				t.Log("*** Dropping connection on 3rd request ***")
+				return true
+			}
+			return false
+		}),
+		Response: nil,
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureWebSocketClose,
+				Probability: 1.0,
+				CloseCode:   1001,
+				CloseReason: "Testing reconnection",
+			},
+		},
+	})
+
+	// Normal select response
+	server.AddStubResponse(fakesdb.SimpleStubResponse("select", map[string]interface{}{
+		"id":   cbor.Tag{Number: 8, Content: []interface{}{"test", "1"}},
+		"name": "Test Record",
+	}))
+
+	// Start server
+	err := server.Start()
+	require.NoError(t, err)
+	defer server.Stop()
+
+	// Configure connection with auto-reconnection
+	wsURL := "ws://" + server.Address()
+
+	// Short reconnection check interval for testing
+	checkInterval := 100 * time.Millisecond
+
+	// Create auto-reconnecting connection
+	conn := rews.New(connectFunc(wsURL), checkInterval, logger.New(slog.NewTextHandler(os.Stdout, nil)))
+
+	// Initial connection
+	err = conn.Connect(context.Background())
+	require.NoError(t, err)
+
+	// Create DB instance
+	db := surrealdb.New(conn)
+	defer db.Close(context.Background())
+
+	// Setup
+	err = db.Use(context.Background(), "test", "test")
+	require.NoError(t, err)
+
+	token, err := db.SignIn(context.Background(), &surrealdb.Auth{
+		Username: "root",
+		Password: "root",
+	})
+	require.NoError(t, err)
+	require.Equal(t, server.TokenSignIn, token)
+
+	err = db.Authenticate(context.Background(), token)
+	require.NoError(t, err)
+
+	type TestRecord struct {
+		ID   models.RecordID `json:"id"`
+		Name string          `json:"name"`
+	}
+
+	// Test select with retries
+	// First two selects should work
+	for i := 0; i < 2; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		result, err := surrealdb.Select[TestRecord](
+			ctx,
+			db,
+			models.NewRecordID("test", "1"),
+		)
+		require.NoError(t, err, "Select %d should succeed", i+1)
+		assert.NotNil(t, result)
+		assert.Equal(t, "test", result.ID.Table)
+		assert.Equal(t, "1", result.ID.ID)
+	}
+
+	// Third select will trigger connection drop
+	// Track retry attempts to ensure reconnection actually happens
+	var retryCount int
+	var lastErr error
+	var result *TestRecord
+
+	// This should fail and trigger reconnection
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	result, lastErr = surrealdb.Select[TestRecord](
+		ctx,
+		db,
+		models.NewRecordID("test", "1"),
+	)
+
+	// We expect this to fail due to connection close
+	if lastErr == nil {
+		t.Fatal("Expected 3rd select to fail with connection close, but it succeeded")
+	}
+	t.Logf("3rd select failed as expected: %v", lastErr)
+
+	// Now retry until success - this tests the auto-reconnection
+	maxRetries := 20
+	for retry := 0; retry < maxRetries; retry++ {
+		retryCount++
+		t.Logf("Retry attempt %d after connection drop", retry+1)
+
+		// Wait to allow reconnection check interval to trigger
+		time.Sleep(600 * time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		result, lastErr = surrealdb.Select[TestRecord](
+			ctx,
+			db,
+			models.NewRecordID("test", "1"),
+		)
+
+		if lastErr == nil {
+			t.Logf("Select succeeded on retry %d", retry+1)
+			break
+		}
+
+		t.Logf("Select still failing: %v", lastErr)
+	}
+
+	// Verify retry actually happened
+	require.Greater(t, retryCount, 0, "At least one retry should have occurred")
+	require.NoError(t, lastErr, "Select should eventually succeed after reconnection")
+	assert.NotNil(t, result)
+	assert.Equal(t, "test", result.ID.Table)
+	assert.Equal(t, "1", result.ID.ID)
+
+	// Verify total select count shows reconnection worked
+	finalCount := atomic.LoadInt32(&selectCount)
+	t.Logf("Total select requests: %d (should be > 3)", finalCount)
+	require.Greater(t, int(finalCount), 3, "Should have made more than 3 select requests due to retry")
+
+	// Verify connection is healthy after reconnection
+	for i := 0; i < 3; i++ {
+		result, err := surrealdb.Select[TestRecord](
+			context.Background(),
+			db,
+			models.NewRecordID("test", "1"),
+		)
+		require.NoError(t, err, "Post-reconnection select %d should succeed", i+1)
+		assert.NotNil(t, result)
+	}
+
+	t.Logf("Test passed: Connection dropped and successfully reconnected with %d retries", retryCount)
+}
+
+// TestDefaultWebSocketDoNotReconnect tests that the default WebSocket connection does not automatically reconnect
+// when the connection is closed by the server. This ensures that our test setup actually drops connections
+// and does not automatically reconnect, which is important for testing connection handling behavior,
+// while verifying that the default WebSocket client does not reconnect.
+func TestDefaultWebSocketDoNotReconnect(t *testing.T) {
+	// This test validates that our test setup actually drops connections
+	// by using a non-reconnecting client
+
+	server := fakesdb.NewServer("127.0.0.1:0")
+	server.TokenSignIn = "test_token_signin"
+
+	// Drop connection on 2nd request
+	var selectCount int32
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher: fakesdb.MatchMethodWithParams("select", func(params []interface{}) bool {
+			count := atomic.AddInt32(&selectCount, 1)
+			return count == 2
+		}),
+		Response: nil,
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureWebSocketClose,
+				Probability: 1.0,
+				CloseCode:   1001,
+			},
+		},
+	})
+
+	// Normal response
+	server.AddStubResponse(fakesdb.SimpleStubResponse("select", map[string]interface{}{
+		"id": cbor.Tag{Number: 8, Content: []interface{}{"test", "1"}},
+	}))
+
+	err := server.Start()
+	require.NoError(t, err)
+	defer server.Stop()
+
+	// Use regular connection WITHOUT auto-reconnect
+	p, err := surrealdb.Configure("ws://" + server.Address())
+	require.NoError(t, err)
+
+	// Create connection with timeout to prevent hanging
+	ws := gorillaws.New(p).SetTimeOut(2 * time.Second)
+	err = ws.Connect(context.Background())
+	require.NoError(t, err)
+
+	db := surrealdb.New(ws)
+	defer db.Close(context.Background())
+
+	err = db.Use(context.Background(), "test", "test")
+	require.NoError(t, err)
+
+	token, err := db.SignIn(context.Background(), &surrealdb.Auth{
+		Username: "root",
+		Password: "root",
+	})
+	require.NoError(t, err)
+	require.Equal(t, server.TokenSignIn, token)
+
+	type TestRecord struct {
+		ID models.RecordID `json:"id"`
+	}
+
+	// First select should work
+	_, err = surrealdb.Select[TestRecord](
+		context.Background(),
+		db,
+		models.NewRecordID("test", "1"),
+	)
+	require.NoError(t, err)
+
+	// Second select should fail due to connection drop
+	_, err = surrealdb.Select[TestRecord](
+		context.Background(),
+		db,
+		models.NewRecordID("test", "1"),
+	)
+	require.Error(t, err, "Connection should be closed after WebSocket close")
+
+	// Third select should also fail (no auto-reconnect)
+	_, err = surrealdb.Select[TestRecord](
+		context.Background(),
+		db,
+		models.NewRecordID("test", "1"),
+	)
+	require.Error(t, err, "Connection should remain closed without auto-reconnect")
+
+	t.Log("Validation passed: Connection drops are working as expected")
+}

--- a/pkg/connection/rews/ws_reconnect.go
+++ b/pkg/connection/rews/ws_reconnect.go
@@ -119,6 +119,22 @@ type Connection[C connection.WebSocketConnection] struct {
 	// It is a mutex to ensure that the state transitions are atomic
 	// and that the state checks are consistent.
 	stateMu sync.Mutex
+
+	// sessionVars is a map that holds the session variables.
+	// It is used to store the session variables that are set by the user
+	// and to restore them on reconnection.
+	sessionVars map[string]any
+
+	// sessionToken is the token used for authentication.
+	// It is used to store the token that is returned by a successful SignIn or SignUp, or
+	// used by a successful Authenticate call.
+	// It is used to re-authenticate on reconnection.
+	sessionToken string
+
+	// sessionNS and sessionDB are the namespace and database used for the session.
+	// They are used to restore the namespace and database on reconnection.
+	sessionNS string
+	sessionDB string
 }
 
 var _ connection.Connection = (*Connection[connection.WebSocketConnection])(nil)
@@ -138,6 +154,7 @@ func New[C connection.WebSocketConnection](
 		ConnectFunc:   connect,
 		state:         StateDisconnected,
 		logger:        log,
+		sessionVars:   make(map[string]any),
 	}
 }
 
@@ -215,6 +232,106 @@ func (arws *Connection[C]) Connect(ctx context.Context) error {
 	return nil
 }
 
+// reconnect attempts to reconnect the WebSocket connection.
+//
+// This enhances the Connect method by re-authenticating with the token in the following cases:
+// - SignUp succeeded before the reconnection (SignUp returns a token and it can be used for re-authentication).
+// - SignIn succeeded before the reconnection (SignIn returns a token and it can be used for re-authentication).
+// - Authenticate succeeded before the reconnection (Authenticate accepts the token and it can be used for re-authentication)
+//
+// The token might be expired or invalid which could result in an re-authentication failure.
+// But rews does not handle the re-authentication failure.
+// It is the caller's responsibility to handle the re-authentication failure.
+func (arws *Connection[C]) reconnect(ctx context.Context) error {
+	if err := arws.Connect(ctx); err != nil {
+		arws.logger.Error("rews.Connection failed to reconnect", "error", err)
+		return fmt.Errorf("rews.Connection failed to reconnect: %w", err)
+	}
+
+	if arws.sessionNS != "" && arws.sessionDB != "" {
+		arws.logger.Debug("rews.Connection is restoring namespace and database", "namespace", arws.sessionNS, "database", arws.sessionDB)
+		if err := arws.Use(ctx, arws.sessionNS, arws.sessionDB); err != nil {
+			arws.logger.Error("rews.Connection failed to restore namespace and database", "error", err)
+			return fmt.Errorf("rews.Connection failed to restore namespace and database: %w", err)
+		}
+		arws.logger.Debug("rews.Connection restored namespace and database successfully")
+	}
+
+	if arws.sessionToken != "" {
+		arws.logger.Debug("rews.Connection is re-authenticating with the session token")
+		if err := arws.Authenticate(ctx, arws.sessionToken); err != nil {
+			arws.logger.Error("rews.Connection failed to re-authenticate with the session token", "error", err)
+			return fmt.Errorf("rews.Connection failed to re-authenticate with the session token: %w", err)
+		}
+		arws.logger.Debug("rews.Connection re-authenticated successfully with the session token")
+	}
+
+	for key, value := range arws.sessionVars {
+		arws.logger.Debug("rews.Connection is restoring session variable", "key", key, "value", value)
+		if err := arws.Let(ctx, key, value); err != nil {
+			arws.logger.Error("rews.Connection failed to restore session variable", "key", key, "error", err)
+			return fmt.Errorf("rews.Connection failed to restore session variable %s: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+func (arws *Connection[C]) Use(ctx context.Context, namespace string, database string) error {
+	if err := arws.WebSocketConnection.Use(ctx, namespace, database); err != nil {
+		return fmt.Errorf("rews.Connection failed to use namespace and database: %w", err)
+	}
+	arws.sessionNS = namespace
+	arws.sessionDB = database
+	return nil
+}
+
+func (arws *Connection[C]) Authenticate(ctx context.Context, token string) error {
+	if err := arws.WebSocketConnection.Authenticate(ctx, token); err != nil {
+		return fmt.Errorf("rews.Connection failed to authenticate: %w", err)
+	}
+
+	arws.sessionToken = token
+
+	return nil
+}
+
+func (arws *Connection[C]) Let(ctx context.Context, key string, value any) error {
+	if err := arws.WebSocketConnection.Let(ctx, key, value); err != nil {
+		return fmt.Errorf("rews.Connection failed to set session variable %s: %w", key, err)
+	}
+	arws.sessionVars[key] = value
+	return nil
+}
+
+func (arws *Connection[C]) Unset(ctx context.Context, key string) error {
+	if err := arws.WebSocketConnection.Unset(ctx, key); err != nil {
+		return fmt.Errorf("rews.Connection failed to unset session variable %s: %w", key, err)
+	}
+	delete(arws.sessionVars, key)
+	return nil
+}
+
+func (arws *Connection[C]) SignUp(ctx context.Context, authData any) (string, error) {
+	token, err := arws.WebSocketConnection.SignUp(ctx, authData)
+	if err != nil {
+		return "", fmt.Errorf("rews.Connection failed to sign up: %w", err)
+	}
+
+	arws.sessionToken = token
+	return token, nil
+}
+
+func (arws *Connection[C]) SignIn(ctx context.Context, authData any) (string, error) {
+	token, err := arws.WebSocketConnection.SignIn(ctx, authData)
+	if err != nil {
+		return "", fmt.Errorf("rews.Connection failed to sign in: %w", err)
+	}
+
+	arws.sessionToken = token
+	return token, nil
+}
+
 // Close stops the reconnection loop and closes the WebSocket connection.
 //
 // You should call this method only when the application is shutting down,
@@ -279,7 +396,7 @@ func (arws *Connection[C]) reconnectionLoop() {
 		if arws.WebSocketConnection.IsClosed() {
 			arws.logger.Info("rews.Connection is attempting to reconnect")
 
-			if err := arws.Connect(context.Background()); err != nil {
+			if err := arws.reconnect(context.Background()); err != nil {
 				arws.logger.Error("rews.Connection failed to reconnect", "error", err)
 				continue
 			}

--- a/pkg/connection/rews/ws_reconnect.go
+++ b/pkg/connection/rews/ws_reconnect.go
@@ -210,8 +210,8 @@ func (arws *Connection[C]) Connect(ctx context.Context) error {
 
 	arws.WebSocketConnection, err = arws.ConnectFunc(ctx)
 	if err != nil {
-		if err := arws.transitionTo(StateDisconnected); err != nil {
-			arws.logger.Error("BUG: rews.Connection failed to transition to disconnected state", "error", err)
+		if stateErr := arws.transitionTo(StateDisconnected); stateErr != nil {
+			arws.logger.Error("BUG: rews.Connection failed to transition to disconnected state", "error", stateErr)
 		}
 		return fmt.Errorf("rews.Connection failed to connect: %w", err)
 	}
@@ -277,7 +277,7 @@ func (arws *Connection[C]) reconnect(ctx context.Context) error {
 	return nil
 }
 
-func (arws *Connection[C]) Use(ctx context.Context, namespace string, database string) error {
+func (arws *Connection[C]) Use(ctx context.Context, namespace, database string) error {
 	if err := arws.WebSocketConnection.Use(ctx, namespace, database); err != nil {
 		return fmt.Errorf("rews.Connection failed to use namespace and database: %w", err)
 	}

--- a/pkg/connection/rews/ws_reconnect.go
+++ b/pkg/connection/rews/ws_reconnect.go
@@ -14,44 +14,68 @@ type State int
 
 const (
 	StateUnknown State = iota
+	StateDisconnected
 	StateConnecting
 	StateConnected
-	StateDisconnecting
-	StateDisconnected
+	StateClosing
+	StateClosed
 )
 
-func (s State) TransitionTo(
-	newState State,
-) (State, error) {
-	switch s {
+func (state State) String() string {
+	switch state {
+	case StateUnknown:
+		return "Unknown"
+	case StateDisconnected:
+		return "Disconnected"
 	case StateConnecting:
-		switch newState {
-		case StateConnected, StateDisconnected:
-			return newState, nil
-		}
+		return "Connecting"
 	case StateConnected:
-		switch newState {
-		case StateDisconnecting, StateDisconnected:
-			return newState, nil
-		}
-	case StateDisconnecting:
-		if newState == StateDisconnected {
-			return newState, nil
-		}
+		return "Connected"
+	case StateClosing:
+		return "Closing"
+	case StateClosed:
+		return "Closed"
+	default:
+		return "InvalidState"
+	}
+}
+
+func (s State) validateTransitionTo(newState State) error {
+	switch s {
 	case StateDisconnected:
 		switch newState {
 		case StateConnecting, StateDisconnected:
-			return newState, nil
+			return nil
+		}
+	case StateConnecting:
+		switch newState {
+		case StateConnected, StateDisconnected:
+			return nil
+		}
+	case StateConnected:
+		switch newState {
+		// Connected to Connecting is possible when the connection is lost
+		// after the connection is established.
+		case StateConnecting, StateClosing, StateDisconnected:
+			return nil
+		}
+	case StateClosing:
+		if newState == StateClosed {
+			return nil
 		}
 	}
 
-	return StateUnknown, fmt.Errorf("invalid state transition from %v to %v", s, newState)
+	return fmt.Errorf("invalid state transition from %v to %v", s, newState)
 }
 
 type Connection[C connection.WebSocketConnection] struct {
 	connection.WebSocketConnection
 
-	connect func(context.Context) (C, error)
+	// ConnectFunc is a function that establishes the WebSocket connection.
+	// It is used to create a new WebSocket connection when the initial
+	// connection is made, or when the reconnection is needed.
+	// The function should return a WebSocket connection and an error.
+	ConnectFunc func(context.Context) (C, error)
 
 	// CheckInterval is the interval at which the reconnection attempts are made.
 	// It is used to avoid busy-waiting and to control the frequency of reconnection
@@ -71,17 +95,34 @@ type Connection[C connection.WebSocketConnection] struct {
 	// connCloseCh signals that the connection is being closed
 	connCloseCh chan int
 
+	// reconnLoopCloseCh is used to signal that the reconnection loop is closed,
+	// by closing the channel.
+	//
+	// This is used solely to ensure that the reconnection loop stops
+	// before Close() returns.
 	reconnLoopCloseCh chan int
 
 	// logger is used to log the state transitions and errors.
 	logger logger.Logger
 
+	// once is used to ensure that the reconnection loop is started only once.
+	// This is to prevent multiple reconnection loops from being started
+	// on second and subsequent Connect() calls for reconnection.
+	once sync.Once
+
+	// state is the current state of the connection.
+	// It is used to track the state of the connection and to ensure that
+	// the state transitions are valid.
 	state State
 
-	mu sync.Mutex
+	// stateMu is used to protect the state transitions and checks.
+	// It is a mutex to ensure that the state transitions are atomic
+	// and that the state checks are consistent.
+	stateMu sync.Mutex
 }
 
 var _ connection.Connection = (*Connection[connection.WebSocketConnection])(nil)
+var _ connection.WebSocketConnection = (*Connection[connection.WebSocketConnection])(nil)
 
 // New creates a new auto-reconnecting WebSocket connection.
 //
@@ -94,31 +135,33 @@ func New[C connection.WebSocketConnection](
 ) *Connection[C] {
 	return &Connection[C]{
 		CheckInterval: checkInterval,
-		connect:       connect,
+		ConnectFunc:   connect,
 		state:         StateDisconnected,
 		logger:        log,
 	}
 }
 
 func (arws *Connection[C]) transitionTo(newState State) error {
-	arws.mu.Lock()
-	defer arws.mu.Unlock()
+	arws.stateMu.Lock()
+	defer arws.stateMu.Unlock()
 
-	newState, err := arws.state.TransitionTo(newState)
-	if err != nil {
+	if err := arws.state.validateTransitionTo(newState); err != nil {
 		return err
 	}
 
 	arws.state = newState
-	arws.logger.Debug("ReconnectingWebSocketConnection state transitioned", "new_state", newState)
+	arws.logger.Debug("rews.Connection state transitioned", "new_state", newState)
 
 	return nil
 }
 
-func (arws *Connection[C]) mustTransitionTo(newState State) {
-	if err := arws.transitionTo(newState); err != nil {
-		panic(fmt.Sprintf("BUG: %v", err))
-	}
+// IsClosed returns true if this reconnecting WebSocket connection is closed.
+// Once closed, it cannot be used to establish a new connection.
+func (arws *Connection[C]) IsClosed() bool {
+	arws.stateMu.Lock()
+	defer arws.stateMu.Unlock()
+
+	return arws.state == StateClosed
 }
 
 // Connect establishes the WebSocket connection and starts the reconnection loop.
@@ -148,18 +191,26 @@ func (arws *Connection[C]) Connect(ctx context.Context) error {
 
 	var err error
 
-	arws.WebSocketConnection, err = arws.connect(ctx)
+	arws.WebSocketConnection, err = arws.ConnectFunc(ctx)
 	if err != nil {
-		arws.mustTransitionTo(StateDisconnected)
-		return fmt.Errorf("failed to connect: %w", err)
+		if err := arws.transitionTo(StateDisconnected); err != nil {
+			arws.logger.Error("BUG: rews.Connection failed to transition to disconnected state", "error", err)
+		}
+		return fmt.Errorf("rews.Connection failed to connect: %w", err)
 	}
 
-	arws.connCloseCh = make(chan int, 1)
-	arws.reconnLoopCloseCh = make(chan int, 1)
+	arws.once.Do(func() {
+		arws.logger.Debug("rews.Connection is starting reconnection loop")
 
-	go arws.reconnectionLoop()
+		arws.connCloseCh = make(chan int, 1)
+		arws.reconnLoopCloseCh = make(chan int, 1)
 
-	arws.mustTransitionTo(StateConnected)
+		go arws.reconnectionLoop()
+	})
+
+	if err := arws.transitionTo(StateConnected); err != nil {
+		panic(fmt.Sprintf("BUG: rews.Connection failed to transition to connected state: %v", err))
+	}
 
 	return nil
 }
@@ -177,24 +228,26 @@ func (arws *Connection[C]) Connect(ctx context.Context) error {
 // because those leaked resources can be eventually cleaned up by the operation system
 // once the application process exits.
 func (arws *Connection[C]) Close(ctx context.Context) error {
-	if err := arws.transitionTo(StateDisconnecting); err != nil {
-		return fmt.Errorf("Connection is already closing or closed: %w", err)
+	if err := arws.transitionTo(StateClosing); err != nil {
+		return fmt.Errorf("rews.Connection is already closing or closed: %w", err)
 	}
 
 	defer func() {
-		arws.mustTransitionTo(StateDisconnected)
+		if err := arws.transitionTo(StateClosed); err != nil {
+			arws.logger.Error("BUG: rews.Connection failed to transition to closed state", "error", err)
+		}
 	}()
 
 	// Ensure the reconnection loop stops first,
-	// so that it doesn't try to reconnect after the connection is closed.
+	// so that it doesn't try to reconnect after the this reconnecting connection is closed.
 	//
 	// This implies a possible edge case where the reconnection loop
 	// stops even though Close failed.
 	//
 	// But we accept this trade-off for simplicity,
-	// assuming that the user would call AutoReconnectingWebSocketconnection.Close
+	// assuming that the user would call rews.Connection.Close()
 	// only when the connection is absolutely not needed anymore,
-	// like when gracefully shutting things down before exiting the program.
+	// like the app is gracefully shutting down before exiting the program.
 	close(arws.connCloseCh)
 	<-arws.reconnLoopCloseCh
 
@@ -216,19 +269,19 @@ func (arws *Connection[C]) reconnectionLoop() {
 	}()
 
 	for {
-		arws.logger.Debug("ReconnectingWebSocketconnection: waiting for reconnection check interval", "interval", checkInterval)
+		arws.logger.Debug("rews.Connection is waiting for reconnection check interval", "interval", checkInterval)
 		select {
 		case <-arws.connCloseCh:
 			return
 		case <-time.After(checkInterval):
 		}
 
-		if arws.IsClosed() {
-			arws.logger.Info("ReconnectingWebSocketConnection: attempting to reconnect")
-			if err := arws.WebSocketConnection.Connect(context.Background()); err != nil {
-				arws.logger.Error("ReconnectingWebSocketConnection: failed to reconnect", "error", err)
-			} else {
-				arws.logger.Info("ReconnectingWebSocketConnection: reconnected successfully")
+		if arws.WebSocketConnection.IsClosed() {
+			arws.logger.Info("rews.Connection is attempting to reconnect")
+
+			if err := arws.Connect(context.Background()); err != nil {
+				arws.logger.Error("rews.Connection failed to reconnect", "error", err)
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
This pull request enhances the auto-reconnection feature #267 by adding support for session restoration, which proved necessary to make reconnection transparent to the SDK consumer.

Without session restoration, when the underlying connection is re-established by the auto-reconnection, the SDK consumer might see RPCs suddenly start failing, like session variables looking disappeared or authentication looking went away. It is due to that the session is [in-memory data within SurrealDB that is associated to the websocket connection](https://surrealdb.com/docs/surrealdb/integration/rpc#session-variables)- reconnection creates a new session on SurrealDB.

The enhanced auto-reconnection feature is tested against both our `gorilla/websocket`-based and the newer `gws`-based (#268 and #269).

The tests are done using the new `internal/fakesdb` package which provides a WebSocket server that speaks a subset of SurrealDC RPCs. I opted to do this rather than just starting/stopping real SurrealDB using `surreal start` or containers or to poke Linux commands for failure injection, because it is more portable and faster to test.

I would try to add a more E2E-like way of testing, perhaps using containers and `tc`, but that's not now.

Related #277
Ref #110