### PR TITLE
Make surrealdb.FromConnection call Connect for you

### DIFF
--- a/contrib/testenv/connection.go
+++ b/contrib/testenv/connection.go
@@ -110,19 +110,13 @@ func New(database string, tables ...string) (*surrealdb.DB, error) {
 				connect = func(ctx context.Context) (*surrealdb.DB, error) {
 					gwsConn := gws.New(conf)
 
-					if err := gwsConn.Connect(ctx); err != nil {
-						return nil, fmt.Errorf("failed to connect to gws: %w", err)
-					}
-					return surrealdb.FromConnection(gwsConn), nil
+					return surrealdb.FromConnection(ctx, gwsConn)
 				}
 			} else {
 				connect = func(ctx context.Context) (*surrealdb.DB, error) {
 					wsConn := gorillaws.New(conf)
 
-					if err := wsConn.Connect(ctx); err != nil {
-						return nil, fmt.Errorf("failed to connect to gorillaws: %w", err)
-					}
-					return surrealdb.FromConnection(wsConn), nil
+					return surrealdb.FromConnection(ctx, wsConn)
 				}
 			}
 		case "http", "https":

--- a/db.go
+++ b/db.go
@@ -26,14 +26,23 @@ type DB struct {
 	con connection.Connection
 }
 
+// New creates a new SurrealDB client.
+//
+// Deprecated: New is deprecated. Use FromEndpointURLString instead.
+func New(connectionURL string) (*DB, error) {
+	return FromEndpointURLString(context.Background(), connectionURL)
+}
+
 // FromConnection creates a new SurrealDB client using the provided connection.
 //
-// It is the caller's responsibility to ensure that the provided connection is connected to the SurrealDB server.
-//
-// If the connection is not connected, the SDK will NOT attempt to connect to the SurrealDB server,
-// and the behavior is undefined.
-func FromConnection(conn connection.Connection) *DB {
-	return &DB{con: conn}
+// Note that this function calls `conn.Connect(ctx)` for you,
+// so you don't need to call it manually.
+func FromConnection(ctx context.Context, conn connection.Connection) (*DB, error) {
+	if err := conn.Connect(ctx); err != nil {
+		return nil, err
+	}
+
+	return &DB{con: conn}, nil
 }
 
 // Deprecated: Use FromEndpointURLString instead.
@@ -74,12 +83,7 @@ func FromEndpointURLString(ctx context.Context, connectionURL string) (*DB, erro
 		return nil, fmt.Errorf("invalid connection url")
 	}
 
-	err = con.Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return FromConnection(con), nil
+	return FromConnection(ctx, con)
 }
 
 // --------------------------------------------------

--- a/example/example_gws_connection_test.go
+++ b/example/example_gws_connection_test.go
@@ -21,11 +21,11 @@ func ExampleConnection_gws() {
 	conf.Logger = nil // Disable logging for this example
 
 	conn := gws.New(conf)
-	if connErr := conn.Connect(context.Background()); connErr != nil {
-		panic(fmt.Sprintf("Failed to connect: %v", connErr))
-	}
 
-	db := surrealdb.FromConnection(conn)
+	db, err := surrealdb.FromConnection(context.Background(), conn)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to connect: %v", err))
+	}
 
 	// Attempt to sign in without setting namespace or database
 	// This should fail with an error, whose message will depend on the connection type.

--- a/internal/fakesdb/integration/server_response_delay_test.go
+++ b/internal/fakesdb/integration/server_response_delay_test.go
@@ -68,10 +68,8 @@ func TestServerFailureResponseDelay(t *testing.T) {
 	ws := gorillaws.New(p).
 		SetTimeOut(100 * time.Millisecond) // Short request timeout
 
-	err = ws.Connect(context.Background())
+	db, err := surrealdb.FromConnection(context.Background(), ws)
 	require.NoError(t, err)
-
-	db := surrealdb.FromConnection(ws)
 	defer db.Close(context.Background())
 
 	// Setup

--- a/pkg/connection/integration/rews_test.go
+++ b/pkg/connection/integration/rews_test.go
@@ -116,12 +116,9 @@ func testDoReconnect[C connection.WebSocketConnection](t *testing.T, newConnFunc
 	// Create auto-reconnecting connection
 	conn := rews.New(newConnFunc(wsURL), checkInterval, logger.New(slog.NewTextHandler(os.Stdout, nil)))
 
-	// Initial connection
-	err = conn.Connect(context.Background())
-	require.NoError(t, err)
-
 	// Create DB instance
-	db := surrealdb.FromConnection(conn)
+	db, err := surrealdb.FromConnection(context.Background(), conn)
+	require.NoError(t, err)
 	defer db.Close(context.Background())
 
 	// Setup
@@ -279,10 +276,9 @@ func TestDefaultWebSocketDoNotReconnect(t *testing.T) {
 
 	// Create connection with timeout to prevent hanging
 	ws := gorillaws.New(p).SetTimeOut(2 * time.Second)
-	err = ws.Connect(context.Background())
-	require.NoError(t, err)
 
-	db := surrealdb.FromConnection(ws)
+	db, err := surrealdb.FromConnection(context.Background(), ws)
+	require.NoError(t, err)
 	defer db.Close(context.Background())
 
 	err = db.Use(context.Background(), "test", "test")


### PR DESCRIPTION
This mainly does two things to ease upgrading from v0.6.x to the upcoming v0.7.0:

- Brings back `surrealdb.New` changed in #268 and removed in #286 with the same signature as it was in v0.6.0. It works as before, so that users have more time to migrate gracefully.
- Added context.Context parameter to the new `surrealdb.FromConnection(connection.Connection)` constructor, and made it call `connection.Connect` for you. This makes `FromConnection` and `FromEndpointURLString` consistent in the sense that they both call `Connection.Connect` for you. You can see several `conn.Connect(context.Background())` before every `surrealdb.FromConnection` in various tests disappeared. The same simplification applies to the advanced users that might want to use `surrealdb.FromConnection`.

Follow-up to #286