### PR TITLE
Tidy up the API surface towards v0.7.0

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -90,7 +90,7 @@ func (s *SurrealDBTestSuite) TearDownSuite() {
 
 // SetupSuite is called before the s starts running
 func (s *SurrealDBTestSuite) SetupSuite() {
-	db, err := surrealdb.Connect(context.Background(), getURL())
+	db, err := surrealdb.FromEndpointURLString(context.Background(), getURL())
 	s.Require().NoError(err, "should not return an error when initializing db")
 	s.db = db
 

--- a/example/example_db_signin_test.go
+++ b/example/example_db_signin_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleDB_signin_failure() {
-	db, err := surrealdb.Connect(
+	db, err := surrealdb.FromEndpointURLString(
 		context.Background(),
 		testenv.GetSurrealDBWSURL(),
 	)

--- a/example/example_gws_connection_test.go
+++ b/example/example_gws_connection_test.go
@@ -3,27 +3,29 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
 	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
 )
 
 func ExampleConnection_gws() {
-	conf, err := surrealdb.Configure(
-		testenv.GetSurrealDBWSURL(),
-	)
-	conf.Logger = nil // Disable logging for this example
+	u, err := url.ParseRequestURI(testenv.GetSurrealDBWSURL())
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("Failed to parse URL: %v", err))
 	}
+
+	conf := connection.NewConfig(u)
+	conf.Logger = nil // Disable logging for this example
 
 	conn := gws.New(conf)
 	if connErr := conn.Connect(context.Background()); connErr != nil {
 		panic(fmt.Sprintf("Failed to connect: %v", connErr))
 	}
 
-	db := surrealdb.New(conn)
+	db := surrealdb.FromConnection(conn)
 
 	// Attempt to sign in without setting namespace or database
 	// This should fail with an error, whose message will depend on the connection type.

--- a/example/main.go
+++ b/example/main.go
@@ -12,7 +12,7 @@ import (
 //nolint:funlen
 func main() {
 	// Connect to SurrealDB
-	db, err := surrealdb.Connect(context.Background(), "ws://localhost:8000")
+	db, err := surrealdb.FromEndpointURLString(context.Background(), "ws://localhost:8000")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -18,7 +18,7 @@ type testUser struct {
 }
 
 func SetupMockDB() (*surrealdb.DB, error) {
-	return surrealdb.Connect(context.Background(), "")
+	return surrealdb.FromEndpointURLString(context.Background(), "")
 }
 
 func BenchmarkCreate(b *testing.B) {

--- a/internal/fakesdb/integration/server_response_delay_test.go
+++ b/internal/fakesdb/integration/server_response_delay_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	surrealdb "github.com/surrealdb/surrealdb.go"
 	"github.com/surrealdb/surrealdb.go/internal/fakesdb"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
@@ -58,8 +60,10 @@ func TestServerFailureResponseDelay(t *testing.T) {
 
 	wsURL := "ws://" + server.Address()
 
-	p, err := surrealdb.Configure(wsURL)
+	u, err := url.ParseRequestURI(wsURL)
 	require.NoError(t, err)
+
+	p := connection.NewConfig(u)
 
 	ws := gorillaws.New(p).
 		SetTimeOut(100 * time.Millisecond) // Short request timeout
@@ -67,7 +71,7 @@ func TestServerFailureResponseDelay(t *testing.T) {
 	err = ws.Connect(context.Background())
 	require.NoError(t, err)
 
-	db := surrealdb.New(ws)
+	db := surrealdb.FromConnection(ws)
 	defer db.Close(context.Background())
 
 	// Setup

--- a/internal/fakesdb/server_test.go
+++ b/internal/fakesdb/server_test.go
@@ -49,7 +49,7 @@ func TestAuthenticationFlow(t *testing.T) {
 		}()
 
 		// Connect to server
-		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		db, err := surrealdb.FromEndpointURLString(ctx, "ws://"+server.Address())
 		require.NoError(t, err)
 		defer db.Close(ctx)
 
@@ -109,7 +109,7 @@ func TestAuthenticationFlow(t *testing.T) {
 		}()
 
 		// Connect first client and sign in
-		db1, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		db1, err := surrealdb.FromEndpointURLString(ctx, "ws://"+server.Address())
 		require.NoError(t, err)
 		defer db1.Close(ctx)
 
@@ -124,7 +124,7 @@ func TestAuthenticationFlow(t *testing.T) {
 		require.Equal(t, server.TokenSignIn, token)
 
 		// Connect second client and authenticate with token
-		db2, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		db2, err := surrealdb.FromEndpointURLString(ctx, "ws://"+server.Address())
 		require.NoError(t, err)
 		defer db2.Close(ctx)
 
@@ -172,7 +172,7 @@ func TestAuthenticationFlow(t *testing.T) {
 		require.Equal(t, "mytoken", token)
 
 		// Connect and authenticate
-		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		db, err := surrealdb.FromEndpointURLString(ctx, "ws://"+server.Address())
 		require.NoError(t, err)
 		defer db.Close(ctx)
 
@@ -208,7 +208,7 @@ func TestAuthenticationFlow(t *testing.T) {
 		}()
 
 		// Connect to server
-		db, err := surrealdb.Connect(ctx, "ws://"+server.Address())
+		db, err := surrealdb.FromEndpointURLString(ctx, "ws://"+server.Address())
 		require.NoError(t, err)
 		defer db.Close(ctx)
 

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -1,0 +1,25 @@
+package connection
+
+import (
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// NewConfig creates a new Config with the SurrealDB endpoint specified by the URL.
+// The URL should be a valid SurrealDB endpoint URL, such as "ws://localhost:8000/rpc" or "http://localhost:8000".
+// It is not absolutely necessary to create a Config using this function,
+// but it is recommended to use this function to ensure that everything needed for the connection is set up correctly.
+func NewConfig(u *url.URL) *Config {
+	return &Config{
+		URL:         *u,
+		Marshaler:   &models.CborMarshaler{},
+		Unmarshaler: &models.CborUnmarshaler{},
+		BaseURL:     fmt.Sprintf("%s://%s", u.Scheme, u.Host),
+		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+}


### PR DESCRIPTION
I changed `surrealdb.New(string)` deprecated in v0.6.0 (released) to `surrealdb.New(connection.Connection)` in #268 (unreleased), but I now think this isn't a good idea, because it makes the introduction of the new function a bit difficult due to the reused name.

I also realized that the top-level `surrealdb` package provides two divergent initialization functions, `New` and `Connect`, which makes it harder for me to introduce those to users, probably an indication that it is less intuitive to use for users too.

All in all, I want users to use `surrealdb.FromConnection(connection.Connection)` or `surrealdb.FromEndpointURLString(context.Context, connection.Connection)`.
They look consistent with each other and aligned with the convention used in Go.

I avoided non-functional-option-version of `WithWhatever`, like `surrealdb.WithWithEndpointURL`, like ones used in Go's context package (e.g. `context.WithTimeout` which isnt an functional option but a constructor).

I also avoided functional options because they resulted in less flexibility and a bloated API surface. See also #283 and #267. I temporarily added `surrealdb.WithReconnectionCheckInterval` functional option in #267 and removed it in #283.

P.S. The `Configure` function extracted in #268 has also been removed and mostly moved to `connect.NewConfig`. This would also make the API surface more intuitive to first-time users, still allowing relatively advanced users to dive into the `connection` sub-package to create a `connection.Config` and `connection.Connection` which usually `surrealdb.FromEndpointURLString` does for you.