### PR TITLE
Simplify gorilla/websocket-based connection back

### DIFF
--- a/pkg/connection/gws/connection.go
+++ b/pkg/connection/gws/connection.go
@@ -17,8 +17,6 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 )
 
-type State int
-
 type Connection struct {
 	connection.Toolkit
 


### PR DESCRIPTION
This reverts changes made in #267 to the existing `gorilla/websocket` based connection implementation.

Those changes turned out to be unnecessary to make the auto-reconnection work.

Now the auto-reconnection is handled by `contrib/rews` entirely. All underlying WebSocket connections (gws and gorilla-based ones) can do is to provide the semantics that they cannot be reconnected once closed. They provide `IsClosed() bool` that permanently returns `true` once closed, so that the higher-level library like `contrib/rews` can use it as an eventually consistent immutable signal to trigger a reconnection.