### PR TITLE
SurrealQL query builder

### DIFF
--- a/contrib/surrealql/README.md
+++ b/contrib/surrealql/README.md
@@ -1,0 +1,21 @@
+# SurrealQL Query Builder
+
+A type-safe query builder for SurrealDB's SurrealQL language. This package provides a fluent interface for constructing SurrealQL queries programmatically.
+
+## Installation
+
+```go
+import "github.com/surrealdb/surrealdb.go/contrib/surrealql"
+```
+
+## Usage
+
+See [USAGE.md](USAGE.md) to go through basic usage of this package.
+
+## Examples
+
+See testable examples named [`example_*_test.go`](./) for the respective symbol exposed by this library to see more detailed examples.
+
+## Contributing
+
+This package is part of the surrealdb.go project. Please see the main repository for contribution guidelines.

--- a/contrib/surrealql/USAGE.md
+++ b/contrib/surrealql/USAGE.md
@@ -1,0 +1,302 @@
+
+# Usage
+
+This document outlines the basic usage of the `surrealql` library
+so that you can go through it and get started with the library quickly.
+
+> [!IMPORTANT] Read the testable examples for more information!
+>
+> This is just an outline for basic usage- Please refer to the testable examples named `example_*_test.go` for more comprehensive and detailed documentation.
+>
+> They are considered part of the documentation, because they strive to
+cover all the features and are verified as a part of our CI.
+
+## Table of Contents
+
+- [SELECT Query](#select-query)
+- [WHERE Conditions](#where-conditions)
+- [COUNT Queries](#count-queries)
+- [Ordering and Pagination](#ordering-and-pagination)
+- [Group By Clause](#group-by-clause)
+- [RETURN Clauses](#return-clauses)
+- [CREATE Queries](#create-queries)
+- [UPDATE Queries](#update-queries)
+- [DELETE Queries](#delete-queries)
+- [RELATE Queries](#relate-queries)
+- [Fetch Clause](#fetch-clause)
+- [Parallel Clause](#parallel-clause)
+- [Explain Clause](#explain-clause)
+- [Integration with surrealdb.Query](#integration-with-surrealdbquery)
+- [Using Aggregate Functions](#using-aggregate-functions)
+- [Raw Queries](#raw-queries)
+
+## SELECT Query
+
+```go
+// Simple select all
+query := surrealql.Select("*").FromTable("users")
+sql, vars := query.Build()
+// SurrealQL: "SELECT * FROM users"
+
+// Select specific fields
+query := surrealql.Select("id", "name", "email").FromTable("users")
+// SurrealQL: "SELECT id, name, email FROM users"
+```
+
+## WHERE Conditions
+
+```go
+// Using WhereEq for equality
+query := surrealql.Select("*").FromTable("users").WhereEq("active", true)
+// SurrealQL: "SELECT * FROM users WHERE active = $active_1"
+
+// Using WhereNull to find null values
+query := surrealql.Select("*").FromTable("users").WhereNull("deleted_at")
+// SurrealQL: "SELECT * FROM users WHERE deleted_at IS NULL"
+
+// Using WhereNotNull to find non-null values
+query := surrealql.Select("*").FromTable("users").WhereNotNull("email")
+// SurrealQL: "SELECT * FROM users WHERE email IS NOT NULL"
+
+// Using WhereIn for multiple values
+query := surrealql.Select("*").From("orders").
+    WhereIn("status", "pending", "processing", "shipped")
+// SurrealQL: "SELECT * FROM orders WHERE status IN ($status_1, $status_2, $status_3)"
+
+// Using Where for complex conditions with placeholders
+query := surrealql.Select("*").FromTable("products").
+    Where("price BETWEEN ? AND ?", 10, 100)
+// SurrealQL: "SELECT * FROM products WHERE price BETWEEN $param_1 AND $param_2"
+
+// Combining multiple WHERE conditions
+query := surrealql.Select("*").FromTable("users").
+    WhereEq("active", true).
+    WhereNotNull("email").
+    WhereIn("role", "admin", "moderator").
+    Where("created_at > ?", "2024-01-01")
+// All conditions are combined with AND
+```
+
+## COUNT Queries
+
+```go
+// Count all records
+query := surrealql.Select("count() as count").FromTable("users").GroupAll()
+// SurrealQL: "SELECT count() FROM users GROUP ALL"
+
+// Count specific field
+query := surrealql.Select("count(id) as id_count").FromTable("orders").GroupAll()
+// SurrealQL: "SELECT count(id) as id_count FROM orders GROUP ALL"
+
+// Count with grouping
+query := surrealql.Select("category", "count() as count").FromTable("products").GroupBy("category").OrderByDesc("count")
+// SurrealQL: "SELECT category, count() AS count FROM products GROUP BY category ORDER BY count DESC"
+```
+
+## Ordering and Pagination
+
+```go
+query := surrealql.Select("*").FromTable("posts").
+    OrderByDesc("created_at").
+    Limit(10).
+    Start(20)
+// SurrealQL: "SELECT * FROM posts ORDER BY created_at DESC LIMIT 10 START 20"
+```
+
+## Group By Clause
+
+```go
+// Group by with aggregates
+query := surrealql.Select("category", "count() AS total", "avg(price) AS avg_price").
+    FromTable("products").
+    GroupBy("category").
+    OrderByDesc("total")
+```
+
+## RETURN Clauses
+
+```go
+// Return none - useful for write operations where you don't need the result
+query := surrealql.Create("users").
+    Set("name", "John").
+    ReturnNone()
+// SurrealQL: "CREATE users CONTENT $content_1 RETURN NONE"
+
+// Return diff - useful for updates
+query := surrealql.Update("users", "123").
+    Set("name", "Jane").
+    ReturnDiff()
+// SurrealQL: "UPDATE users:123 SET $set_1 RETURN DIFF"
+```
+
+## CREATE Queries
+
+```go
+// Create with individual fields
+query := surrealql.Create("users").
+    Set("name", "John Doe").
+    Set("email", "john@example.com").
+    Set("active", true)
+
+// Create with content map
+query := surrealql.Create("users").Content(map[string]any{
+    "name":  "John Doe",
+    "email": "john@example.com",
+    "roles": []string{"user", "admin"},
+})
+```
+
+## UPDATE Queries
+
+```go
+// Update all records
+query := surrealql.Update("users").
+    Set("last_seen", time.Now())
+
+// Update specific record
+query := surrealql.Update("users", "123").
+    Set("name", "Jane Doe")
+
+// Update with conditions
+query := surrealql.Update("users").
+    Set("active", false).
+    Where("last_login < ?", "2024-01-01")
+```
+
+## DELETE Queries
+
+```go
+// Delete all records
+query := surrealql.Delete("users")
+
+// Delete specific record
+query := surrealql.Delete("users:123")
+
+// Delete with conditions
+query := surrealql.Delete("sessions").
+    Where("expires_at < ?", time.Now())
+```
+
+## RELATE Queries
+
+```go
+// Create a relation
+query := surrealql.Relate("users:123", "likes", "posts:456")
+
+// Create a relation with properties
+query := surrealql.Relate("users:123", "purchased", "products:789").
+    Set("quantity", 2).
+    Set("price", 29.99).
+    Set("purchased_at", time.Now())
+```
+
+## Fetch Clause
+
+```go
+// Fetch related records
+query := surrealql.Select("*").FromTable("posts").
+    Fetch("author", "comments", "comments.author")
+```
+
+References:
+
+- [FETCH clause | SurrealQL](https://surrealdb.com/docs/surrealql/clauses/fetch)
+
+## Parallel Clause
+
+Several SurrealQL statements support the `PARALLEL` clause:
+
+```go
+query := surrealql.Select("*").FromTable("large_table").
+    WhereEq("processed", false).
+    Parallel()
+```
+
+References:
+
+- [SELECT statement | SurrealQL](https://surrealdb.com/docs/surrealql/statements/select#the-parallel-clause)
+- [CREATE statement | SurrealQL](https://surrealdb.com/docs/surrealql/statements/create#parallel)
+
+## Explain Clause
+
+```go
+query := surrealql.Select("*").FromTable("users").
+    WhereEq("email", "user@example.com").
+    Explain()
+```
+
+References:
+
+- [EXPLAIN clause | SurrealQL](https://surrealdb.com/docs/surrealql/clauses/explain)
+
+## Integration with surrealdb.Query
+
+```go
+import (
+    "context"
+    "github.com/surrealdb/surrealdb.go"
+    "github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+// Build your query
+query := surrealql.Select("id", "name").
+    FromTable("users").
+    WhereEq("active", true).
+    OrderBy("created_at").
+    Limit(10)
+
+// Get SurrealQL and parameters
+sql, vars := query.Build()
+
+// Execute with surrealdb
+ctx := context.Background()
+result, err := surrealdb.Query[User](ctx, db, sql, vars)
+```
+
+## Using Aggregate Functions
+
+In SurrealDB, aggregate functions work differently than traditional SQL. To aggregate values from a table, use aggregate functions with either `GROUP ALL` or `GROUP BY`.
+
+More specifically:
+
+- Use `SELECT math::sum(field)` with `GROUP [BY|ALL]` instead of `SELECT SUM(col)`
+- Use `SELECT math::avg(field)` with `GROUP [BY|ALL]` instead of `SELECT AVG(col)`
+- Use `SELECT math::max(field)` with `GROUP [BY|ALL]` instead of `SELECT MAX(col)`
+- Use `SELECT math::min(field)` with `GROUP [BY|ALL]` instead of `SELECT MIN(col)`
+
+```go
+// Sum all values from a table
+query := surrealql.Select(surrealql.Fn("math::sum").ArgFromField("amount")).
+			FromTable("orders").
+			GroupAll()
+// Produces: SELECT math::sum(amount) FROM orders GROUP ALL
+
+// Average ratings
+query := surrealql.Select(surrealql.Fn("math::mean").ArgFromField("rating")).
+			FromTable("reviews").
+			GroupAll()
+
+// Min/Max prices
+minQuery := surrealql.Select(surrealql.Fn("math::min").ArgFromField("price")).
+			FromTable("products").
+			GroupAll()
+maxQuery := surrealql.Select(surrealql.Fn("math::max").ArgFromField("price")).
+			FromTable("products").
+			GroupAll()
+
+// For use in SELECT with GROUP BY, use the raw functions:
+query := surrealql.Select("category", "math::sum(price) AS total").
+    FromTable("products").
+    GroupBy("category")
+```
+
+## Raw Queries
+
+For cases where you need complete control:
+
+```go
+query := surrealql.Raw(
+    "SELECT * FROM users WHERE created_at > $date",
+    map[string]any{"date": "2024-01-01"},
+)
+```

--- a/contrib/surrealql/begin.go
+++ b/contrib/surrealql/begin.go
@@ -1,0 +1,9 @@
+package surrealql
+
+// Begin creates a new transaction query
+func Begin() *TransactionQuery {
+	return &TransactionQuery{
+		baseQuery:  newBaseQuery(),
+		statements: []TransactionStatement{},
+	}
+}

--- a/contrib/surrealql/begin_test.go
+++ b/contrib/surrealql/begin_test.go
@@ -1,0 +1,59 @@
+package surrealql
+
+import (
+	"testing"
+)
+
+func TestBegin(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      *TransactionQuery
+		wantQL     string
+		wantParams map[string]any
+	}{
+		{
+			name: "simple transaction",
+			query: Begin().
+				Raw("CREATE person:test SET name = 'John'").
+				Raw("CREATE person:test2 SET name = 'Jane'"),
+			wantQL: `BEGIN TRANSACTION;
+CREATE person:test SET name = 'John';
+CREATE person:test2 SET name = 'Jane';
+COMMIT TRANSACTION;`,
+			wantParams: map[string]any{},
+		},
+		{
+			name: "transaction with let and throw",
+			query: Begin().
+				Let("amount", 100).
+				Raw("UPDATE account SET balance -= $amount").
+				If("balance < 0").
+				Then(func(tb *ThenBuilder) {
+					tb.Throw("Insufficient funds")
+				}).
+				End(),
+			wantQL: `BEGIN TRANSACTION;
+LET $amount = 100;
+UPDATE account SET balance -= $amount;
+IF balance < 0 {
+    THROW "Insufficient funds";
+};
+COMMIT TRANSACTION;`,
+			wantParams: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, vars := tt.query.Build()
+
+			if sql != tt.wantQL {
+				t.Errorf("Build() sql = %v, want %v", sql, tt.wantQL)
+			}
+
+			if len(vars) != len(tt.wantParams) {
+				t.Errorf("Build() params = %v, want %v", vars, tt.wantParams)
+			}
+		})
+	}
+}

--- a/contrib/surrealql/count.go
+++ b/contrib/surrealql/count.go
@@ -1,0 +1,72 @@
+package surrealql
+
+import "fmt"
+
+// CountQuery represents a COUNT query builder
+type CountQuery struct {
+	*SelectQuery
+}
+
+// Count creates a new COUNT query builder
+// If no field is specified, it counts all records (COUNT()).
+// If a field is specified, it counts non-null values in that field (COUNT(field)).
+// Note that there is no `COUNT(*)` in SurrealQL, so you should use `COUNT()` for counting all.
+//
+// Deprecated: Use `Select()` instead, e.g. `Select("name", "count()")`.
+// This function is here to demonstrate that this isn't a right abstaction,
+// because you cannot specify non-aggregated fields in the SELECT clause
+// when using COUNT.
+func Count[T selectField](fields ...T) *CountQuery {
+	if len(fields) == 0 {
+		return &CountQuery{
+			SelectQuery: Select("count()"),
+		}
+	}
+
+	q := &CountQuery{
+		SelectQuery: Select(fields[0], fields[1:]...),
+	}
+	for i, field := range fields {
+		f := F(field)
+		f.expr = fmt.Sprintf("count(%s)", f.expr)
+
+		f = f.As(fmt.Sprintf("count_%d", i))
+
+		q.Field(f)
+	}
+
+	return q
+}
+
+// As adds an alias to the count result
+func (q *CountQuery) As(alias string) *CountQuery {
+	if len(q.fields) > 0 {
+		q.fields[0] = q.fields[0] + " AS " + alias
+	}
+	return q
+}
+
+// Additional helper methods for common count patterns
+
+// CountGroupBy creates a count query with grouping
+//
+// Deprecated: Use `Select()` with `GroupBy()` instead,
+// e.g. `Select("category", "count() AS count").FromTable("products").GroupBy("category")`.
+// This function is here to demonstrate that this isn't a right abstraction,
+// because you cannot specify non-aggregated fields in the SELECT clause
+// when using COUNT with GROUP BY.
+// It is recommended to use `Select()` for more flexibility.
+func CountGroupBy(groupField string, groupFields ...string) *CountQuery {
+	// Build the field list: group fields + count()
+	fields := make([]string, len(groupFields)+2)
+	fields[0] = groupField
+	copy(fields[1:], groupFields)
+	fields[len(fields)-1] = "count() AS count"
+
+	query := &CountQuery{
+		SelectQuery: Select(fields[0], fields[1:]...),
+	}
+	query.GroupBy(append([]string{groupField}, groupFields...)...)
+
+	return query
+}

--- a/contrib/surrealql/count_test.go
+++ b/contrib/surrealql/count_test.go
@@ -1,0 +1,47 @@
+package surrealql
+
+import "testing"
+
+func TestCount(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  Query
+		wantQL string
+	}{
+		{
+			name:   "count all",
+			query:  Count[string]().FromTable("users").GroupAll(),
+			wantQL: "SELECT count() FROM users GROUP ALL",
+		},
+		{
+			name:   "count field",
+			query:  Count("id").FromTable("users").GroupAll(),
+			wantQL: "SELECT id, count(id) AS count_0 FROM users GROUP ALL",
+		},
+		{
+			name:   "count with alias",
+			query:  Count[string]().As("total").FromTable("users").GroupAll(),
+			wantQL: "SELECT count() AS total FROM users GROUP ALL",
+		},
+		{
+			name:   "count with where",
+			query:  Count[string]().FromTable("users").Where("active = ?", true).GroupAll(),
+			wantQL: "SELECT count() FROM users WHERE active = $param_1 GROUP ALL",
+		},
+		{
+			name:   "count group by",
+			query:  CountGroupBy("category").FromTable("products"),
+			wantQL: "SELECT category, count() AS count FROM products GROUP BY category",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQL, _ := tt.query.Build()
+
+			if gotQL != tt.wantQL {
+				t.Errorf("SurrealQL mismatch\ngot:  %q\nwant: %q", gotQL, tt.wantQL)
+			}
+		})
+	}
+}

--- a/contrib/surrealql/create.go
+++ b/contrib/surrealql/create.go
@@ -1,0 +1,85 @@
+package surrealql
+
+import "fmt"
+
+// CreateQuery represents a CREATE query
+type CreateQuery struct {
+	baseQuery
+	thing        string
+	content      map[string]any
+	returnClause string
+}
+
+// Create starts a CREATE query
+// The `thing` parameter is either a table name, or a record ID with a colon (e.g., "users:123").
+// If you want to create a new record without specifying an ID, use just the table name (e.g., "users").
+// If you want to create a new record with a specific ID, use the format "table:id" (e.g., "users:123").
+// A special case to note for `table:id` is that when the `id` is a number-like string (e.g., "123")
+// "table:123" will treat `123` as an integer ID,
+// while "table:`123`" will treat `123` as a string ID.
+func Create[T mutationTarget](thing T) *CreateQuery {
+	bq := newBaseQuery()
+	sql, vars := buildTargetExpr(thing)
+	for k, v := range vars {
+		bq.addParam(k, v)
+	}
+	return &CreateQuery{
+		baseQuery: bq,
+		thing:     sql,
+		content:   make(map[string]any),
+	}
+}
+
+// Set adds a field to set in the CREATE query
+func (q *CreateQuery) Set(field string, value any) *CreateQuery {
+	q.content[field] = value
+	return q
+}
+
+// SetMap sets multiple fields from a map
+func (q *CreateQuery) SetMap(fields map[string]any) *CreateQuery {
+	for k, v := range fields {
+		q.content[k] = v
+	}
+	return q
+}
+
+// Content sets the entire content for the CREATE query
+func (q *CreateQuery) Content(content map[string]any) *CreateQuery {
+	q.content = content
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *CreateQuery) Return(clause string) *CreateQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *CreateQuery) ReturnNone() *CreateQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *CreateQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *CreateQuery) String() string {
+	sql := fmt.Sprintf("CREATE %s", q.thing)
+
+	if len(q.content) > 0 {
+		paramName := q.generateParamName("content")
+		q.addParam(paramName, q.content)
+		sql += fmt.Sprintf(" CONTENT $%s", paramName)
+	}
+
+	if q.returnClause != "" {
+		sql += " RETURN " + q.returnClause
+	}
+
+	return sql
+}

--- a/contrib/surrealql/create_test.go
+++ b/contrib/surrealql/create_test.go
@@ -1,0 +1,64 @@
+package surrealql
+
+import "testing"
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    Query
+		wantQL   string
+		wantArgs map[string]any
+	}{
+		{
+			name:   "create with set",
+			query:  Create("users").Set("name", "John").Set("email", "john@example.com"),
+			wantQL: "CREATE users CONTENT $content_1",
+			wantArgs: map[string]any{
+				"content_1": map[string]any{
+					"name":  "John",
+					"email": "john@example.com",
+				},
+			},
+		},
+		{
+			name:   "create with return none",
+			query:  Create("users").Set("name", "John").ReturnNone(),
+			wantQL: "CREATE users CONTENT $content_1 RETURN NONE",
+			wantArgs: map[string]any{
+				"content_1": map[string]any{
+					"name": "John",
+				},
+			},
+		},
+		{
+			name: "create with content",
+			query: Create("users").Content(map[string]any{
+				"name":  "John",
+				"age":   30,
+				"roles": []string{"admin", "user"},
+			}),
+			wantQL: "CREATE users CONTENT $content_1",
+			wantArgs: map[string]any{
+				"content_1": map[string]any{
+					"name":  "John",
+					"age":   30,
+					"roles": []string{"admin", "user"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQL, gotArgs := tt.query.Build()
+
+			if gotQL != tt.wantQL {
+				t.Errorf("SurrealQL mismatch\ngot:  %q\nwant: %q", gotQL, tt.wantQL)
+			}
+
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Errorf("Args count mismatch\ngot:  %d\nwant: %d", len(gotArgs), len(tt.wantArgs))
+			}
+		})
+	}
+}

--- a/contrib/surrealql/define.go
+++ b/contrib/surrealql/define.go
@@ -1,0 +1,203 @@
+package surrealql
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefineTableQuery represents a DEFINE TABLE query
+type DefineTableQuery struct {
+	baseQuery
+	table           string
+	changefeed      string
+	includeOriginal bool
+	schemafull      bool
+	schemaless      bool
+	permissions     []permission
+	fields          []string
+}
+
+// permission holds permission type and value
+type permission struct {
+	perm  string
+	value string
+}
+
+// DefineTable creates a new DEFINE TABLE query
+func DefineTable(table string) *DefineTableQuery {
+	return &DefineTableQuery{
+		baseQuery:   newBaseQuery(),
+		table:       table,
+		permissions: make([]permission, 0),
+		fields:      make([]string, 0),
+	}
+}
+
+// Changefeed enables changefeed for the table with specified duration
+func (q *DefineTableQuery) Changefeed(duration string) *DefineTableQuery {
+	q.changefeed = duration
+	return q
+}
+
+// ChangefeedDuration enables changefeed for the table with specified duration
+func (q *DefineTableQuery) ChangefeedDuration(duration time.Duration) *DefineTableQuery {
+	q.changefeed = duration.String()
+	return q
+}
+
+// ChangefeedWithOriginal enables changefeed with INCLUDE ORIGINAL option
+func (q *DefineTableQuery) ChangefeedWithOriginal(duration string) *DefineTableQuery {
+	q.changefeed = duration
+	q.includeOriginal = true
+	return q
+}
+
+// ChangefeedDurationWithOriginal enables changefeed with INCLUDE ORIGINAL option
+func (q *DefineTableQuery) ChangefeedDurationWithOriginal(duration time.Duration) *DefineTableQuery {
+	q.changefeed = duration.String()
+	q.includeOriginal = true
+	return q
+}
+
+// Schemafull sets the table to SCHEMAFULL mode
+func (q *DefineTableQuery) Schemafull() *DefineTableQuery {
+	q.schemafull = true
+	q.schemaless = false
+	return q
+}
+
+// Schemaless sets the table to SCHEMALESS mode
+func (q *DefineTableQuery) Schemaless() *DefineTableQuery {
+	q.schemaless = true
+	q.schemafull = false
+	return q
+}
+
+// Permissions sets permissions for the table
+func (q *DefineTableQuery) Permissions(perm, value string) *DefineTableQuery {
+	q.permissions = append(q.permissions, permission{perm: perm, value: value})
+	return q
+}
+
+// Build returns the SurrealQL string and parameters for the query
+func (q *DefineTableQuery) Build() (query string, params map[string]any) {
+	var builder strings.Builder
+
+	builder.WriteString("DEFINE TABLE ")
+	builder.WriteString(escapeIdent(q.table))
+
+	// Add schema mode
+	if q.schemafull {
+		builder.WriteString(" SCHEMAFULL")
+	} else if q.schemaless {
+		builder.WriteString(" SCHEMALESS")
+	}
+
+	// Add changefeed if specified
+	if q.changefeed != "" {
+		builder.WriteString(" CHANGEFEED ")
+		builder.WriteString(q.changefeed)
+		if q.includeOriginal {
+			builder.WriteString(" INCLUDE ORIGINAL")
+		}
+	}
+
+	// Add permissions if specified
+	if len(q.permissions) > 0 {
+		builder.WriteString(" PERMISSIONS")
+		for _, p := range q.permissions {
+			builder.WriteString(fmt.Sprintf(" %s %s", strings.ToUpper(p.perm), p.value))
+		}
+	}
+
+	return builder.String(), q.vars
+}
+
+// String returns the SurrealQL string for the query
+func (q *DefineTableQuery) String() string {
+	sql, _ := q.Build()
+	return sql
+}
+
+// DefineFieldQuery represents a DEFINE FIELD query
+type DefineFieldQuery struct {
+	baseQuery
+	table    string
+	field    string
+	dataType string
+	value    string
+	assert   string
+	default_ string
+}
+
+// DefineField creates a new DEFINE FIELD query
+func DefineField(field, table string) *DefineFieldQuery {
+	return &DefineFieldQuery{
+		baseQuery: newBaseQuery(),
+		field:     field,
+		table:     table,
+	}
+}
+
+// Type sets the field type
+func (q *DefineFieldQuery) Type(dataType string) *DefineFieldQuery {
+	q.dataType = dataType
+	return q
+}
+
+// Value sets the field value expression
+func (q *DefineFieldQuery) Value(value string) *DefineFieldQuery {
+	q.value = value
+	return q
+}
+
+// Assert sets the field assertion
+func (q *DefineFieldQuery) Assert(assert string) *DefineFieldQuery {
+	q.assert = assert
+	return q
+}
+
+// Default sets the field default value
+func (q *DefineFieldQuery) Default(defaultValue string) *DefineFieldQuery {
+	q.default_ = defaultValue
+	return q
+}
+
+// Build returns the SurrealQL string and parameters for the query
+func (q *DefineFieldQuery) Build() (query string, params map[string]any) {
+	var builder strings.Builder
+
+	builder.WriteString("DEFINE FIELD ")
+	builder.WriteString(escapeIdent(q.field))
+	builder.WriteString(" ON TABLE ")
+	builder.WriteString(escapeIdent(q.table))
+
+	if q.dataType != "" {
+		builder.WriteString(" TYPE ")
+		builder.WriteString(q.dataType)
+	}
+
+	if q.value != "" {
+		builder.WriteString(" VALUE ")
+		builder.WriteString(q.value)
+	}
+
+	if q.assert != "" {
+		builder.WriteString(" ASSERT ")
+		builder.WriteString(q.assert)
+	}
+
+	if q.default_ != "" {
+		builder.WriteString(" DEFAULT ")
+		builder.WriteString(q.default_)
+	}
+
+	return builder.String(), q.vars
+}
+
+// String returns the SurrealQL string for the query
+func (q *DefineFieldQuery) String() string {
+	sql, _ := q.Build()
+	return sql
+}

--- a/contrib/surrealql/delete.go
+++ b/contrib/surrealql/delete.go
@@ -1,0 +1,79 @@
+package surrealql
+
+// DeleteQuery represents a DELETE query
+type DeleteQuery struct {
+	baseQuery
+	targets      []string
+	whereClause  *whereBuilder
+	returnClause string
+}
+
+// Delete starts a DELETE query
+func Delete[T mutationTarget](target T, targets ...T) *DeleteQuery {
+	q := &DeleteQuery{
+		baseQuery: newBaseQuery(),
+		targets:   nil,
+	}
+	deleteAddTarget(q, target)
+	for _, t := range targets {
+		deleteAddTarget(q, t)
+	}
+	return q
+}
+
+func deleteAddTarget[MT mutationTarget](q *DeleteQuery, target MT) *DeleteQuery {
+	sql, vars := buildTargetExpr(target)
+	q.targets = append(q.targets, sql)
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+	return q
+}
+
+// Where adds a WHERE condition
+func (q *DeleteQuery) Where(condition string, args ...any) *DeleteQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition("AND", condition, args, &q.baseQuery)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *DeleteQuery) Return(clause string) *DeleteQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *DeleteQuery) ReturnNone() *DeleteQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *DeleteQuery) Build() (sql string, params map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *DeleteQuery) String() string {
+	sql := "DELETE "
+
+	for i, target := range q.targets {
+		if i > 0 {
+			sql += ", "
+		}
+		sql += target
+	}
+
+	if q.whereClause != nil && q.whereClause.hasConditions() {
+		sql += " WHERE " + q.whereClause.build()
+	}
+
+	if q.returnClause != "" {
+		sql += " RETURN " + q.returnClause
+	}
+
+	return sql
+}

--- a/contrib/surrealql/delete_test.go
+++ b/contrib/surrealql/delete_test.go
@@ -1,0 +1,42 @@
+package surrealql
+
+import "testing"
+
+func TestDelete(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  Query
+		wantQL string
+	}{
+		{
+			name:   "delete all",
+			query:  Delete("users"),
+			wantQL: "DELETE users",
+		},
+		{
+			name:   "delete specific record",
+			query:  Delete("users:123"),
+			wantQL: "DELETE users:123",
+		},
+		{
+			name:   "delete with where",
+			query:  Delete("users").Where("active = ?", false),
+			wantQL: "DELETE users WHERE active = $param_1",
+		},
+		{
+			name:   "delete with return none",
+			query:  Delete("users").ReturnNone(),
+			wantQL: "DELETE users RETURN NONE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQL, _ := tt.query.Build()
+
+			if gotQL != tt.wantQL {
+				t.Errorf("SurrealQL mismatch\ngot:  %q\nwant: %q", gotQL, tt.wantQL)
+			}
+		})
+	}
+}

--- a/contrib/surrealql/doc.go
+++ b/contrib/surrealql/doc.go
@@ -1,0 +1,14 @@
+// Package surrealql provides a type-safe query builder for SurrealDB's SurrealQL language.
+//
+// This package allows you to construct SurrealQL queries programmatically with a fluent interface,
+// ensuring type safety and preventing SurrealQL injection through proper parameter binding.
+//
+// The query builder supports the following SurrealQL operations:
+//   - SELECT with WHERE, ORDER BY, LIMIT, GROUP BY, etc.
+//   - COUNT and other aggregate functions
+//   - CREATE with CONTENT
+//   - UPDATE with SET
+//   - DELETE
+//   - RELATE for creating relationships
+//   - RETURN clauses (NONE, DIFF, BEFORE, AFTER)
+package surrealql

--- a/contrib/surrealql/example_begin_test.go
+++ b/contrib/surrealql/example_begin_test.go
@@ -1,0 +1,24 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleBegin() {
+	// Create a simple transaction
+	tx := surrealql.Begin().
+		Let("transfer_amount", 300.00).
+		Raw("UPDATE account:one SET balance += $transfer_amount").
+		Raw("UPDATE account:two SET balance -= $transfer_amount")
+
+	sql, _ := tx.Build()
+	fmt.Println(sql)
+	// Output:
+	// BEGIN TRANSACTION;
+	// LET $transfer_amount = 300;
+	// UPDATE account:one SET balance += $transfer_amount;
+	// UPDATE account:two SET balance -= $transfer_amount;
+	// COMMIT TRANSACTION;
+}

--- a/contrib/surrealql/example_countgroupby_test.go
+++ b/contrib/surrealql/example_countgroupby_test.go
@@ -1,0 +1,20 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleCountGroupBy() {
+	// Count active users by role
+	query := surrealql.CountGroupBy("role").
+		FromTable("users").
+		Where("active = ?", true).
+		OrderByDesc("count")
+
+	sql, _ := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	// Output:
+	// SurrealQL: SELECT role, count() AS count FROM users WHERE active = $param_1 GROUP BY role ORDER BY count DESC
+}

--- a/contrib/surrealql/example_create_test.go
+++ b/contrib/surrealql/example_create_test.go
@@ -1,0 +1,152 @@
+package surrealql_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+)
+
+func ExampleCreate() {
+	// Create a new user
+	query := surrealql.Create("users").
+		Set("name", "John Doe").
+		Set("email", "john@example.com").
+		Set("created_at", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)).
+		Return("id, name, email")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: CREATE users CONTENT $content_1 RETURN id, name, email
+	// Vars: map[content_1:map[created_at:2023-10-01 12:00:00 +0000 UTC email:john@example.com name:John Doe]]
+}
+
+func ExampleCreate_withThing() {
+	// Create a new user with a specific ID
+	query := surrealql.Create(surrealql.Thing("users", 123)).
+		Set("name", "Alice").
+		Set("email", "alice@example.com").
+		Set("created_at", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)).
+		Return("id, name, email")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	keys := slices.Collect(maps.Keys(vars))
+	slices.Sort(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: CREATE $id_1 CONTENT $content_1 RETURN id, name, email
+	// Var content_1: map[created_at:2023-10-01 12:00:00 +0000 UTC email:alice@example.com name:Alice]
+	// Var id_1: {users 123}
+}
+
+// ExampleCreate_integration_f_recordID demonstrates creating a record with a specific RecordID using the query builder.
+// It shows how to use the `surrealql.T` function to specify the RecordID.
+func ExampleCreate_integration_thing_recordID() {
+	// This example shows how to use the query builder with surrealdb.Query
+
+	// Assume we have a *surrealdb.DB instance
+	var db *surrealdb.DB
+
+	db, err := testenv.New("test", "users")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// Create a new user with a specific ID
+	query := surrealql.Create(surrealql.Thing("users", 123)).
+		Set("name", "Alice").
+		Set("email", "alice@example.com").
+		Set("created_at", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)).
+		Return("id, name, email")
+
+	sql, vars := query.Build()
+
+	results, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	users := (*results)[0].Result
+
+	fmt.Println("Results:")
+	for i, user := range users {
+		fmt.Printf("  User %d:\n", i+1)
+
+		keys := slices.Collect(maps.Keys(user))
+		slices.Sort(keys)
+		for _, key := range keys {
+			fmt.Printf("    %s: %v\n", key, user[key])
+		}
+	}
+
+	// Output:
+	// Results:
+	//   User 1:
+	//     email: alice@example.com
+	//     id: {users 123}
+	//     name: Alice
+}
+
+// ExampleCreate_integration_f_table demonstrates creating a record in a table using the query builder.
+// It shows how to use the `surrealql.T` function to specify the table.
+// The ID is specified via the `Set` method, so that the record is created with a specific ID.
+func ExampleCreate_integration_table() {
+	var db *surrealdb.DB
+
+	db, err := testenv.New("test", "users")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// Create a new user with a specific ID
+	query := surrealql.Create(surrealql.Table("users")).
+		Set("id", 123).
+		Set("name", "Alice").
+		Set("email", "alice@example.com").
+		Set("created_at", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)).
+		Return("id, name, email")
+
+	sql, vars := query.Build()
+
+	results, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	users := (*results)[0].Result
+
+	fmt.Println("Results:")
+	for i, user := range users {
+		fmt.Printf("  User %d:\n", i+1)
+
+		keys := slices.Collect(maps.Keys(user))
+		slices.Sort(keys)
+		for _, key := range keys {
+			fmt.Printf("    %s: %v\n", key, user[key])
+		}
+	}
+
+	// Output:
+	// Results:
+	//   User 1:
+	//     email: alice@example.com
+	//     id: {users 123}
+	//     name: Alice
+}

--- a/contrib/surrealql/example_define_table_test.go
+++ b/contrib/surrealql/example_define_table_test.go
@@ -1,0 +1,109 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleDefineTable() {
+	// Simple table definition
+	q := surrealql.DefineTable("user")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE TABLE user
+}
+
+func ExampleDefineTable_changefeed() {
+	// Table with changefeed
+	q := surrealql.DefineTable("reading").Changefeed("3d")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE TABLE reading CHANGEFEED 3d
+}
+
+func ExampleDefineTable_changefeedDuration() {
+	// Table with changefeed using duration
+	q := surrealql.DefineTable("reading").ChangefeedDuration(72 * time.Hour)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE TABLE reading CHANGEFEED 72h0m0s
+}
+
+func ExampleDefineTable_changefeedWithOriginal() {
+	// Table with changefeed including original
+	q := surrealql.DefineTable("events").ChangefeedWithOriginal("7d")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE TABLE events CHANGEFEED 7d INCLUDE ORIGINAL
+}
+
+func ExampleDefineTable_changefeedDurationWithOriginal() {
+	// Table with changefeed including original using duration
+	q := surrealql.DefineTable("events").ChangefeedDurationWithOriginal(24 * time.Hour)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE TABLE events CHANGEFEED 24h0m0s INCLUDE ORIGINAL
+}
+
+func ExampleDefineTable_schemafull() {
+	// Schemafull table with changefeed
+	q := surrealql.DefineTable("product").
+		Schemafull().
+		Changefeed("30d")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE TABLE product SCHEMAFULL CHANGEFEED 30d
+}
+
+func ExampleDefineTable_permissions() {
+	// Table with permissions
+	q := surrealql.DefineTable("secure_data").
+		Permissions("select", "WHERE user = $auth.id").
+		Permissions("create", "WHERE user = $auth.id").
+		Permissions("update", "NONE").
+		Permissions("delete", "NONE")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE TABLE secure_data PERMISSIONS SELECT WHERE user = $auth.id CREATE WHERE user = $auth.id UPDATE NONE DELETE NONE
+}
+
+func ExampleDefineField() {
+	// Define a field with type and default
+	q := surrealql.DefineField("email", "user").
+		Type("string").
+		Assert("$value != NONE AND string::is::email($value)").
+		Default("\"no-email@example.com\"")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE FIELD email ON TABLE user TYPE string ASSERT $value != NONE AND string::is::email($value) DEFAULT "no-email@example.com"
+}
+
+func ExampleDefineField_value() {
+	// Define a computed field
+	q := surrealql.DefineField("full_name", "person").
+		Type("string").
+		Value("string::concat(first_name, ' ', last_name)")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// DEFINE FIELD full_name ON TABLE person TYPE string VALUE string::concat(first_name, ' ', last_name)
+}

--- a/contrib/surrealql/example_delete_test.go
+++ b/contrib/surrealql/example_delete_test.go
@@ -1,0 +1,23 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleDelete_withReturnNone() {
+	// Delete expired sessions without returning results
+	query := surrealql.Delete("sessions").
+		Where("expires_at < ?", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)).
+		ReturnNone()
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: DELETE sessions WHERE expires_at < $param_1 RETURN NONE
+	// Vars: map[param_1:2023-10-01 12:00:00 +0000 UTC]
+}

--- a/contrib/surrealql/example_fn_test.go
+++ b/contrib/surrealql/example_fn_test.go
@@ -1,0 +1,49 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleFunCall_ArgFromField() {
+	// Example of using Fn with ArgFromField
+	query := surrealql.Fn("math::sum").ArgFromField("amount")
+
+	sql, _ := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	// Output:
+	// SurrealQL: math::sum(amount)
+}
+
+func ExampleFunCall_ArgFromValue() {
+	// Example of using Fn with ArgFromValue
+	query := surrealql.Fn("math::mean").ArgFromValue(42)
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: math::mean($fn_math_mean_0)
+	// Var fn_math_mean_0: 42
+}
+
+func ExampleFunCall_ArgFromQuery() {
+	// Example of using Fn with ArgFromQuery
+	subQuery := surrealql.SelectValue("amount").FromTable("transactions").Where("status = ?", "completed")
+	query := surrealql.Fn("math::sum").ArgFromQuery(subQuery)
+
+	sql, _ := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	// Output:
+	// SurrealQL: math::sum(SELECT VALUE amount FROM transactions WHERE status = $param_1)
+}

--- a/contrib/surrealql/example_insert_relation_test.go
+++ b/contrib/surrealql/example_insert_relation_test.go
@@ -1,0 +1,24 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleInsertRelation() {
+	// Insert a relation
+	relationData := surrealql.NewRelationData().
+		SetIn("person:1").
+		SetID("follows").
+		SetOut("person:2").
+		Set("since", "2023-01-01").
+		Build()
+
+	q := surrealql.Insert("likes").Relation().Value(relationData)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// INSERT RELATION INTO likes $insert_data_1
+}

--- a/contrib/surrealql/example_insert_test.go
+++ b/contrib/surrealql/example_insert_test.go
@@ -1,0 +1,171 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleInsert() {
+	// Simple insert with data
+	q := surrealql.Insert("company").Value(map[string]any{
+		"name":    "SurrealDB",
+		"founded": "2021-09-10",
+		"tags":    []string{"big data", "database"},
+	})
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// INSERT INTO company $insert_data_1
+}
+
+func ExampleInsert_valueArray() {
+	// Insert multiple records with an array of data
+	data := []map[string]any{
+		{"name": "Company A"},
+		{"name": "Company B"},
+	}
+
+	q := surrealql.Insert("company").Value(data)
+
+	sql, vars := q.Build()
+	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// INSERT INTO company $insert_data_1
+	// Var insert_data_1: [map[name:Company A] map[name:Company B]]
+}
+
+func ExampleInsert_valueQuery() {
+	// Insert using a SELECT query
+	selectQuery := surrealql.Select("name", "founded").
+		FromTable("companies").
+		Where("active = ?", true)
+
+	q := surrealql.Insert("company").ValueQuery(selectQuery)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// INSERT INTO company (SELECT name, founded FROM companies WHERE active = $param_1)
+}
+
+func ExampleInsert_fields() {
+	// Insert with fields and values
+	q := surrealql.Insert("company").
+		Fields("name", "founded").
+		Values("SurrealDB", "2021-09-10").
+		Values("Another Company", "2022-01-01")
+
+	sql, vars := q.Build()
+	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// INSERT INTO company (name, founded) VALUES ($insert_0_0_1, $insert_0_1_1), ($insert_1_0_1, $insert_1_1_1)
+	// Var insert_0_0_1: SurrealDB
+	// Var insert_0_1_1: 2021-09-10
+	// Var insert_1_0_1: Another Company
+	// Var insert_1_1_1: 2022-01-01
+}
+
+func ExampleInsert_onDuplicate() {
+	// Insert with ON DUPLICATE KEY UPDATE
+	q := surrealql.Insert("user").
+		Fields("id", "name", "email").
+		Values("user:1", "John", "john@example.com").
+		OnDuplicateKeyUpdateSet("name", "John Updated").
+		OnDuplicateKeyUpdateSet("email", "john.updated@example.com")
+
+	sql, vars := q.Build()
+	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// INSERT INTO user (id, name, email) VALUES ($insert_0_0_1, $insert_0_1_1, $insert_0_2_1) ON DUPLICATE KEY UPDATE email = $dup_email_1, name = $dup_name_1
+	// Var dup_email_1: john.updated@example.com
+	// Var dup_name_1: John Updated
+	// Var insert_0_0_1: user:1
+	// Var insert_0_1_1: John
+	// Var insert_0_2_1: john@example.com
+}
+
+func ExampleInsert_onDuplicateRaw() {
+	// Insert with ON DUPLICATE KEY UPDATE using raw SQL
+	q := surrealql.Insert("user").
+		Fields("id", "name", "times_updated", "last_edited").
+		Values("user:1", "John", 0).
+		Values("user:2", "Jane", 0).
+		OnDuplicateKeyUpdateRaw("times_updated += 1").
+		OnDuplicateKeyUpdateRaw("last_edited = time::now()")
+
+	sql, vars := q.Build()
+	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// INSERT INTO user (id, name, times_updated, last_edited) VALUES ($insert_0_0_1, $insert_0_1_1, $insert_0_2_1), ($insert_1_0_1, $insert_1_1_1, $insert_1_2_1) ON DUPLICATE KEY UPDATE times_updated += 1, last_edited = time::now()
+	// Var insert_0_0_1: user:1
+	// Var insert_0_1_1: John
+	// Var insert_0_2_1: 0
+	// Var insert_1_0_1: user:2
+	// Var insert_1_1_1: Jane
+	// Var insert_1_2_1: 0
+}
+
+func ExampleInsert_returnOptions() {
+	// Insert with different return options
+	q1 := surrealql.Insert("person").Value(map[string]any{"name": "Alice"}).ReturnNone()
+	q2 := surrealql.Insert("person").Value(map[string]any{"name": "Bob"}).ReturnAfter()
+	q3 := surrealql.Insert("person").Value(map[string]any{"name": "Charlie"}).ReturnDiff()
+
+	sql1, _ := q1.Build()
+	sql2, _ := q2.Build()
+	sql3, _ := q3.Build()
+
+	fmt.Println(sql1)
+	fmt.Println(sql2)
+	fmt.Println(sql3)
+	// Output:
+	// INSERT INTO person $insert_data_1 RETURN NONE
+	// INSERT INTO person $insert_data_1 RETURN AFTER
+	// INSERT INTO person $insert_data_1 RETURN DIFF
+}
+
+func ExampleInsert_ignore() {
+	// Insert with IGNORE flag
+	q := surrealql.Insert("user").
+		Ignore().
+		Fields("id", "email").
+		Values("user:1", "existing@example.com")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// INSERT IGNORE INTO user (id, email) VALUES ($insert_0_0_1, $insert_0_1_1)
+}

--- a/contrib/surrealql/example_relate_test.go
+++ b/contrib/surrealql/example_relate_test.go
@@ -1,0 +1,23 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleRelate() {
+	// Create a "likes" relation between user and post
+	query := surrealql.Relate("users:123", "likes", "posts:456").
+		Set("liked_at", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)).
+		Set("reaction", "heart")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: RELATE users:123->likes->posts:456 CONTENT $content_1
+	// Vars: map[content_1:map[liked_at:2023-10-01 12:00:00 +0000 UTC reaction:heart]]
+}

--- a/contrib/surrealql/example_select_test.go
+++ b/contrib/surrealql/example_select_test.go
@@ -1,0 +1,396 @@
+package surrealql_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelect demonstrates basic usage of the SELECT query builder.
+//
+// This example shows how to create a simple SELECT query and execute it with surrealdb.Query.
+func ExampleSelect() {
+	// Simple SELECT query
+	query1 := surrealql.Select("*").FromTable("users")
+	sql1, vars1 := query1.Build()
+	fmt.Println("SurrealQL:", sql1)
+	fmt.Println("Vars:", vars1)
+
+	// SELECT all users with id and name
+	query2 := surrealql.Select("id", "name").FromTable("users")
+	sql2, vars2 := query2.Build()
+
+	fmt.Println("SurrealQL:", sql2)
+	fmt.Println("Vars:", vars2)
+
+	// To execute with surrealdb.Query:
+	// results, err := surrealdb.Query[User](ctx, db, sql, vars)
+
+	// Output:
+	// SurrealQL: SELECT * FROM users
+	// Vars: map[]
+	// SurrealQL: SELECT id, name FROM users
+	// Vars: map[]
+}
+
+// ExampleSelect_omit demonstrates how to use the OMIT clause in a SELECT query.
+func ExampleSelect_omit() {
+	// Select all fields except 'password' and 'created_at'
+	query := surrealql.Select("*").
+		Omit("password").
+		Omit("created_at").
+		FromTable("users")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * OMIT password, created_at FROM users
+	// Vars: map[]
+}
+
+// ExampleSelect_omitRaw demonstrates how to use the OMIT clause with a raw field.
+func ExampleSelect_omitRaw_destructuring() {
+	// Select all fields except a raw field
+	query := surrealql.Select("*").
+		Omit("password").
+		OmitRaw("opts.{ security, enabled }").
+		FromTable("users")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * OMIT password, opts.{ security, enabled } FROM users
+	// Vars: map[]
+}
+
+// ExampleSelect_fieldName demonstrates how to add a field to the SELECT query.
+func ExampleSelect_fieldName() {
+	// Select specific fields from users
+	query := surrealql.Select("id").
+		FieldName("name").
+		FieldName("email").
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name, email FROM users
+	// Vars: map[]
+}
+
+func ExampleSelect_fieldNameAsAlias() {
+	// Select specific fields with an alias
+	query := surrealql.Select("id").
+		FieldNameAs("name", "username").
+		FieldName("email").
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name AS username, email FROM users
+	// Vars: map[]
+}
+
+func ExampleSelect_fieldQueryAs() {
+	// Select specific fields with a subquery as a field
+	subQuery := surrealql.Select("id", "total").FromTable("orders").Where("user_id = $parent.id")
+	query := surrealql.Select("id", "name").
+		FieldQueryAs(
+			subQuery,
+			"orders",
+		).
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name, (SELECT id, total FROM orders WHERE user_id = $parent.id) AS orders FROM users
+	// Vars: map[]
+}
+
+func ExampleSelect_fieldFunCallAs() {
+	// Select specific fields with a function call as a field
+	query := surrealql.Select("id").
+		FieldFunCallAs(
+			surrealql.Fn("count").ArgFromField("orders"),
+			"order_count",
+		).
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, count(orders) AS order_count FROM users
+	// Vars: map[]
+}
+
+// ExampleSelect_fieldRaw demonstrates how to add a raw field to the SELECT query.
+func ExampleSelect_fieldRaw() {
+	// Select specific fields with a raw field
+	query := surrealql.Select("id").
+		FieldName("name").
+		FieldRaw("name + ' <' + email + '>' AS contact").
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name, name + ' <' + email + '>' AS contact FROM users
+	// Vars: map[]
+}
+
+func ExampleSelect_field() {
+	// Add fields to the SELECT query
+	query := surrealql.Select("id", "name").
+		Field(surrealql.F("email")).
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name, email FROM users
+	// Vars: map[]
+}
+
+func ExampleSelect_field_fieldWithAlias() {
+	// Add fields with alias to the SELECT query
+	query := surrealql.Select("id", "name").
+		Field(surrealql.F("email").As("contact")).
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name, email AS contact FROM users
+	// Vars: map[]
+}
+
+func ExampleSelect_field_queryWithAlias() {
+	// Add a subquery with alias to the SELECT query
+	subQuery := surrealql.Select("id", "total").FromTable("orders").Where("user_id = $parent.id")
+	query := surrealql.Select("id", "name").
+		Field(surrealql.F(subQuery).As("orders")).
+		FromTable("users")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name, (SELECT id, total FROM orders WHERE user_id = $parent.id) AS orders FROM users
+	// Vars: map[]
+}
+
+func ExampleSelect_withConditions() {
+	// Select active users with email
+	query := surrealql.Select("id", "name", "email").
+		FromTable("users").
+		WhereEq("active", true).
+		WhereNotNull("email").
+		OrderByDesc("created_at").
+		Limit(10)
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name, email FROM users WHERE active = $active_1 AND email IS NOT NULL ORDER BY created_at DESC LIMIT 10
+	// Vars: map[active_1:true]
+}
+
+func ExampleSelect_withF() {
+	// Select users with a specific condition using F
+	query := surrealql.Select(surrealql.F("id"), surrealql.F("name")).
+		FromTable("users").
+		WhereEq("active", true).
+		OrderBy("created_at").
+		Limit(5)
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT id, name FROM users WHERE active = $active_1 ORDER BY created_at LIMIT 5
+	// Vars: map[active_1:true]
+}
+
+func ExampleSelect_withF_query() {
+	// Select users and their orders
+	query := surrealql.Select(
+		surrealql.F("id"),
+		surrealql.F("name"),
+		surrealql.F(
+			// $parent is a predefined variable.
+			// See https://surrealdb.com/docs/surrealql/statements/select#using-parameters
+			surrealql.Select("id", "total").FromTable("orders").Where("user_id = $parent.id"),
+		).As("orders"),
+	).FromTable("users").
+		WhereEq("active", true).
+		OrderBy("created_at").
+		Limit(5)
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+	// Output:
+	// SurrealQL: SELECT id, name, (SELECT id, total FROM orders WHERE user_id = $parent.id) AS orders FROM users WHERE active = $active_1 ORDER BY created_at LIMIT 5
+	// Vars: map[active_1:true]
+}
+
+func ExampleSelect_fromTarget_recordID() {
+	// Select users from a specific target
+	query := surrealql.Select("*").From(surrealql.Thing("users", "123"))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * FROM $id_1
+	// Vars: map[id_1:{users 123}]
+}
+
+func ExampleSelect_fromTarget_table() {
+	// Select users from a specific target
+	query := surrealql.Select("*").From(surrealql.Table("users"))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * FROM type::table($tb_1)
+	// Vars: map[tb_1:users]
+}
+
+func ExampleSelect_fromRecordID_intID() {
+	// Select a user by RecordID
+	query := surrealql.Select("*").FromRecordID(models.NewRecordID("users", 123))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * FROM users:123
+	// Vars: map[]
+}
+
+func ExampleSelect_fromRecordID_intLikeStringID() {
+	// Select a user by RecordID
+	query := surrealql.Select("*").FromRecordID(models.NewRecordID("users", "123"))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * FROM users:⟨123⟩
+	// Vars: map[]
+}
+
+func ExampleSelect_fromRecordID_stringID() {
+	// Select a user by RecordID
+	query := surrealql.Select("*").FromRecordID(models.NewRecordID("users", "abc"))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * FROM users:abc
+	// Vars: map[]
+}
+
+func ExampleSelect_fromQuery() {
+	// Select users from a subquery
+	subQuery := surrealql.Select("id", "name").FromTable("users").WhereEq("active", true)
+	query := surrealql.Select("*").FromQuery(subQuery)
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: SELECT * FROM (SELECT id, name FROM users WHERE active = $active_1)
+	// Vars: map[active_1:true]
+}
+
+func ExampleSelect_integration() {
+	// This example shows how to use the query builder with surrealdb.Query
+
+	// Assume we have a *surrealdb.DB instance
+	var db *surrealdb.DB
+
+	db, err := testenv.New("test", "users")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	create := surrealql.Create("users").
+		Set("id", "123").
+		Set("name", "Test Item").
+		Set("email", "test@example.com").
+		Set("active", true).
+		Set("created_at", time.Now()).
+		ReturnNone()
+
+	createQuery, createParams := create.Build()
+	_, err = surrealdb.Query[any](ctx, db, createQuery, createParams)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Build a query to find active users
+	query := surrealql.Select("id", "name", "email").
+		FromTable("users").
+		WhereEq("active", true).
+		OrderBy("name").
+		Limit(100)
+
+	// Get the SurrealQL and parameters
+	ql, vars := query.Build()
+
+	// Execute the query
+	type User struct {
+		ID    models.RecordID `json:"id"`
+		Name  string          `json:"name"`
+		Email string          `json:"email"`
+	}
+
+	results, err := surrealdb.Query[[]User](ctx, db, ql, vars)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Process results
+	for _, result := range *results {
+		if result.Status == surrealql.StatusOK {
+			fmt.Printf("Users: %+v\n", result.Result)
+		}
+	}
+
+	// Output:
+	// Users: [{ID:{Table:users ID:123} Name:Test Item Email:test@example.com}]
+}

--- a/contrib/surrealql/example_show_changes_test.go
+++ b/contrib/surrealql/example_show_changes_test.go
@@ -1,0 +1,67 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleShowChangesForTable_sinceRawDate() {
+	// Show changes from a specific timestamp
+	q := surrealql.ShowChangesForTable("reading").
+		Since("d\"2023-09-07T01:23:52Z\"").
+		Limit(10)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// SHOW CHANGES FOR TABLE reading SINCE d"2023-09-07T01:23:52Z" LIMIT 10
+}
+
+func ExampleShowChangesForTable_sinceTime() {
+	// Show changes since a specific time
+	since := time.Date(2023, 9, 7, 1, 23, 52, 0, time.UTC)
+	q := surrealql.ShowChangesForTable("reading").
+		SinceTime(&since).
+		Limit(10)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// SHOW CHANGES FOR TABLE reading SINCE d"2023-09-07T01:23:52Z" LIMIT 10
+}
+
+func ExampleShowChangesForTable_sinceRawVersionstamp() {
+	// Show changes from version 0
+	q := surrealql.ShowChangesForTable("events").
+		Since("0").
+		Limit(50)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// SHOW CHANGES FOR TABLE events SINCE 0 LIMIT 50
+}
+
+func ExampleShowChangesForTable_sinceVersionstamp() {
+	// Show changes since a specific versionstamp
+	q := surrealql.ShowChangesForTable("events").
+		SinceVersionstamp(100).
+		Limit(50)
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// SHOW CHANGES FOR TABLE events SINCE 100 LIMIT 50
+}
+
+func ExampleShowChangesForTable_noLimit() {
+	// Show all changes since a version
+	q := surrealql.ShowChangesForTable("users").Since("100")
+
+	sql, _ := q.Build()
+	fmt.Println(sql)
+	// Output:
+	// SHOW CHANGES FOR TABLE users SINCE 100
+}

--- a/contrib/surrealql/example_sum_test.go
+++ b/contrib/surrealql/example_sum_test.go
@@ -1,0 +1,40 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleSelect_aggregate() {
+	// Using various aggregate functions
+
+	// Total revenue
+	sumQuery := surrealql.Select("math::sum(amount)").
+		FromTable("orders").
+		Where("status = ?", "completed")
+
+	// Average rating
+	avgQuery := surrealql.Select("math::mean(rating)").
+		FromTable("reviews").
+		Where("product_id = ?", "product:123")
+
+	// Price range
+	minQuery := surrealql.Select("math::min(price)").
+		FromTable("products").
+		Where("category = ?", "electronics")
+
+	maxQuery := surrealql.Select("math::max(price)").
+		FromTable("products")
+
+	fmt.Println("Sum:", sumQuery.String())
+	fmt.Println("Avg:", avgQuery.String())
+	fmt.Println("Min:", minQuery.String())
+	fmt.Println("Max:", maxQuery.String())
+
+	// Output:
+	// Sum: SELECT math::sum(amount) FROM orders WHERE status = $param_1
+	// Avg: SELECT math::mean(rating) FROM reviews WHERE product_id = $param_1
+	// Min: SELECT math::min(price) FROM products WHERE category = $param_1
+	// Max: SELECT math::max(price) FROM products
+}

--- a/contrib/surrealql/example_transaction_query_test.go
+++ b/contrib/surrealql/example_transaction_query_test.go
@@ -1,0 +1,116 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleTransactionQuery_Query() {
+	// Create a transaction with multiple query builders
+	createUser := surrealql.Create("users:123").Set("name", "Alice")
+	updateUser := surrealql.Update("users:123").Set("email", "alice@example.com")
+
+	tx := surrealql.Begin().
+		Query(createUser).
+		Query(updateUser)
+
+	sql, vars := tx.Build()
+	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+	// Output:
+	// BEGIN TRANSACTION;
+	// CREATE users:123 CONTENT $content_1;
+	// UPDATE users:123 SET email = $email_1;
+	// COMMIT TRANSACTION;
+	// Var content_1: map[name:Alice]
+	// Var content_2: map[name:Alice]
+	// Var email_1: alice@example.com
+	// Var email_2: alice@example.com
+}
+
+func ExampleTransactionQuery_If() {
+	// Create a transaction with conditional logic
+	tx := surrealql.Begin().
+		Let("transfer_amount", 300.00).
+		Raw("UPDATE account:one SET dollars -= $transfer_amount").
+		If("account:one.dollars < 0").
+		Then(func(tb *surrealql.ThenBuilder) {
+			// TODO: Fix this so that it becomes:
+			//   THROW "Insufficient funds, would have $" + <string>account:one.dollars;
+			// Instead of:
+			//   THROW "Insufficient funds, would have $\" + <string>account:one.dollars";
+			tb.Throw("Insufficient funds, would have $\" + <string>account:one.dollars")
+		}).
+		End()
+
+	sql, _ := tx.Build()
+	fmt.Println(sql)
+	// Output:
+	// BEGIN TRANSACTION;
+	// LET $transfer_amount = 300;
+	// UPDATE account:one SET dollars -= $transfer_amount;
+	// IF account:one.dollars < 0 {
+	//     THROW "Insufficient funds, would have $\" + <string>account:one.dollars";
+	// };
+	// COMMIT TRANSACTION;
+}
+
+// ExampleTransactionQuery_returningEarly demonstrates how to create a transaction with multiple query builders.
+// Note that this example is derived from https://surrealdb.com/docs/surrealql/statements/begin#returning-early-from-a-transaction.
+func ExampleTransactionQuery_returningEarly() {
+	// Create a transaction using existing query builders
+	createAccount1 := surrealql.Create("account:one").Set("balance", 135605.16)
+	createAccount2 := surrealql.Create("account:two").Set("balance", 91031.31)
+	updateAccount1 := surrealql.Raw("UPDATE account:one SET balance += 300.00", nil)
+	updateAccount2 := surrealql.Raw("UPDATE account:two SET balance -= 300.00", nil)
+
+	tx := surrealql.Begin().
+		Query(createAccount1).
+		Query(createAccount2).
+		If("!account:two.wants_to_send_money").
+		Then(func(tb *surrealql.ThenBuilder) {
+			tb.Throw("Customer doesn't want to send any money!")
+		}).
+		End().
+		Query(updateAccount1).
+		Query(updateAccount2)
+
+	sql, _ := tx.Build()
+	fmt.Println(sql)
+	// Output:
+	// BEGIN TRANSACTION;
+	// CREATE account:one CONTENT $content_1;
+	// CREATE account:two CONTENT $content_1;
+	// IF !account:two.wants_to_send_money {
+	//     THROW "Customer doesn't want to send any money!";
+	// };
+	// UPDATE account:one SET balance += 300.00;
+	// UPDATE account:two SET balance -= 300.00;
+	// COMMIT TRANSACTION;
+}
+
+func ExampleTransactionQuery_LetTyped() {
+	// Create a transaction with typed LET statements
+	tx := surrealql.Begin().
+		LetTyped("num", "int | string", "9").
+		LetTyped("vals", "array<bool>", surrealql.Raw("some:record.vals.map(|$val| <bool>$val)", nil)).
+		Raw("CREATE thing SET number = $num, values = $vals")
+
+	sql, _ := tx.Build()
+	fmt.Println(sql)
+	// Output:
+	// BEGIN TRANSACTION;
+	// LET $num: int | string = "9";
+	// LET $vals: array<bool> = (some:record.vals.map(|$val| <bool>$val));
+	// CREATE thing SET number = $num, values = $vals;
+	// COMMIT TRANSACTION;
+}

--- a/contrib/surrealql/example_update_test.go
+++ b/contrib/surrealql/example_update_test.go
@@ -1,0 +1,203 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleUpdate_allInTable() {
+	// Update all records in a table
+	query := surrealql.Update("users").
+		Set("active", true).
+		Where("last_login < ?", time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: UPDATE users SET active = $active_1 WHERE last_login < $param_1
+	// Var active_1: true
+	// Var param_1: 2022-10-01 00:00:00 +0000 UTC
+}
+
+func ExampleUpdate_allInMultipleTables() {
+	// Update all records in multiple tables
+	query := surrealql.Update("users", "products").
+		Set("active", true).
+		Where("last_updated < ?", time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: UPDATE users, products SET active = $active_1 WHERE last_updated < $param_1
+	// Var active_1: true
+	// Var param_1: 2022-10-01 00:00:00 +0000 UTC
+}
+
+func ExampleUpdate_specificRecord() {
+	// Update a specific record by ID
+	query := surrealql.Update("users:123").
+		Set("name", "Jane Doe").
+		Set("email", "jane.doe@example.com")
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+	// Output:
+	// SurrealQL: UPDATE users:123 SET email = $email_1, name = $name_1
+	// Var email_1: jane.doe@example.com
+	// Var name_1: Jane Doe
+}
+
+func ExampleUpdate_specificRecordsAcrossMultipleTables() {
+	// Update specific records across multiple tables
+	query := surrealql.Update("users:123", "products:456").
+		Set("active", false).
+		Where("last_login < ?", time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: UPDATE users:123, products:456 SET active = $active_1 WHERE last_login < $param_1
+	// Var active_1: false
+	// Var param_1: 2022-10-01 00:00:00 +0000 UTC
+}
+
+func ExampleUpdate_thing() {
+	// Update a record using a Thing
+	query := surrealql.Update(surrealql.Thing("users", 123)).
+		Set("name", "Alice Smith").
+		Set("email", "alice.smith@example.com")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: UPDATE $id_1 SET email = $email_1, name = $name_1
+	// Var email_1: alice.smith@example.com
+	// Var id_1: {users 123}
+	// Var name_1: Alice Smith
+}
+
+func ExampleUpdate_table() {
+	// Update records in a table using Table function
+	query := surrealql.Update(surrealql.Table("users")).
+		Set("active", true).
+		Where("last_login < ?", time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: UPDATE type::table($tb_1) SET active = $active_1 WHERE last_login < $param_1
+	// Var active_1: true
+	// Var param_1: 2022-10-01 00:00:00 +0000 UTC
+	// Var tb_1: users
+}
+
+func ExampleUpdate_thingAndTable() {
+	// Update a record using a Thing and a Table
+	query := surrealql.Update(surrealql.Thing("users", 123), surrealql.Table("products")).
+		Set("name", "Bob").
+		Set("email", "bob@example.com")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: UPDATE $id_1, type::table($tb_1) SET email = $email_1, name = $name_1
+	// Var email_1: bob@example.com
+	// Var id_1: {users 123}
+	// Var name_1: Bob
+	// Var tb_1: products
+}
+
+func ExampleUpdate_returnNone() {
+	// Use RETURN NONE for better performance when results aren't needed
+
+	// Bulk update without returning results
+	updateQuery := surrealql.Update("products").
+		Set("on_sale", false).
+		Where("sale_ends_at < ?", time.Now()).
+		ReturnNone()
+
+	// Bulk delete without returning results
+	deleteQuery := surrealql.Delete("logs").
+		Where("created_at < ?", time.Now().AddDate(0, -1, 0)).
+		ReturnNone()
+
+	fmt.Println("Update:", updateQuery.String())
+	fmt.Println("Delete:", deleteQuery.String())
+
+	// Output:
+	// Update: UPDATE products SET on_sale = $on_sale_1 WHERE sale_ends_at < $param_1 RETURN NONE
+	// Delete: DELETE logs WHERE created_at < $param_1 RETURN NONE
+}
+
+func ExampleUpdate_withReturnDiff() {
+	// Update user and return changes
+	query := surrealql.Update("users:123").
+		Set("name", "Jane Doe").
+		Set("updated_at", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)).
+		ReturnDiff()
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// SurrealQL: UPDATE users:123 SET name = $name_1, updated_at = $updated_at_1 RETURN DIFF
+	// Var name_1: Jane Doe
+	// Var updated_at_1: 2023-10-01 12:00:00 +0000 UTC
+}

--- a/contrib/surrealql/f.go
+++ b/contrib/surrealql/f.go
@@ -1,0 +1,76 @@
+package surrealql
+
+import (
+	"fmt"
+)
+
+func F[T selectField](f T) *field {
+	switch v := any(f).(type) {
+	case *field:
+		return v
+	default:
+		return &field{expr: f, alias: ""}
+	}
+}
+
+// selectField is an interface for fields in SELECT queries.
+// This should be used solely for type safety in the SelectQuery.
+type selectField interface {
+	*field | fieldType
+}
+
+// fieldType is an interface for fields in SELECT queries.
+//
+// Select can be done with fields, or aliased fields,
+// where each field can be a simple escaped field,
+// a function call, or another SelectQuery.
+type fieldType interface {
+	string | *SelectQuery | *FunCall
+}
+
+// buildSelectFieldExpr builds the SQL expression for a select field.
+// The f MUST be any of the types defined in fieldType.
+//
+// It panics if the type is unsupported, but it should happen only when
+// this library has a bug, because this function is private to prevent misuse.
+func buildSelectFieldExpr(f any) (sql string, vars map[string]any) {
+	if f == nil {
+		return "*", nil // Default to selecting all fields
+	}
+
+	switch v := f.(type) {
+	case string:
+		return v, nil
+	case *SelectQuery:
+		sql, vars := v.Build()
+		return fmt.Sprintf("(%s)", sql), vars
+	case *FunCall:
+		return v.Build()
+	default:
+		panic(fmt.Sprintf("unsupported select field type: %T", f))
+	}
+}
+
+// field represents a field in a SELECT query.
+// It can be a simple field, a function call, or an expression, with an optional alias.
+type field struct {
+	expr  any
+	alias string
+}
+
+// As adds an alias to the function call.
+// This is useful when using the function in a SELECT query.
+// It returns an Aliased[*FunCall] which can be used in SELECT queries.
+func (f *field) As(alias string) *field {
+	return &field{expr: f.expr, alias: alias}
+}
+
+// Build returns the SurrealQL expression for the field and any associated vars.
+func (f *field) Build() (sql string, vars map[string]any) {
+	innerQL, innerVars := buildSelectFieldExpr(f.expr)
+
+	if f.alias != "" {
+		return fmt.Sprintf("%s AS %s", innerQL, escapeIdent(f.alias)), innerVars
+	}
+	return innerQL, innerVars
+}

--- a/contrib/surrealql/f_test.go
+++ b/contrib/surrealql/f_test.go
@@ -1,0 +1,55 @@
+package surrealql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestF_string(t *testing.T) {
+	sql, vars := F("price").Build()
+	assert.Equal(t, "price", sql)
+	assert.Empty(t, vars)
+}
+
+func TestF_stringAlias(t *testing.T) {
+	sql, vars := F("price").As("cost").Build()
+	assert.Equal(t, "price AS cost", sql)
+	assert.Empty(t, vars)
+}
+
+func TestF_selectQuery(t *testing.T) {
+	sql, vars := F(Select("*").FromTable("products").Where("category = ?", "electronics")).Build()
+	assert.Equal(t, "(SELECT * FROM products WHERE category = $param_1)", sql)
+	assert.Equal(t, map[string]any{"param_1": "electronics"}, vars)
+}
+
+func TestF_selectQueryAlias(t *testing.T) {
+	sql, vars := F(Select("*").FromTable("products").Where("category = ?", "electronics")).As("product_list").Build()
+	assert.Equal(t, "(SELECT * FROM products WHERE category = $param_1) AS product_list", sql)
+	assert.Equal(t, map[string]any{"param_1": "electronics"}, vars)
+}
+
+func TestF_fnArgFromField(t *testing.T) {
+	sql, vars := F(Fn("math::sum").ArgFromField("amount")).Build()
+	assert.Equal(t, "math::sum(amount)", sql)
+	assert.Empty(t, vars)
+}
+
+func TestF_fnArgFromFieldAlias(t *testing.T) {
+	sql, vars := F(Fn("math::sum").ArgFromField("amount")).As("total_amount").Build()
+	assert.Equal(t, "math::sum(amount) AS total_amount", sql)
+	assert.Empty(t, vars)
+}
+
+func TestF_fnArgFromValue(t *testing.T) {
+	sql, vars := F(Fn("math::sum").ArgFromValue([]int{100})).Build()
+	assert.Equal(t, "math::sum($fn_math_sum_0)", sql)
+	assert.Equal(t, map[string]any{"fn_math_sum_0": []int{100}}, vars)
+}
+
+func TestF_fnArgFromValueAlias(t *testing.T) {
+	sql, vars := F(Fn("math::sum").ArgFromValue([]int{100})).As("total_amount").Build()
+	assert.Equal(t, "math::sum($fn_math_sum_0) AS total_amount", sql)
+	assert.Equal(t, map[string]any{"fn_math_sum_0": []int{100}}, vars)
+}

--- a/contrib/surrealql/fn.go
+++ b/contrib/surrealql/fn.go
@@ -1,0 +1,70 @@
+package surrealql
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Fn creates a function call string for SurrealDB
+// which can be used in SELECT queries.
+func Fn(name string) *FunCall {
+	return &FunCall{
+		fn: name,
+	}
+}
+
+// FunCall represents a function call.
+// It can be used as a field directly or aliased in a SELECT query.
+// It can also be used for `return` statement in queries.
+type FunCall struct {
+	fn     string
+	args   []string
+	params map[string]any
+}
+
+func (f *FunCall) Build() (sql string, params map[string]any) {
+	sql = fmt.Sprintf("%s(%s)", f.fn, strings.Join(f.args, ", "))
+
+	return sql, f.params
+}
+
+// WithArg adds a field as an argument to the function call.
+// The field must exist in the select target.
+func (f *FunCall) ArgFromField(name string) *FunCall {
+	f.args = append(f.args, escapeIdent(name))
+	return f
+}
+
+// ArgFromValue adds a value as an argument to the function call.
+//
+// The value can be anything that can be marshaled using CBOR.
+func (f *FunCall) ArgFromValue(value any) *FunCall {
+	paramName := f.generateParamName()
+	f.args = append(f.args, "$"+escapeIdent(paramName))
+	if f.params == nil {
+		f.params = make(map[string]any)
+	}
+	f.addParam(paramName, value)
+	return f
+}
+
+// ArgFromQuery adds a query as an argument to the function call.
+func (f *FunCall) ArgFromQuery(query *SelectQuery) *FunCall {
+	sql, vars := query.Build()
+	f.args = append(f.args, sql)
+	for k, v := range vars {
+		f.addParam(k, v)
+	}
+	return f
+}
+
+func (f *FunCall) generateParamName() string {
+	return fmt.Sprintf("fn_%s_%d", strings.ReplaceAll(f.fn, "::", "_"), len(f.params))
+}
+
+func (f *FunCall) addParam(name string, value any) {
+	if f.params == nil {
+		f.params = make(map[string]any)
+	}
+	f.params[name] = value
+}

--- a/contrib/surrealql/fn_test.go
+++ b/contrib/surrealql/fn_test.go
@@ -1,0 +1,42 @@
+package surrealql
+
+import "testing"
+
+func TestFn(t *testing.T) {
+	tests := []struct {
+		name   string
+		fc     *FunCall
+		wantQL string
+	}{
+		{
+			name:   "sum",
+			fc:     Fn("math::sum").ArgFromField("amount"),
+			wantQL: "math::sum(amount)",
+		},
+		{
+			name:   "avg",
+			fc:     Fn("math::mean").ArgFromField("price"),
+			wantQL: "math::mean(price)",
+		},
+		{
+			name:   "min",
+			fc:     Fn("math::min").ArgFromField("created_at"),
+			wantQL: "math::min(created_at)",
+		},
+		{
+			name:   "max",
+			fc:     Fn("math::max").ArgFromField("score"),
+			wantQL: "math::max(score)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getQL, _ := tt.fc.Build()
+
+			if getQL != tt.wantQL {
+				t.Errorf("SurrealQL mismatch\ngot:  %q\nwant: %q", getQL, tt.wantQL)
+			}
+		})
+	}
+}

--- a/contrib/surrealql/insert.go
+++ b/contrib/surrealql/insert.go
@@ -1,0 +1,304 @@
+package surrealql
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// InsertQuery represents an INSERT query
+type InsertQuery struct {
+	baseQuery
+	table      string
+	isRelation bool
+	ignore     bool
+
+	// valueQuery is for INSERT INTO table (SELECT ...) queries
+	valueQuery *SelectQuery
+
+	// value is for INSERT INTO table $value queries
+	value any
+
+	fields            []string
+	values            [][]any
+	onDuplicateSet    map[string]any
+	onDuplicateSetRaw []string
+	returnClause      string
+}
+
+// Insert creates a new INSERT query
+func Insert(table string) *InsertQuery {
+	return &InsertQuery{
+		baseQuery:      newBaseQuery(),
+		table:          table,
+		onDuplicateSet: make(map[string]any),
+	}
+}
+
+// Ignore sets the IGNORE flag for the insert,
+// which changes the syntax to INSERT IGNORE
+func (q *InsertQuery) Ignore() *InsertQuery {
+	q.ignore = true
+	return q
+}
+
+// Relation sets the query as a relation insert,
+// which changes the syntax to INSERT RELATION
+func (q *InsertQuery) Relation() *InsertQuery {
+	q.isRelation = true
+	return q
+}
+
+// Value sets the data to insert (single record or array of records)
+func (q *InsertQuery) Value(data any) *InsertQuery {
+	q.value = data
+	return q
+}
+
+// ValueQuery sets the query to use the result of the provided SELECT query
+// as the data to insert
+// This is used for INSERT INTO table (SELECT ...)
+func (q *InsertQuery) ValueQuery(query *SelectQuery) *InsertQuery {
+	q.valueQuery = query
+	return q
+}
+
+// Fields sets the fields for VALUES insert
+func (q *InsertQuery) Fields(fields ...string) *InsertQuery {
+	q.fields = fields
+	return q
+}
+
+// Values adds values for VALUES insert
+func (q *InsertQuery) Values(values ...any) *InsertQuery {
+	q.values = append(q.values, values)
+	return q
+}
+
+// OnDuplicateKeyUpdateSet adds an ON DUPLICATE KEY UPDATE field = value clause
+func (q *InsertQuery) OnDuplicateKeyUpdateSet(field string, value any) *InsertQuery {
+	q.onDuplicateSet[field] = value
+	return q
+}
+
+// OnDuplicateKeyUpdateRaw adds an ON DUPLICATE KEY UPDATE expression
+func (q *InsertQuery) OnDuplicateKeyUpdateRaw(expr string) *InsertQuery {
+	q.onDuplicateSetRaw = append(q.onDuplicateSetRaw, expr)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *InsertQuery) Return(clause string) *InsertQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *InsertQuery) ReturnNone() *InsertQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnBefore sets RETURN BEFORE
+func (q *InsertQuery) ReturnBefore() *InsertQuery {
+	q.returnClause = ReturnBeforeClause
+	return q
+}
+
+// ReturnAfter sets RETURN AFTER
+func (q *InsertQuery) ReturnAfter() *InsertQuery {
+	q.returnClause = ReturnAfterClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *InsertQuery) ReturnDiff() *InsertQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters for the query
+func (q *InsertQuery) Build() (query string, vars map[string]any) {
+	var builder strings.Builder
+
+	q.buildInsertClause(&builder)
+	q.buildDataOrValues(&builder)
+	q.buildReturnClause(&builder)
+
+	return builder.String(), q.vars
+}
+
+// buildInsertClause builds the INSERT clause part
+func (q *InsertQuery) buildInsertClause(builder *strings.Builder) {
+	builder.WriteString("INSERT")
+	if q.ignore && !q.isRelation {
+		builder.WriteString(" IGNORE")
+	}
+	if q.isRelation {
+		builder.WriteString(" RELATION")
+	}
+	builder.WriteString(" INTO ")
+	builder.WriteString(escapeIdent(q.table))
+}
+
+// buildDataOrValues builds the data or fields/values part
+func (q *InsertQuery) buildDataOrValues(builder *strings.Builder) {
+	if q.valueQuery != nil {
+		q.buildValueQuery(builder)
+	} else if q.value != nil {
+		q.buildValueParam(builder)
+	} else if len(q.fields) > 0 && len(q.values) > 0 {
+		q.buildFieldsValues(builder)
+		q.buildOnDuplicate(builder)
+	}
+}
+
+// buildValueQuery builds the value query part
+func (q *InsertQuery) buildValueQuery(builder *strings.Builder) {
+	builder.WriteString(" (")
+	sql, vars := q.valueQuery.Build()
+	builder.WriteString(sql)
+	builder.WriteString(")")
+
+	// Merge parameters from the value query
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+}
+
+// buildValueParam builds the value parameter
+func (q *InsertQuery) buildValueParam(builder *strings.Builder) {
+	paramName := q.generateParamName("insert_data")
+	builder.WriteString(" $")
+	builder.WriteString(paramName)
+	q.addParam(paramName, q.value)
+}
+
+// buildFieldsValues builds the fields and values part
+func (q *InsertQuery) buildFieldsValues(builder *strings.Builder) {
+	// Fields
+	builder.WriteString(" (")
+	for i, field := range q.fields {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(escapeIdent(field))
+	}
+	builder.WriteString(") VALUES")
+
+	// Values
+	for i, row := range q.values {
+		if i > 0 {
+			builder.WriteString(",")
+		}
+		builder.WriteString(" (")
+		for j, value := range row {
+			if j > 0 {
+				builder.WriteString(", ")
+			}
+			paramName := q.generateParamName(fmt.Sprintf("insert_%d_%d", i, j))
+			builder.WriteString("$")
+			builder.WriteString(paramName)
+			q.addParam(paramName, value)
+		}
+		builder.WriteString(")")
+	}
+}
+
+// buildOnDuplicate builds the ON DUPLICATE KEY UPDATE part
+func (q *InsertQuery) buildOnDuplicate(builder *strings.Builder) {
+	if len(q.onDuplicateSet) == 0 && len(q.onDuplicateSetRaw) == 0 {
+		return
+	}
+
+	builder.WriteString(" ON DUPLICATE KEY UPDATE")
+	first := true
+	keys := sort.StringSlice(slices.Collect(maps.Keys(q.onDuplicateSet)))
+	sort.Stable(keys)
+	for _, field := range keys {
+		if !first {
+			builder.WriteString(",")
+		} else {
+			first = false
+		}
+
+		value := q.onDuplicateSet[field]
+
+		builder.WriteString(" ")
+		builder.WriteString(escapeIdent(field))
+		builder.WriteString(" = ")
+
+		paramName := q.generateParamName("dup_" + field)
+		builder.WriteString("$")
+		builder.WriteString(paramName)
+		q.addParam(paramName, value)
+	}
+
+	for _, expr := range q.onDuplicateSetRaw {
+		if !first {
+			builder.WriteString(",")
+		} else {
+			first = false
+		}
+
+		builder.WriteString(" ")
+		builder.WriteString(expr)
+	}
+}
+
+// buildReturnClause builds the RETURN clause
+func (q *InsertQuery) buildReturnClause(builder *strings.Builder) {
+	if q.returnClause != "" {
+		builder.WriteString(" RETURN ")
+		builder.WriteString(q.returnClause)
+	}
+}
+
+// String returns the SurrealQL string for the query
+func (q *InsertQuery) String() string {
+	sql, _ := q.Build()
+	return sql
+}
+
+// InsertBuilder provides a fluent interface for building complex insert data
+type InsertBuilder struct {
+	data map[string]any
+}
+
+// NewRelationData creates a new insert data builder
+func NewRelationData() *InsertBuilder {
+	return &InsertBuilder{
+		data: make(map[string]any),
+	}
+}
+
+// Set adds a field-value pair to the insert data
+func (b *InsertBuilder) Set(field string, value any) *InsertBuilder {
+	b.data[field] = value
+	return b
+}
+
+// SetIn sets the 'in' field for relation inserts
+func (b *InsertBuilder) SetIn(record string) *InsertBuilder {
+	b.data["in"] = record
+	return b
+}
+
+// SetOut sets the 'out' field for relation inserts
+func (b *InsertBuilder) SetOut(record string) *InsertBuilder {
+	b.data["out"] = record
+	return b
+}
+
+// SetID sets the 'id' field for relation inserts
+func (b *InsertBuilder) SetID(id string) *InsertBuilder {
+	b.data["id"] = id
+	return b
+}
+
+// Build returns the built data map
+func (b *InsertBuilder) Build() map[string]any {
+	return b.data
+}

--- a/contrib/surrealql/integration_create_return_test.go
+++ b/contrib/surrealql/integration_create_return_test.go
@@ -1,0 +1,124 @@
+package surrealql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestIntegrationReturnClauses(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "tasks")
+
+	ctx := context.Background()
+
+	type Task struct {
+		ID        models.RecordID       `json:"id,omitempty"`
+		Title     string                `json:"title"`
+		Completed bool                  `json:"completed"`
+		UpdatedAt models.CustomDateTime `json:"updated_at"`
+	}
+
+	type TaskCreate struct {
+		Title     string                `json:"title"`
+		Completed bool                  `json:"completed"`
+		UpdatedAt models.CustomDateTime `json:"updated_at"`
+	}
+
+	// Create a task
+	task, err := surrealdb.Create[Task](ctx, db, "tasks", TaskCreate{
+		Title:     "Test Task",
+		Completed: false,
+		UpdatedAt: models.CustomDateTime{Time: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create task: %v", err)
+	}
+
+	// Test RETURN NONE
+	t.Run("ReturnNone", func(t *testing.T) {
+		query := surrealql.Update(fmt.Sprintf("tasks:%v", task.ID.ID)).
+			Set("completed", true).
+			ReturnNone()
+
+		ql, vars := query.Build()
+		t.Logf("UPDATE RETURN NONE SurrealQL: %s", ql)
+		t.Logf("UPDATE RETURN NONE Params: %v", vars)
+
+		// With RETURN NONE, the result should be empty
+		results, err := surrealdb.Query[[]Task](ctx, db, ql, vars)
+		if err != nil {
+			t.Fatalf("Update failed: %v", err)
+		}
+
+		// The result should be empty
+		if len((*results)[0].Result) != 0 {
+			t.Errorf("Expected empty result with RETURN NONE, got %d items", len((*results)[0].Result))
+		}
+
+		// Verify the update worked - select all tasks
+		selectQuery := surrealql.Select("*").FromTable("tasks")
+		ql, vars = selectQuery.Build()
+		t.Logf("Verify SELECT SurrealQL: %s", ql)
+		t.Logf("Verify SELECT Params: %v", vars)
+
+		verifyResults, err := surrealdb.Query[[]Task](ctx, db, ql, vars)
+		if err != nil {
+			t.Fatalf("Select failed: %v", err)
+		}
+
+		tasks := (*verifyResults)[0].Result
+		t.Logf("Verify results: %d tasks found", len(tasks))
+
+		// Find the task we updated
+		var updatedTask *Task
+		for i, tsk := range tasks {
+			t.Logf("Task %d: %+v", i, tsk)
+			if tsk.ID.ID == task.ID.ID {
+				updatedTask = &tasks[i]
+				break
+			}
+		}
+
+		if updatedTask == nil {
+			t.Error("Could not find the updated task")
+		} else if !updatedTask.Completed {
+			t.Error("Task was not updated correctly")
+		}
+	})
+
+	t.Run("ReturnDiff", func(t *testing.T) {
+		// Create another task
+		task2, err := surrealdb.Create[Task](ctx, db, "tasks", TaskCreate{
+			Title:     "Another Task",
+			Completed: false,
+			UpdatedAt: models.CustomDateTime{Time: time.Now()},
+		})
+		if err != nil {
+			t.Fatalf("Failed to create task: %v", err)
+		}
+
+		query := surrealql.Update(fmt.Sprintf("tasks:%v", task2.ID.ID)).
+			Set("title", "Updated Task").
+			Set("completed", true).
+			ReturnDiff()
+
+		sql, vars := query.Build()
+		t.Logf("RETURN DIFF SurrealQL: %s", sql)
+
+		// RETURN DIFF returns a complex structure that varies by SurrealDB version
+		// Just verify it works and returns non-empty result
+		_, err2 := surrealdb.Query[any](ctx, db, sql, vars)
+		if err2 != nil {
+			t.Fatalf("Update failed: %v", err2)
+		}
+
+		// The fact that we got here without error means RETURN DIFF worked
+		t.Log("RETURN DIFF query succeeded - UPDATE with RETURN DIFF is supported")
+	})
+}

--- a/contrib/surrealql/integration_define_test.go
+++ b/contrib/surrealql/integration_define_test.go
@@ -1,0 +1,73 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestIntegrationDefineTable(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "events")
+
+	ctx := context.Background()
+
+	t.Run("DefineTableWithChangefeed", func(t *testing.T) {
+		// Define a table with changefeed
+		defineQuery := surrealql.DefineTable("events").
+			Schemafull().
+			Changefeed("1h")
+
+		ql, vars := defineQuery.Build()
+		t.Logf("DEFINE TABLE SurrealQL: %s", ql)
+
+		_, err := surrealdb.Query[any](ctx, db, ql, vars)
+		if err != nil {
+			t.Fatalf("DEFINE TABLE failed: %v", err)
+		}
+
+		// Define fields
+		fieldQuery := surrealql.DefineField("timestamp", "events").
+			Type("datetime").
+			Default("time::now()")
+
+		ql, vars = fieldQuery.Build()
+		_, err = surrealdb.Query[any](ctx, db, ql, vars)
+		if err != nil {
+			t.Fatalf("DEFINE FIELD failed: %v", err)
+		}
+
+		// Create some events using query
+		type Event struct {
+			ID        models.RecordID       `json:"id,omitempty"`
+			Timestamp models.CustomDateTime `json:"timestamp"`
+			Action    string                `json:"action"`
+		}
+
+		createEvent := surrealql.Create("events").
+			Set("action", "user_login")
+		ql, vars = createEvent.Build()
+		_, err = surrealdb.Query[[]Event](ctx, db, ql, vars)
+		if err != nil {
+			t.Fatalf("Failed to create event: %v", err)
+		}
+
+		// Show changes (this will only work if enough time has passed)
+		showQuery := surrealql.ShowChangesForTable("events").
+			Since("0").
+			Limit(10)
+
+		ql, vars = showQuery.Build()
+		t.Logf("SHOW CHANGES SurrealQL: %s", ql)
+
+		// The query should be valid even if no changes are returned yet
+		_, err = surrealdb.Query[any](ctx, db, ql, vars)
+		if err != nil {
+			// Some versions of SurrealDB might not support SHOW CHANGES yet
+			t.Logf("SHOW CHANGES query failed (might not be supported): %v", err)
+		}
+	})
+}

--- a/contrib/surrealql/integration_insert_test.go
+++ b/contrib/surrealql/integration_insert_test.go
@@ -1,0 +1,130 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestIntegrationInsert(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "products", "categories", "product_categories")
+
+	ctx := context.Background()
+
+	type Product struct {
+		ID       models.RecordID `json:"id,omitempty"`
+		Name     string          `json:"name"`
+		Price    float64         `json:"price"`
+		Category string          `json:"category"`
+	}
+
+	t.Run("InsertSingle", func(t *testing.T) {
+		// Insert a single product
+		insertQuery := surrealql.Insert("products").Value(map[string]any{
+			"name":     "Laptop",
+			"price":    999.99,
+			"category": "Electronics",
+		})
+
+		sql, vars := insertQuery.Build()
+		t.Logf("INSERT QL: %s", sql)
+		t.Logf("INSERT Params: %v", vars)
+
+		results, err := surrealdb.Query[[]Product](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("INSERT failed: %v", err)
+		}
+
+		products := (*results)[0].Result
+		if len(products) != 1 {
+			t.Fatalf("Expected 1 product inserted, got %d", len(products))
+		}
+
+		if products[0].Name != "Laptop" {
+			t.Errorf("Expected name 'Laptop', got %s", products[0].Name)
+		}
+	})
+
+	t.Run("InsertMultipleWithValues", func(t *testing.T) {
+		// Insert multiple products using VALUES
+		insertQuery := surrealql.Insert("products").
+			Fields("name", "price", "category").
+			Values("Phone", 699.99, "Electronics").
+			Values("Desk", 299.99, "Furniture").
+			Values("Chair", 199.99, "Furniture")
+
+		sql, vars := insertQuery.Build()
+
+		results, err := surrealdb.Query[[]Product](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("INSERT failed: %v", err)
+		}
+
+		products := (*results)[0].Result
+		if len(products) != 3 {
+			t.Fatalf("Expected 3 products inserted, got %d", len(products))
+		}
+	})
+
+	t.Run("InsertWithReturnNone", func(t *testing.T) {
+		// Insert with RETURN NONE
+		insertQuery := surrealql.Insert("products").
+			Value(map[string]any{
+				"name":     "Monitor",
+				"price":    399.99,
+				"category": "Electronics",
+			}).
+			ReturnNone()
+
+		sql, vars := insertQuery.Build()
+
+		results, err := surrealdb.Query[[]Product](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("INSERT failed: %v", err)
+		}
+
+		// With RETURN NONE, result should be empty
+		if len((*results)[0].Result) != 0 {
+			t.Errorf("Expected empty result with RETURN NONE, got %d items", len((*results)[0].Result))
+		}
+	})
+
+	t.Run("InsertRelation", func(t *testing.T) {
+		// Create a category first
+		type Category struct {
+			ID   models.RecordID `json:"id,omitempty"`
+			Name string          `json:"name"`
+		}
+		// Create category using query
+		createCat := surrealql.Create("categories").
+			Set("name", "Electronics")
+		sql, vars := createCat.Build()
+		catResults, err := surrealdb.Query[[]Category](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Failed to create category: %v", err)
+		}
+		category := (*catResults)[0].Result[0]
+
+		// Get first product
+		products, err := surrealdb.Select[[]Product](ctx, db, "products")
+		if err != nil || len(*products) == 0 {
+			t.Fatalf("Failed to get products: %v", err)
+		}
+
+		// Insert a relation using RELATE instead as INSERT RELATION might have issues
+		relateQuery := surrealql.Relate((*products)[0].ID.String(), "belongs_to", category.ID.String()).
+			Set("primary", true)
+
+		sql, vars = relateQuery.Build()
+		t.Logf("RELATE SurrealQL: %s", sql)
+
+		_, err = surrealdb.Query[any](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("RELATE failed: %v", err)
+		}
+	})
+}

--- a/contrib/surrealql/integration_item_crud_test.go
+++ b/contrib/surrealql/integration_item_crud_test.go
@@ -1,0 +1,176 @@
+package surrealql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Item struct for CRUD tests
+type Item struct {
+	ID          *models.RecordID      `json:"id,omitempty"`
+	Name        string                `json:"name"`
+	Description string                `json:"description"`
+	Price       float64               `json:"price"`
+	Active      bool                  `json:"active"`
+	UpdatedAt   models.CustomDateTime `json:"updated_at"`
+}
+
+func TestIntegrationCreateThenUpdate(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "items")
+	ctx := context.Background()
+
+	t.Run("Create", func(t *testing.T) {
+		query := surrealql.Create("items").
+			Set("name", "Test Item").
+			Set("description", "A test item").
+			Set("price", 99.99).
+			Set("active", true).
+			Set("updated_at", models.CustomDateTime{Time: time.Now()})
+
+		sql, vars := query.Build()
+
+		results, err := surrealdb.Query[[]Item](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+
+		items := (*results)[0].Result
+		if len(items) != 1 {
+			t.Fatalf("Expected 1 item created, got %d", len(items))
+		}
+
+		if items[0].Name != "Test Item" {
+			t.Errorf("Expected name 'Test Item', got %s", items[0].Name)
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		// First create some items
+		for i := 1; i <= 3; i++ {
+			_, err := surrealdb.Create[Item](ctx, db, "items", Item{
+				Name:      fmt.Sprintf("Item %c", 'A'+i-1),
+				Price:     float64(i * 10),
+				Active:    true,
+				UpdatedAt: models.CustomDateTime{Time: time.Now()},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create item: %v", err)
+			}
+		}
+
+		// Update items with price > 15
+		query := surrealql.Update("items").
+			Set("active", false).
+			Set("updated_at", models.CustomDateTime{Time: time.Now()}).
+			Where("price > ?", 15.0)
+
+		sql, vars := query.Build()
+
+		_, err := surrealdb.Query[[]Item](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Update failed: %v", err)
+		}
+
+		// First check all items
+		allQuery := surrealql.Select("*").FromTable("items")
+		allQL, allParams := allQuery.Build()
+		allResults, _ := surrealdb.Query[[]Item](ctx, db, allQL, allParams)
+		if len(*allResults) > 0 {
+			t.Logf("All items after update: %+v", (*allResults)[0].Result)
+		}
+
+		// Verify update
+		selectQuery := surrealql.Select("*").FromTable("items").WhereEq("active", false)
+		sql, vars = selectQuery.Build()
+
+		results, err := surrealdb.Query[[]Item](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Select failed: %v", err)
+		}
+
+		items := (*results)[0].Result
+		// Test Item (99.99), Item B (20), and Item C (30) all have price > 15
+		if len(items) != 3 {
+			t.Errorf("Expected 3 inactive items, got %d", len(items))
+		}
+	})
+}
+
+func TestIntegrationCreateThenDelete(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "items_delete")
+	ctx := context.Background()
+
+	// Setup: Create items with different active states
+	t.Run("Setup", func(t *testing.T) {
+		// Create active items
+		for i := 1; i <= 2; i++ {
+			_, err := surrealdb.Create[Item](ctx, db, "items_delete", Item{
+				Name:      fmt.Sprintf("Active Item %d", i),
+				Price:     float64(i * 10),
+				Active:    true,
+				UpdatedAt: models.CustomDateTime{Time: time.Now()},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create active item: %v", err)
+			}
+		}
+
+		// Create inactive items
+		for i := 1; i <= 3; i++ {
+			_, err := surrealdb.Create[Item](ctx, db, "items_delete", Item{
+				Name:      fmt.Sprintf("Inactive Item %d", i),
+				Price:     float64(i * 20),
+				Active:    false,
+				UpdatedAt: models.CustomDateTime{Time: time.Now()},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create inactive item: %v", err)
+			}
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		// Delete inactive items
+		query := surrealql.Delete("items_delete").
+			Where("active = ?", false)
+
+		sql, vars := query.Build()
+
+		_, err := surrealdb.Query[[]Item](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+
+		// Verify deletion
+		selectQuery := surrealql.Select("*").FromTable("items_delete")
+		sql, vars = selectQuery.Build()
+
+		results, err := surrealdb.Query[[]Item](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Select failed: %v", err)
+		}
+
+		items := (*results)[0].Result
+		// After DELETE of inactive items:
+		// Only 2 active items should remain
+		if len(items) != 2 {
+			t.Errorf("Expected 2 items remaining, got %d", len(items))
+			for i, item := range items {
+				t.Logf("Item %d: %+v", i, item)
+			}
+		}
+
+		for _, item := range items {
+			if !item.Active {
+				t.Errorf("Expected all remaining items to be active")
+			}
+		}
+	})
+}

--- a/contrib/surrealql/integration_product_count_test.go
+++ b/contrib/surrealql/integration_product_count_test.go
@@ -1,0 +1,157 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Product struct for COUNT tests
+type Product struct {
+	ID       *models.RecordID `json:"id,omitempty"`
+	Name     string           `json:"name"`
+	Category string           `json:"category"`
+	Price    float64          `json:"price"`
+	InStock  bool             `json:"in_stock"`
+}
+
+// setupProductData creates test product data for COUNT tests
+func setupProductData(t *testing.T, ctx context.Context, db *surrealdb.DB, table string) {
+	testProducts := []Product{
+		{Name: "Laptop", Category: "Electronics", Price: 999.99, InStock: true},
+		{Name: "Mouse", Category: "Electronics", Price: 29.99, InStock: true},
+		{Name: "Keyboard", Category: "Electronics", Price: 79.99, InStock: false},
+		{Name: "Desk", Category: "Furniture", Price: 299.99, InStock: true},
+		{Name: "Chair", Category: "Furniture", Price: 199.99, InStock: true},
+		{Name: "Lamp", Category: "Furniture", Price: 49.99, InStock: false},
+	}
+
+	for _, product := range testProducts {
+		_, err := surrealdb.Create[Product](ctx, db, table, product)
+		if err != nil {
+			t.Fatalf("Failed to create product: %v", err)
+		}
+	}
+}
+
+func TestIntegrationCount_All(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "products_all")
+	ctx := context.Background()
+
+	// Setup test data
+	setupProductData(t, ctx, db, "products_all")
+
+	// First check if products exist
+	checkQuery := surrealql.Select("*").FromTable("products_all")
+	checkQL, checkParams := checkQuery.Build()
+	checkResults, err := surrealdb.Query[[]Product](ctx, db, checkQL, checkParams)
+	if err != nil {
+		t.Fatalf("Failed to check products: %v", err)
+	}
+	if len(*checkResults) > 0 {
+		t.Logf("Found %d products in database", len((*checkResults)[0].Result))
+	}
+
+	// Try raw query first
+	rawResults, err := surrealdb.Query[[]map[string]any](ctx, db, "SELECT count() FROM products_all GROUP ALL", nil)
+	if err != nil {
+		t.Fatalf("Raw query failed: %v", err)
+	}
+	t.Logf("Raw query with GROUP ALL results: %+v", rawResults)
+
+	query := surrealql.Count[string]().FromTable("products_all").GroupAll()
+	sql, vars := query.Build()
+	t.Logf("COUNT SurrealQL: %s", sql)
+	t.Logf("COUNT Params: %v", vars)
+
+	type CountResult struct {
+		Count int `json:"count"`
+	}
+
+	results, err := surrealdb.Query[[]CountResult](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	t.Logf("Full results: %+v", results)
+	if len(*results) > 0 {
+		t.Logf("First result: %+v", (*results)[0])
+		t.Logf("Result data: %+v", (*results)[0].Result)
+	}
+
+	countResults := (*results)[0].Result
+	if len(countResults) == 0 {
+		t.Errorf("No count results returned")
+	} else if countResults[0].Count != 6 {
+		t.Errorf("Expected count 6, got %d", countResults[0].Count)
+	}
+}
+
+func TestIntegrationCount_WithWhere(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "products_where")
+	ctx := context.Background()
+
+	// Setup test data
+	setupProductData(t, ctx, db, "products_where")
+
+	query := surrealql.Count[string]().
+		FromTable("products_where").
+		WhereEq("in_stock", true).
+		GroupAll()
+
+	sql, vars := query.Build()
+
+	type CountResult struct {
+		Count int `json:"count"`
+	}
+
+	results, err := surrealdb.Query[[]CountResult](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	countResults := (*results)[0].Result
+	if len(countResults) > 0 && countResults[0].Count != 4 {
+		t.Errorf("Expected count 4, got %d", countResults[0].Count)
+	}
+}
+
+func TestIntegrationCount_GroupBy(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "products_group")
+	ctx := context.Background()
+
+	// Setup test data
+	setupProductData(t, ctx, db, "products_group")
+
+	query := surrealql.CountGroupBy("category").
+		FromTable("products_group").
+		OrderByDesc("count")
+
+	sql, vars := query.Build()
+
+	type CategoryCount struct {
+		Category string `json:"category"`
+		Count    int    `json:"count"`
+	}
+
+	results, err := surrealdb.Query[[]CategoryCount](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	categories := (*results)[0].Result
+	if len(categories) != 2 {
+		t.Errorf("Expected 2 categories, got %d", len(categories))
+	}
+
+	// Both categories should have 3 products each
+	for _, cat := range categories {
+		if cat.Count != 3 {
+			t.Errorf("Expected count 3 for %s, got %d", cat.Category, cat.Count)
+		}
+	}
+}

--- a/contrib/surrealql/integration_relate_test.go
+++ b/contrib/surrealql/integration_relate_test.go
@@ -1,0 +1,84 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestIntegrationRelate(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "users", "posts", "likes")
+
+	ctx := context.Background()
+
+	// Create a user and a post
+	type User struct {
+		ID   *models.RecordID `json:"id,omitempty"`
+		Name string           `json:"name"`
+	}
+
+	type Post struct {
+		ID    *models.RecordID `json:"id,omitempty"`
+		Title string           `json:"title"`
+	}
+
+	user, err := surrealdb.Create[User](ctx, db, "users", User{Name: "John"})
+	if err != nil {
+		t.Fatalf("Failed to create user: %v", err)
+	}
+
+	post, err := surrealdb.Create[Post](ctx, db, "posts", Post{Title: "Hello World"})
+	if err != nil {
+		t.Fatalf("Failed to create post: %v", err)
+	}
+
+	// Create a relation
+	t.Run("CreateRelation", func(t *testing.T) {
+		query := surrealql.Relate(user.ID.String(), "likes", post.ID.String()).
+			Set("rating", 5).
+			Set("created_at", models.CustomDateTime{Time: time.Now()})
+
+		sql, vars := query.Build()
+
+		type Like struct {
+			ID        models.RecordID       `json:"id,omitempty"`
+			In        models.RecordID       `json:"in"`
+			Out       models.RecordID       `json:"out"`
+			Rating    int                   `json:"rating"`
+			CreatedAt models.CustomDateTime `json:"created_at"`
+		}
+
+		results, err := surrealdb.Query[[]Like](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Relate failed: %v", err)
+		}
+
+		likes := (*results)[0].Result
+		if len(likes) != 1 {
+			t.Fatalf("Expected 1 relation created, got %d", len(likes))
+		}
+
+		if likes[0].Rating != 5 {
+			t.Errorf("Expected rating 5, got %d", likes[0].Rating)
+		}
+
+		// Verify the relation exists
+		selectQuery := surrealql.Select("*").FromTable("likes")
+		sql, vars = selectQuery.Build()
+
+		results, err = surrealdb.Query[[]Like](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Select failed: %v", err)
+		}
+
+		likes = (*results)[0].Result
+		if len(likes) != 1 {
+			t.Errorf("Expected 1 like relation, got %d", len(likes))
+		}
+	})
+}

--- a/contrib/surrealql/integration_sales_aggregate_test.go
+++ b/contrib/surrealql/integration_sales_aggregate_test.go
@@ -1,0 +1,184 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Sale struct for aggregate tests
+type Sale struct {
+	ID       models.RecordID `json:"id,omitempty"`
+	Product  string          `json:"product"`
+	Quantity int             `json:"quantity"`
+	Price    float64         `json:"price"`
+	Total    float64         `json:"total"`
+}
+
+// SaleCreate struct for aggregate tests
+type SaleCreate struct {
+	Product  string  `json:"product"`
+	Quantity int     `json:"quantity"`
+	Price    float64 `json:"price"`
+	Total    float64 `json:"total"`
+}
+
+// setupSalesData creates test sales data for aggregate tests
+func setupSalesData(t *testing.T, ctx context.Context, db *surrealdb.DB, table string) {
+	testSales := []SaleCreate{
+		{Product: "Widget A", Quantity: 5, Price: 10.00, Total: 50.00},
+		{Product: "Widget B", Quantity: 3, Price: 15.00, Total: 45.00},
+		{Product: "Widget A", Quantity: 2, Price: 10.00, Total: 20.00},
+		{Product: "Widget C", Quantity: 7, Price: 8.00, Total: 56.00},
+		{Product: "Widget B", Quantity: 4, Price: 15.00, Total: 60.00},
+	}
+
+	for _, sale := range testSales {
+		_, err := surrealdb.Create[Sale](ctx, db, table, sale)
+		if err != nil {
+			t.Fatalf("Failed to create sale: %v", err)
+		}
+	}
+}
+
+func TestIntegrationAggregate_Sum(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "sales_sum")
+	ctx := context.Background()
+
+	// Setup test data
+	setupSalesData(t, ctx, db, "sales_sum")
+
+	// First check if sales exist with raw query
+	rawResults, _ := surrealdb.Query[[]map[string]any](ctx, db, "SELECT * FROM sales_sum", nil)
+	if len(*rawResults) > 0 && len((*rawResults)[0].Result) > 0 {
+		t.Logf("Raw sale record: %+v", (*rawResults)[0].Result[0])
+	}
+
+	// Try raw sum query
+	rawSumResults, _ := surrealdb.Query[[]map[string]any](ctx, db, "SELECT math::sum(total) FROM sales_sum GROUP ALL", nil)
+	if len(*rawSumResults) > 0 {
+		t.Logf("Raw sum results: %+v", (*rawSumResults)[0].Result)
+	}
+
+	query := surrealql.Select(surrealql.Fn("math::sum").ArgFromField("total")).
+		FromTable("sales_sum").
+		GroupAll()
+	sql, vars := query.Build()
+	t.Logf("SUM SurrealQL: %s", sql)
+	t.Logf("SUM Params: %v", vars)
+
+	type SumResult struct {
+		Sum float64 `json:"math::sum"`
+	}
+
+	results, err := surrealdb.Query[[]SumResult](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	t.Logf("SUM results: %+v", results)
+	sumResults := (*results)[0].Result
+	if len(sumResults) > 0 {
+		expected := 50.0 + 45.0 + 20.0 + 56.0 + 60.0
+		if sumResults[0].Sum != expected {
+			t.Errorf("Expected sum %.2f, got %.2f", expected, sumResults[0].Sum)
+		}
+	} else {
+		t.Error("No sum results returned")
+	}
+}
+
+func TestIntegrationAggregate_Average(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "sales_avg")
+	ctx := context.Background()
+
+	// Setup test data
+	setupSalesData(t, ctx, db, "sales_avg")
+
+	query := surrealql.Select(surrealql.Fn("math::mean").ArgFromField("price")).
+		FromTable("sales_avg").
+		GroupAll()
+	sql, vars := query.Build()
+
+	type AvgResult struct {
+		Avg float64 `json:"math::mean"`
+	}
+
+	results, err := surrealdb.Query[[]AvgResult](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	avgResults := (*results)[0].Result
+	if len(avgResults) > 0 {
+		// Expected average: (10 + 15 + 10 + 8 + 15) / 5 = 11.6
+		expected := 11.6
+		if avgResults[0].Avg != expected {
+			t.Errorf("Expected avg %.2f, got %.2f", expected, avgResults[0].Avg)
+		}
+	} else {
+		t.Error("No average results returned")
+	}
+}
+
+func TestIntegrationAggregate_MinMax(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "sales_minmax")
+	ctx := context.Background()
+
+	// Setup test data
+	setupSalesData(t, ctx, db, "sales_minmax")
+
+	t.Run("Min", func(t *testing.T) {
+		minQuery := surrealql.Select(surrealql.Fn("math::min").ArgFromField("total")).
+			FromTable("sales_minmax").
+			GroupAll()
+		sql, vars := minQuery.Build()
+
+		type MinResult struct {
+			Min float64 `json:"math::min"`
+		}
+
+		minResults, err := surrealdb.Query[[]MinResult](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Min query failed: %v", err)
+		}
+
+		if len((*minResults)[0].Result) > 0 {
+			minValue := (*minResults)[0].Result[0].Min
+			if minValue != 20.0 {
+				t.Errorf("Expected min 20.0, got %.2f", minValue)
+			}
+		} else {
+			t.Error("No min results returned")
+		}
+	})
+
+	t.Run("Max", func(t *testing.T) {
+		maxQuery := surrealql.Select(surrealql.Fn("math::max").ArgFromField("total")).
+			FromTable("sales_minmax").
+			GroupAll()
+		sql, vars := maxQuery.Build()
+
+		type MaxResult struct {
+			Max float64 `json:"math::max"`
+		}
+
+		maxResults, err := surrealdb.Query[[]MaxResult](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Max query failed: %v", err)
+		}
+
+		if len((*maxResults)[0].Result) > 0 {
+			maxValue := (*maxResults)[0].Result[0].Max
+			if maxValue != 60.0 {
+				t.Errorf("Expected max 60.0, got %.2f", maxValue)
+			}
+		} else {
+			t.Error("No max results returned")
+		}
+	})
+}

--- a/contrib/surrealql/integration_transaction_test.go
+++ b/contrib/surrealql/integration_transaction_test.go
@@ -1,0 +1,102 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestIntegrationTransaction(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "accounts")
+
+	ctx := context.Background()
+
+	type Account struct {
+		ID      models.RecordID `json:"id,omitempty"`
+		Name    string          `json:"name"`
+		Balance float64         `json:"balance"`
+	}
+
+	// Create test accounts using queries (since Create with record ID has issues)
+	createQuery1 := surrealql.Create("accounts:one").
+		Set("name", "Account One").
+		Set("balance", 1000.00)
+
+	sql, vars := createQuery1.Build()
+	results1, err := surrealdb.Query[[]Account](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Failed to create account one: %v", err)
+	}
+	acc1 := (*results1)[0].Result[0]
+
+	createQuery2 := surrealql.Create("accounts:two").
+		Set("name", "Account Two").
+		Set("balance", 500.00)
+
+	sql, vars = createQuery2.Build()
+	results2, err := surrealdb.Query[[]Account](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Failed to create account two: %v", err)
+	}
+	acc2 := (*results2)[0].Result[0]
+
+	t.Run("SuccessfulTransaction", func(t *testing.T) {
+		// Create a successful transaction
+		tx := surrealql.Begin().
+			Let("transfer_amount", 200.00).
+			Raw("UPDATE accounts:one SET balance -= $transfer_amount").
+			Raw("UPDATE accounts:two SET balance += $transfer_amount")
+
+		sql, vars := tx.Build()
+		t.Logf("Transaction SurrealQL: %s", sql)
+		t.Logf("Transaction Params: %v", vars)
+
+		_, err := surrealdb.Query[any](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Transaction failed: %v", err)
+		}
+
+		// Verify balances
+		accounts, err := surrealdb.Select[[]Account](ctx, db, "accounts")
+		if err != nil {
+			t.Fatalf("Failed to select accounts: %v", err)
+		}
+
+		for _, acc := range *accounts {
+			if acc.ID.ID == acc1.ID.ID && acc.Balance != 800.00 {
+				t.Errorf("Expected balance 800.00 for account one, got %.2f", acc.Balance)
+			}
+			if acc.ID.ID == acc2.ID.ID && acc.Balance != 700.00 {
+				t.Errorf("Expected balance 700.00 for account two, got %.2f", acc.Balance)
+			}
+		}
+	})
+
+	t.Run("TransactionWithCondition", func(t *testing.T) {
+		// Create a transaction with IF condition
+		tx := surrealql.Begin().
+			Let("min_balance", 100.00).
+			Raw("UPDATE accounts:one SET balance -= 100").
+			If("accounts:one.balance < $min_balance").
+			Then(func(tb *surrealql.ThenBuilder) {
+				tb.Throw("Insufficient funds")
+			}).
+			End()
+
+		sql, vars := tx.Build()
+		t.Logf("Conditional Transaction SurrealQL: %s", sql)
+
+		_, err := surrealdb.Query[any](ctx, db, sql, vars)
+		// The transaction might fail if balance goes below minimum after deduction
+		// Just verify the query runs without error
+		if err == nil {
+			t.Log("Transaction succeeded - balance still above minimum")
+		} else {
+			t.Logf("Transaction failed as expected: %v", err)
+		}
+	})
+}

--- a/contrib/surrealql/integration_update_return_test.go
+++ b/contrib/surrealql/integration_update_return_test.go
@@ -1,0 +1,102 @@
+package surrealql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+)
+
+// TestIntegrationUpdateReturnNone tests UPDATE with RETURN NONE clause
+func TestIntegrationUpdateReturnNone(t *testing.T) {
+	// Skip if not in integration test mode
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := testenv.MustNew("surrealql_test", "update_table")
+	ctx := context.Background()
+
+	// Setup: Create test records
+	for i := 1; i <= 3; i++ {
+		createQuery := surrealql.Create("update_table").
+			Set("name", fmt.Sprintf("Item %d", i)).
+			Set("value", i*10).
+			Set("active", true)
+
+		sql, vars := createQuery.Build()
+		_, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+		if err != nil {
+			t.Fatalf("Failed to create test record %d: %v", i, err)
+		}
+	}
+
+	// Create an inactive record
+	createQuery := surrealql.Create("update_table").
+		Set("name", "Inactive Item").
+		Set("value", 100).
+		Set("active", false)
+
+	sql, vars := createQuery.Build()
+	_, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Failed to create inactive record: %v", err)
+	}
+
+	// Test UPDATE with RETURN NONE
+	updateQuery := surrealql.Update("update_table").
+		Set("updated", true).
+		Where("active = ?", true).
+		ReturnNone()
+
+	sql, vars = updateQuery.Build()
+	t.Logf("UPDATE SurrealQL: %s", sql)
+	t.Logf("UPDATE Params: %v", vars)
+
+	results, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("UPDATE failed: %v", err)
+	}
+
+	// With RETURN NONE, result should be empty
+	if len((*results)[0].Result) != 0 {
+		t.Errorf("Expected empty result with RETURN NONE, got %d items", len((*results)[0].Result))
+	}
+
+	// Verify the update worked
+	selectQuery := surrealql.Select("*").FromTable("update_table").WhereEq("updated", true)
+	sql, vars = selectQuery.Build()
+
+	verifyResults, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("SELECT failed: %v", err)
+	}
+
+	updatedRecords := (*verifyResults)[0].Result
+	// We should have 3 updated records (the 3 active ones)
+	if len(updatedRecords) != 3 {
+		t.Errorf("Expected 3 updated records, got %d", len(updatedRecords))
+	}
+
+	// Verify inactive record was not updated
+	selectInactiveQuery := surrealql.Select("*").FromTable("update_table").WhereEq("active", false)
+	sql, vars = selectInactiveQuery.Build()
+
+	inactiveResults, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("SELECT inactive failed: %v", err)
+	}
+
+	inactiveRecords := (*inactiveResults)[0].Result
+	if len(inactiveRecords) == 1 {
+		// Check that the inactive record doesn't have the "updated" field set to true
+		if updated, exists := inactiveRecords[0]["updated"]; exists && updated == true {
+			t.Errorf("Inactive record should not have been updated")
+		}
+	} else {
+		t.Errorf("Expected 1 inactive record, got %d", len(inactiveRecords))
+	}
+}

--- a/contrib/surrealql/integration_user_select_test.go
+++ b/contrib/surrealql/integration_user_select_test.go
@@ -1,0 +1,155 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// User struct for SELECT tests
+type User struct {
+	ID     *models.RecordID `json:"id,omitempty"`
+	Name   string           `json:"name"`
+	Email  string           `json:"email"`
+	Active bool             `json:"active"`
+	Age    int              `json:"age"`
+}
+
+// setupUserData creates test user data for SELECT tests
+func setupUserData(t *testing.T, ctx context.Context, db *surrealdb.DB, table string) {
+	testUsers := []User{
+		{Name: "Alice", Email: "alice@example.com", Active: true, Age: 25},
+		{Name: "Bob", Email: "bob@example.com", Active: true, Age: 30},
+		{Name: "Charlie", Email: "charlie@example.com", Active: false, Age: 35},
+		{Name: "Diana", Email: "diana@example.com", Active: true, Age: 28},
+	}
+
+	for _, user := range testUsers {
+		_, err := surrealdb.Create[User](ctx, db, table, user)
+		if err != nil {
+			t.Fatalf("Failed to create user: %v", err)
+		}
+	}
+}
+
+func TestIntegrationSelect_All(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "users_all")
+	ctx := context.Background()
+
+	// Setup test data
+	setupUserData(t, ctx, db, "users_all")
+
+	query := surrealql.Select("*").FromTable("users_all")
+	sql, vars := query.Build()
+
+	results, err := surrealdb.Query[[]User](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(*results) != 1 {
+		t.Fatalf("Expected 1 result set, got %d", len(*results))
+	}
+
+	if (*results)[0].Status != surrealql.StatusOK {
+		t.Fatalf("Query status not OK: %s", (*results)[0].Status)
+	}
+
+	users := (*results)[0].Result
+	if len(users) != 4 {
+		t.Errorf("Expected 4 users, got %d", len(users))
+	}
+}
+
+func TestIntegrationSelect_WhereEq(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "users_whereeq")
+	ctx := context.Background()
+
+	// Setup test data
+	setupUserData(t, ctx, db, "users_whereeq")
+
+	query := surrealql.Select("id", "name", "email").
+		FromTable("users_whereeq").
+		WhereEq("active", true).
+		OrderBy("name")
+
+	sql, vars := query.Build()
+
+	results, err := surrealdb.Query[[]User](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	users := (*results)[0].Result
+	if len(users) != 3 {
+		t.Errorf("Expected 3 active users, got %d", len(users))
+	}
+
+	// Check order
+	if len(users) > 0 && users[0].Name != "Alice" {
+		t.Errorf("Expected first user to be Alice, got %s", users[0].Name)
+	}
+}
+
+func TestIntegrationSelect_WhereWithParams(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "users_params")
+	ctx := context.Background()
+
+	// Setup test data
+	setupUserData(t, ctx, db, "users_params")
+
+	query := surrealql.Select("*").
+		FromTable("users_params").
+		Where("age > ? AND active = ?", 26, true).
+		OrderByDesc("age")
+
+	sql, vars := query.Build()
+
+	results, err := surrealdb.Query[[]User](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	users := (*results)[0].Result
+	if len(users) != 2 { // Bob (30) and Diana (28)
+		t.Errorf("Expected 2 users, got %d", len(users))
+	}
+
+	if len(users) > 0 && users[0].Name != "Bob" {
+		t.Errorf("Expected first user to be Bob, got %s", users[0].Name)
+	}
+}
+
+func TestIntegrationSelect_WithPagination(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "users_page")
+	ctx := context.Background()
+
+	// Setup test data
+	setupUserData(t, ctx, db, "users_page")
+
+	query := surrealql.Select("*").
+		FromTable("users_page").
+		OrderBy("name").
+		Limit(2).
+		Start(1)
+
+	sql, vars := query.Build()
+
+	results, err := surrealdb.Query[[]User](ctx, db, sql, vars)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	users := (*results)[0].Result
+	if len(users) != 2 {
+		t.Errorf("Expected 2 users, got %d", len(users))
+	}
+
+	if len(users) > 0 && users[0].Name != "Bob" {
+		t.Errorf("Expected first user to be Bob, got %s", users[0].Name)
+	}
+}

--- a/contrib/surrealql/query.go
+++ b/contrib/surrealql/query.go
@@ -1,0 +1,84 @@
+// Package surrealql provides a query builder for SurrealQL queries.
+// It allows you to construct SurrealQL queries programmatically with type safety.
+package surrealql
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Constants for common return clauses
+const (
+	ReturnNoneClause   = "NONE"
+	ReturnDiffClause   = "DIFF"
+	ReturnBeforeClause = "BEFORE"
+	ReturnAfterClause  = "AFTER"
+	StatusOK           = "OK"
+)
+
+// Query represents a SurrealQL query that can be built and executed.
+type Query interface {
+	// Build returns the SurrealQL string and parameters for the query
+	Build() (string, map[string]any)
+	// String returns the SurrealQL string for the query
+	String() string
+}
+
+// baseQuery contains common fields for all query types
+type baseQuery struct {
+	vars map[string]any
+}
+
+// newBaseQuery creates a new base query
+func newBaseQuery() baseQuery {
+	return baseQuery{
+		vars: make(map[string]any),
+	}
+}
+
+// addParam adds a parameter to the query
+func (q *baseQuery) addParam(name string, value any) {
+	q.vars[name] = value
+}
+
+// generateParamName generates a unique parameter name
+func (q *baseQuery) generateParamName(prefix string) string {
+	for i := 1; ; i++ {
+		name := fmt.Sprintf("%s_%d", prefix, i)
+		if _, exists := q.vars[name]; !exists {
+			return name
+		}
+	}
+}
+
+// escapeIdent escapes an identifier for use in SurrealQL
+func escapeIdent(ident string) string {
+	// If the identifier contains special characters, wrap it in backticks
+	if strings.ContainsAny(ident, " -:`") || isReservedWord(ident) {
+		return "`" + strings.ReplaceAll(ident, "`", "``") + "`"
+	}
+	return ident
+}
+
+// isReservedWord checks if a word is a SurrealQL reserved word
+func isReservedWord(word string) bool {
+	// This is a simplified check - in a real implementation,
+	// you'd have a complete list of reserved words
+	reserved := []string{
+		"SELECT", "FROM", "WHERE", "ORDER", "BY", "LIMIT", "START",
+		"FETCH", "GROUP", "SPLIT", "RETURN", "PARALLEL", "EXPLAIN",
+		"CREATE", "UPDATE", "DELETE", "RELATE", "INSERT", "DEFINE",
+		"REMOVE", "INFO", "USE", "BEGIN", "CANCEL", "COMMIT",
+		"IF", "ELSE", "THEN", "END", "BREAK", "CONTINUE",
+		"FUNCTION", "PARAM", "FIELD", "TYPE", "DEFAULT",
+		"ASSERT", "PERMISSIONS", "DURATION", "FLEXIBLE",
+	}
+
+	upperWord := strings.ToUpper(word)
+	for _, r := range reserved {
+		if upperWord == r {
+			return true
+		}
+	}
+	return false
+}

--- a/contrib/surrealql/query_test.go
+++ b/contrib/surrealql/query_test.go
@@ -1,0 +1,30 @@
+package surrealql
+
+import (
+	"testing"
+)
+
+func TestEscapeIdent(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"users", "users"},
+		{"user_name", "user_name"},
+		{"user-name", "`user-name`"},
+		{"user name", "`user name`"},
+		{"user:id", "`user:id`"},
+		{"SELECT", "`SELECT`"},
+		{"select", "`select`"},
+		{"my`table", "`my``table`"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := escapeIdent(tt.input)
+			if got != tt.want {
+				t.Errorf("escapeIdent(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/contrib/surrealql/raw.go
+++ b/contrib/surrealql/raw.go
@@ -1,0 +1,22 @@
+package surrealql
+
+// Helper function to create raw queries
+func Raw(sql string, params map[string]any) Query {
+	return &rawQuery{
+		sql:    sql,
+		params: params,
+	}
+}
+
+type rawQuery struct {
+	sql    string
+	params map[string]any
+}
+
+func (q *rawQuery) Build() (sql string, params map[string]any) {
+	return q.sql, q.params
+}
+
+func (q *rawQuery) String() string {
+	return q.sql
+}

--- a/contrib/surrealql/relate.go
+++ b/contrib/surrealql/relate.go
@@ -1,0 +1,68 @@
+package surrealql
+
+import "fmt"
+
+// RelateQuery represents a RELATE query
+type RelateQuery struct {
+	baseQuery
+	from         string
+	edge         string
+	to           string
+	content      map[string]any
+	returnClause string
+}
+
+// Relate starts a RELATE query
+func Relate(from, edge, to string) *RelateQuery {
+	return &RelateQuery{
+		baseQuery: newBaseQuery(),
+		from:      from,
+		edge:      edge,
+		to:        to,
+		content:   make(map[string]any),
+	}
+}
+
+// Set adds a field to the relation
+func (q *RelateQuery) Set(field string, value any) *RelateQuery {
+	q.content[field] = value
+	return q
+}
+
+// Content sets the entire content for the relation
+func (q *RelateQuery) Content(content map[string]any) *RelateQuery {
+	q.content = content
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *RelateQuery) Return(clause string) *RelateQuery {
+	q.returnClause = clause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *RelateQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *RelateQuery) String() string {
+	// Don't escape record IDs with colons, only escape the edge table name
+	sql := fmt.Sprintf("RELATE %s->%s->%s",
+		q.from,
+		escapeIdent(q.edge),
+		q.to)
+
+	if len(q.content) > 0 {
+		paramName := q.generateParamName("content")
+		q.addParam(paramName, q.content)
+		sql += fmt.Sprintf(" CONTENT $%s", paramName)
+	}
+
+	if q.returnClause != "" {
+		sql += " RETURN " + q.returnClause
+	}
+
+	return sql
+}

--- a/contrib/surrealql/relate_test.go
+++ b/contrib/surrealql/relate_test.go
@@ -1,0 +1,32 @@
+package surrealql
+
+import "testing"
+
+func TestRelate(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     Query
+		wantSurQL string
+	}{
+		{
+			name:      "simple relate",
+			query:     Relate("users:123", "likes", "posts:456"),
+			wantSurQL: "RELATE users:123->likes->posts:456",
+		},
+		{
+			name:      "relate with content",
+			query:     Relate("users:123", "likes", "posts:456").Set("rating", 5),
+			wantSurQL: "RELATE users:123->likes->posts:456 CONTENT $content_1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSurQL, _ := tt.query.Build()
+
+			if gotSurQL != tt.wantSurQL {
+				t.Errorf("SurrealQL mismatch\ngot:  %q\nwant: %q", gotSurQL, tt.wantSurQL)
+			}
+		})
+	}
+}

--- a/contrib/surrealql/select.go
+++ b/contrib/surrealql/select.go
@@ -1,0 +1,590 @@
+package surrealql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// SelectQuery represents a SELECT query builder
+type SelectQuery struct {
+	baseQuery
+	fields      []string
+	omits       []string
+	from        string
+	whereClause *whereBuilder
+	orderBy     []orderByClause
+	limitVal    *int
+	startVal    *int
+	fetchFields []string
+	groupBy     []string
+	splitFields []string
+	parallel    bool
+	explain     bool
+	// indicates if this query is a SELECT VALUE query
+	value        bool
+	returnClause string
+}
+
+// orderByClause represents an ORDER BY clause
+type orderByClause struct {
+	field   string
+	desc    bool
+	collate bool
+	numeric bool
+}
+
+// SelectValue creates a `SELECT VALUE field FROM ...` query.
+// It is used to select a single value per each record.
+func SelectValue[T selectField](field T) *SelectQuery {
+	bq := newBaseQuery()
+	fs := make([]string, 0, 1)
+
+	sql, vars := F(field).Build()
+	fs = append(fs, sql)
+	for k, v := range vars {
+		bq.addParam(k, v)
+	}
+
+	return &SelectQuery{
+		baseQuery: bq,
+		fields:    fs,
+		value:     true,
+	}
+}
+
+// Select creates a new SELECT query builder.
+func Select[T selectField](field T, fields ...T) *SelectQuery {
+	bq := newBaseQuery()
+	fs := make([]string, 0, len(fields)+1)
+
+	sql, vars := F(field).Build()
+	fs = append(fs, sql)
+	for k, v := range vars {
+		bq.addParam(k, v)
+	}
+
+	for _, field := range fields {
+		sql, vars := F(field).Build()
+		fs = append(fs, sql)
+		for k, v := range vars {
+			bq.addParam(k, v)
+		}
+	}
+
+	return &SelectQuery{
+		baseQuery: bq,
+		fields:    fs,
+	}
+}
+
+// Field adds a field to the SELECT query.
+func (q *SelectQuery) Field(field *field) *SelectQuery {
+	sql, vars := field.Build()
+	q.fields = append(q.fields, sql)
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+	return q
+}
+
+// FieldName adds a field to the SELECT query.
+func (q *SelectQuery) FieldName(field string) *SelectQuery {
+	q.fields = append(q.fields, escapeIdent(field))
+	return q
+}
+
+// FieldNameAs adds a field with an alias to the SELECT query.
+func (q *SelectQuery) FieldNameAs(field, alias string) *SelectQuery {
+	q.fields = append(q.fields, fmt.Sprintf("%s AS %s", escapeIdent(field), escapeIdent(alias)))
+	return q
+}
+
+// AddQuery adds another SelectQuery as a field to the current query.
+func (q *SelectQuery) FieldQueryAs(query *SelectQuery, alias string) *SelectQuery {
+	sql, vars := F(query).As(alias).Build()
+	q.fields = append(q.fields, sql)
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+	return q
+}
+
+// FieldFunCallAs adds a function call as a field to the SELECT query.
+func (q *SelectQuery) FieldFunCallAs(fun *FunCall, alias string) *SelectQuery {
+	sql, vars := F(fun).As(alias).Build()
+	q.fields = append(q.fields, sql)
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+	return q
+}
+
+// FieldRaw adds a raw field to the SELECT query without escaping.
+// This is useful for fields that should not be escaped, such as function calls.
+func (q *SelectQuery) FieldRaw(field string) *SelectQuery {
+	// Add raw field without escaping
+	q.fields = append(q.fields, field)
+	return q
+}
+
+// Omit removes a field from the SELECT query by specifying OMIT clause.
+// This is useful for excluding specific fields from the result set.
+// Valid only when `SELECT *` is used.
+func (q *SelectQuery) Omit(field string) *SelectQuery {
+	// Omit a field from the SELECT query
+	q.omits = append(q.omits, escapeIdent(field))
+	return q
+}
+
+// OmitRaw adds a raw OMIT clause to the SELECT query.
+// This allows specifying fields to omit without escaping.
+// This is useful for using destructuring syntax described in
+// https://surrealdb.com/docs/surrealql/statements/select#skip-certain-fields-using-the-omit-clause
+func (q *SelectQuery) OmitRaw(field string) *SelectQuery {
+	// Add raw OMIT clause without escaping
+	q.omits = append(q.omits, field)
+	return q
+}
+
+// FromTable sets the FROM clause of the query
+// The from parameter can be:
+// - A table name: "users"
+// - A specific record: "users:123"
+// - A RecordID string representation
+func (q *SelectQuery) FromTable(table string) *SelectQuery {
+	q.from = table
+	return q
+}
+
+// From sets the FROM clause using a target expression.
+// The target can be a table, or a specific record ID.
+func (q *SelectQuery) From(thing *target) *SelectQuery {
+	sql, vars := buildTargetExpr(thing)
+	q.from = sql
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+	return q
+}
+
+// FromQuery sets the FROM clause using another SelectQuery.
+// This allows using the result of another query as the source for this query.
+func (q *SelectQuery) FromQuery(query *SelectQuery) *SelectQuery {
+	sql, vars := query.Build()
+	q.from = fmt.Sprintf("(%s)", sql)
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+	return q
+}
+
+// FromRecordID sets the FROM clause using a RecordID
+func (q *SelectQuery) FromRecordID(recordID models.RecordID) *SelectQuery {
+	q.from = recordID.String()
+	return q
+}
+
+// Where adds a WHERE condition to the query.
+//
+// All values are automatically parameterized to prevent injection:
+//
+//	query := surrealql.Select().From("users").
+//	    Where("age > ? AND status = ?", 18, "active")
+//	// Generates: SELECT * FROM users WHERE age > $param_1 AND status = $param_2
+func (q *SelectQuery) Where(condition string, args ...any) *SelectQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition("AND", condition, args, &q.baseQuery)
+	return q
+}
+
+// WhereEq adds a WHERE equality condition
+func (q *SelectQuery) WhereEq(field string, value any) *SelectQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	paramName := q.generateParamName(field)
+	condition := fmt.Sprintf("%s = $%s", escapeIdent(field), paramName)
+	q.addParam(paramName, value)
+	q.whereClause.addRawCondition(condition)
+	return q
+}
+
+// WhereIn adds a WHERE IN condition
+func (q *SelectQuery) WhereIn(field string, values ...any) *SelectQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	if len(values) == 0 {
+		return q
+	}
+
+	paramName := q.generateParamName(field + "_in")
+	condition := fmt.Sprintf("%s IN $%s", escapeIdent(field), paramName)
+	q.addParam(paramName, values)
+	q.whereClause.addRawCondition(condition)
+	return q
+}
+
+// WhereNotNull adds a WHERE IS NOT NULL condition
+func (q *SelectQuery) WhereNotNull(field string) *SelectQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	condition := fmt.Sprintf("%s IS NOT NULL", escapeIdent(field))
+	q.whereClause.addRawCondition(condition)
+	return q
+}
+
+// WhereNull adds a WHERE IS NULL condition
+func (q *SelectQuery) WhereNull(field string) *SelectQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	condition := fmt.Sprintf("%s IS NULL", escapeIdent(field))
+	q.whereClause.addRawCondition(condition)
+	return q
+}
+
+// OrderBy adds an ORDER BY clause
+func (q *SelectQuery) OrderBy(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, desc: false})
+	return q
+}
+
+// OrderByCollate adds an ORDER BY COLLATE clause
+func (q *SelectQuery) OrderByCollate(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, collate: true})
+	return q
+}
+
+// OrderByNumeric adds an ORDER BY NUMERIC clause
+func (q *SelectQuery) OrderByNumeric(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, numeric: true})
+	return q
+}
+
+// OrderByCollateNumeric adds an ORDER BY COLLATE NUMERIC clause
+func (q *SelectQuery) OrderByCollateNumeric(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, collate: true, numeric: true})
+	return q
+}
+
+// OrderByDesc adds an ORDER BY DESC clause
+func (q *SelectQuery) OrderByDesc(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, desc: true})
+	return q
+}
+
+// OrderByCollateDesc adds an ORDER BY COLLATE DESC clause
+func (q *SelectQuery) OrderByCollateDesc(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, desc: true, collate: true})
+	return q
+}
+
+// OrderByNumericDesc adds an ORDER BY NUMERIC DESC clause
+func (q *SelectQuery) OrderByNumericDesc(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, desc: true, numeric: true})
+	return q
+}
+
+// OrderByCollateNumericDesc adds an ORDER BY COLLATE NUMERIC DESC clause
+func (q *SelectQuery) OrderByCollateNumericDesc(field string) *SelectQuery {
+	q.orderBy = append(q.orderBy, orderByClause{field: field, desc: true, collate: true, numeric: true})
+	return q
+}
+
+// Limit sets the LIMIT clause
+func (q *SelectQuery) Limit(limit int) *SelectQuery {
+	q.limitVal = &limit
+	return q
+}
+
+// Start sets the START clause
+func (q *SelectQuery) Start(start int) *SelectQuery {
+	q.startVal = &start
+	return q
+}
+
+// Fetch adds fields to fetch relationships
+func (q *SelectQuery) Fetch(fields ...string) *SelectQuery {
+	q.fetchFields = append(q.fetchFields, fields...)
+	return q
+}
+
+// GroupBy adds GROUP BY fields
+func (q *SelectQuery) GroupBy(fields ...string) *SelectQuery {
+	q.groupBy = append(q.groupBy, fields...)
+	return q
+}
+
+// GroupAll adds GROUP ALL clause for table-wide aggregation
+func (q *SelectQuery) GroupAll() *SelectQuery {
+	q.groupBy = []string{"ALL"}
+	return q
+}
+
+// Split adds SPLIT AT fields
+func (q *SelectQuery) Split(fields ...string) *SelectQuery {
+	q.splitFields = append(q.splitFields, fields...)
+	return q
+}
+
+// Parallel enables PARALLEL execution
+func (q *SelectQuery) Parallel() *SelectQuery {
+	q.parallel = true
+	return q
+}
+
+// Explain enables EXPLAIN mode
+func (q *SelectQuery) Explain() *SelectQuery {
+	q.explain = true
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *SelectQuery) Return(clause string) *SelectQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *SelectQuery) ReturnNone() *SelectQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *SelectQuery) ReturnDiff() *SelectQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// ReturnBefore sets RETURN BEFORE
+func (q *SelectQuery) ReturnBefore() *SelectQuery {
+	q.returnClause = ReturnBeforeClause
+	return q
+}
+
+// ReturnAfter sets RETURN AFTER
+func (q *SelectQuery) ReturnAfter() *SelectQuery {
+	q.returnClause = ReturnAfterClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters for the query
+func (q *SelectQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// buildSelectClause builds the SELECT clause
+func (q *SelectQuery) buildSelectClause() string {
+	if len(q.fields) == 0 {
+		return "SELECT *"
+	}
+
+	fields := make([]string, len(q.fields))
+	for i, field := range q.fields {
+		// Don't escape if it's *, contains parentheses (function call), or AS (alias)
+		if field == "*" || strings.Contains(field, "(") || strings.Contains(field, " AS ") {
+			fields[i] = field
+		} else {
+			fields[i] = escapeIdent(field)
+		}
+	}
+
+	base := "SELECT "
+
+	if q.value {
+		base += "VALUE "
+	}
+
+	base += strings.Join(fields, ", ")
+
+	if len(q.omits) > 0 {
+		return base + " OMIT " + strings.Join(q.omits, ", ")
+	}
+
+	return base
+}
+
+// buildGroupClause builds the GROUP BY clause
+func (q *SelectQuery) buildGroupClause() string {
+	if len(q.groupBy) == 0 {
+		return ""
+	}
+
+	if len(q.groupBy) == 1 && q.groupBy[0] == "ALL" {
+		return "GROUP ALL"
+	}
+
+	groupFields := make([]string, len(q.groupBy))
+	for i, field := range q.groupBy {
+		groupFields[i] = escapeIdent(field)
+	}
+	return "GROUP BY " + strings.Join(groupFields, ", ")
+}
+
+// buildOrderClause builds the ORDER BY clause
+func (q *SelectQuery) buildOrderClause() string {
+	if len(q.orderBy) == 0 {
+		return ""
+	}
+
+	orderClauses := make([]string, len(q.orderBy))
+	for i, order := range q.orderBy {
+		clause := escapeIdent(order.field)
+		if order.desc {
+			clause += " DESC"
+		}
+		orderClauses[i] = clause
+	}
+	return "ORDER BY " + strings.Join(orderClauses, ", ")
+}
+
+// buildSplitClause builds the SPLIT clause
+func (q *SelectQuery) buildSplitClause() string {
+	if len(q.splitFields) == 0 {
+		return ""
+	}
+
+	splitFields := make([]string, len(q.splitFields))
+	for i, field := range q.splitFields {
+		splitFields[i] = escapeIdent(field)
+	}
+	return "SPLIT AT " + strings.Join(splitFields, ", ")
+}
+
+// buildFetchClause builds the FETCH clause
+func (q *SelectQuery) buildFetchClause() string {
+	if len(q.fetchFields) == 0 {
+		return ""
+	}
+
+	fetchFields := make([]string, len(q.fetchFields))
+	for i, field := range q.fetchFields {
+		fetchFields[i] = escapeIdent(field)
+	}
+	return "FETCH " + strings.Join(fetchFields, ", ")
+}
+
+// String returns the SurrealQL string for the query
+func (q *SelectQuery) String() string {
+	var parts []string
+
+	// Add EXPLAIN if enabled
+	if q.explain {
+		parts = append(parts, "EXPLAIN")
+	}
+
+	// SELECT clause
+	parts = append(parts, q.buildSelectClause())
+
+	// FROM clause
+	if q.from != "" {
+		parts = append(parts, "FROM "+q.from)
+	}
+
+	// WHERE clause
+	if q.whereClause != nil && q.whereClause.hasConditions() {
+		parts = append(parts, "WHERE "+q.whereClause.build())
+	}
+
+	// SPLIT clause
+	if splitClause := q.buildSplitClause(); splitClause != "" {
+		parts = append(parts, splitClause)
+	}
+
+	// GROUP BY clause
+	if groupClause := q.buildGroupClause(); groupClause != "" {
+		parts = append(parts, groupClause)
+	}
+
+	// ORDER BY clause
+	if orderClause := q.buildOrderClause(); orderClause != "" {
+		parts = append(parts, orderClause)
+	}
+
+	// LIMIT clause
+	if q.limitVal != nil {
+		parts = append(parts, fmt.Sprintf("LIMIT %d", *q.limitVal))
+	}
+
+	// START clause
+	if q.startVal != nil {
+		parts = append(parts, fmt.Sprintf("START %d", *q.startVal))
+	}
+
+	// FETCH clause
+	if fetchClause := q.buildFetchClause(); fetchClause != "" {
+		parts = append(parts, fetchClause)
+	}
+
+	// PARALLEL clause
+	if q.parallel {
+		parts = append(parts, "PARALLEL")
+	}
+
+	// RETURN clause
+	if q.returnClause != "" {
+		parts = append(parts, "RETURN "+q.returnClause)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// whereBuilder helps build WHERE clauses
+type whereBuilder struct {
+	conditions []whereCondition
+}
+
+type whereCondition struct {
+	operator  string // AND or OR
+	condition string
+}
+
+func (w *whereBuilder) addCondition(operator, condition string, args []any, base *baseQuery) {
+	// Replace ? placeholders with named parameters
+	processedCondition := condition
+	for _, arg := range args {
+		paramName := base.generateParamName("param")
+		processedCondition = strings.Replace(processedCondition, "?", "$"+paramName, 1)
+		base.addParam(paramName, arg)
+	}
+
+	w.conditions = append(w.conditions, whereCondition{
+		operator:  operator,
+		condition: processedCondition,
+	})
+}
+
+func (w *whereBuilder) addRawCondition(condition string) {
+	w.conditions = append(w.conditions, whereCondition{
+		operator:  "AND",
+		condition: condition,
+	})
+}
+
+func (w *whereBuilder) hasConditions() bool {
+	return len(w.conditions) > 0
+}
+
+func (w *whereBuilder) build() string {
+	if len(w.conditions) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for i, cond := range w.conditions {
+		if i == 0 {
+			parts = append(parts, cond.condition)
+		} else {
+			parts = append(parts, cond.operator+" "+cond.condition)
+		}
+	}
+
+	return strings.Join(parts, " ")
+}

--- a/contrib/surrealql/select_test.go
+++ b/contrib/surrealql/select_test.go
@@ -1,0 +1,119 @@
+package surrealql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelect(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     Query
+		wantSurQL string
+		wantArgs  map[string]any
+	}{
+		{
+			name:      "simple select all",
+			query:     Select("*").FromTable("users"),
+			wantSurQL: "SELECT * FROM users",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select specific fields",
+			query:     Select("id", "name", "email").FromTable("users"),
+			wantSurQL: "SELECT id, name, email FROM users",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with where equals",
+			query:     Select("*").FromTable("users").WhereEq("active", true),
+			wantSurQL: "SELECT * FROM users WHERE active = $active_1",
+			wantArgs:  map[string]any{"active_1": true},
+		},
+		{
+			name:      "select with where in",
+			query:     Select("*").FromTable("users").WhereIn("status", "active", "pending"),
+			wantSurQL: "SELECT * FROM users WHERE status IN $status_in_1",
+			wantArgs:  map[string]any{"status_in_1": []any{"active", "pending"}},
+		},
+		{
+			name:      "select with order by",
+			query:     Select("*").FromTable("users").OrderBy("created_at"),
+			wantSurQL: "SELECT * FROM users ORDER BY created_at",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with order by desc",
+			query:     Select("*").FromTable("users").OrderByDesc("created_at"),
+			wantSurQL: "SELECT * FROM users ORDER BY created_at DESC",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with limit and start",
+			query:     Select("*").FromTable("users").Limit(10).Start(20),
+			wantSurQL: "SELECT * FROM users LIMIT 10 START 20",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with return none",
+			query:     Select("*").FromTable("users").ReturnNone(),
+			wantSurQL: "SELECT * FROM users RETURN NONE",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with group by",
+			query:     Select("category", "count() AS total").FromTable("products").GroupBy("category"),
+			wantSurQL: "SELECT category, count() AS total FROM products GROUP BY category",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with multiple where conditions",
+			query:     Select("*").FromTable("users").WhereEq("active", true).WhereNotNull("email"),
+			wantSurQL: "SELECT * FROM users WHERE active = $active_1 AND email IS NOT NULL",
+			wantArgs:  map[string]any{"active_1": true},
+		},
+		{
+			name:      "select with fetch",
+			query:     Select("*").FromTable("posts").Fetch("author", "comments"),
+			wantSurQL: "SELECT * FROM posts FETCH author, comments",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with parallel",
+			query:     Select("*").FromTable("users").Parallel(),
+			wantSurQL: "SELECT * FROM users PARALLEL",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with explain",
+			query:     Select("*").FromTable("users").Explain(),
+			wantSurQL: "EXPLAIN SELECT * FROM users",
+			wantArgs:  map[string]any{},
+		},
+		{
+			name:      "select with complex where",
+			query:     Select("*").FromTable("orders").Where("total > ? AND status = ?", 100, "pending"),
+			wantSurQL: "SELECT * FROM orders WHERE total > $param_1 AND status = $param_2",
+			wantArgs:  map[string]any{"param_1": 100, "param_2": "pending"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSurQL, gotArgs := tt.query.Build()
+
+			if gotSurQL != tt.wantSurQL {
+				t.Errorf("SurrealQL mismatch\ngot:  %q\nwant: %q", gotSurQL, tt.wantSurQL)
+			}
+
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Errorf("Args count mismatch\ngot:  %d\nwant: %d", len(gotArgs), len(tt.wantArgs))
+			}
+
+			for k, v := range tt.wantArgs {
+				assert.Equal(t, v, gotArgs[k], "Arg %q mismatch", k)
+			}
+		})
+	}
+}

--- a/contrib/surrealql/show.go
+++ b/contrib/surrealql/show.go
@@ -1,0 +1,73 @@
+package surrealql
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ShowChangesForTableQuery represents a SHOW CHANGES query
+type ShowChangesForTableQuery struct {
+	baseQuery
+	table string
+	since string
+	limit int
+}
+
+// ShowChangesForTable creates a new SHOW CHANGES query
+func ShowChangesForTable(table string) *ShowChangesForTableQuery {
+	return &ShowChangesForTableQuery{
+		baseQuery: newBaseQuery(),
+		table:     table,
+	}
+}
+
+// Since sets the starting point for showing changes
+// Can be either a timestamp (e.g., "d\"2023-09-07T01:23:52Z\"") or a version number (e.g., "0")
+func (q *ShowChangesForTableQuery) Since(since string) *ShowChangesForTableQuery {
+	q.since = since
+	return q
+}
+
+// SinceVersionstamp sets the starting point for showing changes using a versionstamp.
+func (q *ShowChangesForTableQuery) SinceVersionstamp(versionstamp uint64) *ShowChangesForTableQuery {
+	q.since = fmt.Sprintf("%d", versionstamp)
+	return q
+}
+
+// SinceTime sets the starting point for showing changes using a timestamp
+func (q *ShowChangesForTableQuery) SinceTime(since *time.Time) *ShowChangesForTableQuery {
+	q.since = fmt.Sprintf("d%q", since.Format(time.RFC3339))
+	return q
+}
+
+// Limit sets the maximum number of changes to return
+func (q *ShowChangesForTableQuery) Limit(limit int) *ShowChangesForTableQuery {
+	q.limit = limit
+	return q
+}
+
+// Build returns the SurrealQL string and parameters for the query
+func (q *ShowChangesForTableQuery) Build() (sql string, vars map[string]any) {
+	var builder strings.Builder
+
+	builder.WriteString("SHOW CHANGES FOR TABLE ")
+	builder.WriteString(escapeIdent(q.table))
+
+	if q.since != "" {
+		builder.WriteString(" SINCE ")
+		builder.WriteString(q.since)
+	}
+
+	if q.limit > 0 {
+		builder.WriteString(fmt.Sprintf(" LIMIT %d", q.limit))
+	}
+
+	return builder.String(), q.vars
+}
+
+// String returns the SurrealQL string for the query
+func (q *ShowChangesForTableQuery) String() string {
+	sql, _ := q.Build()
+	return sql
+}

--- a/contrib/surrealql/target.go
+++ b/contrib/surrealql/target.go
@@ -1,0 +1,70 @@
+package surrealql
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Thing creates a target for a SurrealQL query.
+func Thing(tb string, id any) *target {
+	return &target{table: tb, id: id}
+}
+
+// Table creates a target for a SurrealQL query with a specified table name.
+func Table(tb string) *target {
+	if tb == "" {
+		panic("table name cannot be empty")
+	}
+	return &target{table: tb}
+}
+
+// mutationTarget is an interface for targets in mutation queries like CREATE, UPDATE, DELETE, etc.
+type mutationTarget interface {
+	string | *target | *models.RecordID
+}
+
+// The `f` parameter needs to be targetType.
+// If not, it will panic.
+func buildTargetExpr(f any) (sql string, vars map[string]any) {
+	if f == nil {
+		return "*", nil // Default to selecting all fields
+	}
+
+	switch v := f.(type) {
+	case string:
+		return v, nil
+	case *target:
+		return v.Build()
+	case *models.RecordID:
+		return buildTarget(v.Table, v.ID)
+	default:
+		panic(fmt.Sprintf("unsupported select field type: %T", f))
+	}
+}
+
+// target represents a target in a SurrealQL query.
+// It appears as an item in @targets of `UPDATE @targets`,
+// `CREATE @targets`, `DELETE @targets`, `SELECT * FROM @target`, and so on.
+type target struct {
+	table string
+	id    any
+}
+
+func (t *target) Build() (sql string, vars map[string]any) {
+	return buildTarget(t.table, t.id)
+}
+
+func buildTarget(table string, id any) (sql string, vars map[string]any) {
+	if table == "" {
+		panic("target table cannot be empty")
+	}
+	var bq baseQuery
+	if id == nil {
+		tb := bq.generateParamName("tb")
+		return fmt.Sprintf("type::table($%s)", tb), map[string]any{tb: table}
+	}
+
+	idParam := bq.generateParamName("id")
+	return fmt.Sprintf("$%s", idParam), map[string]any{idParam: models.NewRecordID(table, id)}
+}

--- a/contrib/surrealql/transaction_query.go
+++ b/contrib/surrealql/transaction_query.go
@@ -1,0 +1,283 @@
+package surrealql
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TransactionQuery represents a transaction query with BEGIN/COMMIT statements
+type TransactionQuery struct {
+	baseQuery
+	statements []TransactionStatement
+}
+
+// TransactionStatement represents a statement that can be executed within a transaction
+type TransactionStatement interface {
+	build() string
+}
+
+// LetStatement represents a LET statement within a transaction
+type LetStatement struct {
+	variable string
+	dataType string
+	value    any
+}
+
+// IfStatement represents an IF statement within a transaction
+type IfStatement struct {
+	condition string
+	thenBlock []TransactionStatement
+	elseBlock []TransactionStatement
+}
+
+// ThrowStatement represents a THROW statement within a transaction
+type ThrowStatement struct {
+	err any
+}
+
+// RawStatement represents a raw SurrealQL statement within a transaction
+type RawStatement struct {
+	sql string
+}
+
+// QueryStatement wraps any Query to be used within a transaction
+type QueryStatement struct {
+	query Query
+}
+
+// Let adds a LET statement to the transaction
+func (t *TransactionQuery) Let(variable string, value any) *TransactionQuery {
+	if !strings.HasPrefix(variable, "$") {
+		variable = "$" + variable
+	}
+	t.statements = append(t.statements, &LetStatement{
+		variable: variable,
+		value:    value,
+	})
+	return t
+}
+
+// LetTyped adds a typed LET statement to the transaction
+func (t *TransactionQuery) LetTyped(variable, dataType string, value any) *TransactionQuery {
+	if !strings.HasPrefix(variable, "$") {
+		variable = "$" + variable
+	}
+	t.statements = append(t.statements, &LetStatement{
+		variable: variable,
+		dataType: dataType,
+		value:    value,
+	})
+	return t
+}
+
+// If adds an IF statement to the transaction
+func (t *TransactionQuery) If(condition string) *IfBuilder {
+	ifStmt := &IfStatement{
+		condition: condition,
+	}
+	return &IfBuilder{
+		transaction: t,
+		ifStatement: ifStmt,
+	}
+}
+
+// Throw adds a THROW statement to the transaction
+func (t *TransactionQuery) Throw(err any) *TransactionQuery {
+	t.statements = append(t.statements, &ThrowStatement{
+		err: err,
+	})
+	return t
+}
+
+// Raw adds a raw SurrealQL statement to the transaction
+func (t *TransactionQuery) Raw(sql string) *TransactionQuery {
+	t.statements = append(t.statements, &RawStatement{
+		sql: sql,
+	})
+	return t
+}
+
+// Query adds any Query to the transaction
+func (t *TransactionQuery) Query(query Query) *TransactionQuery {
+	t.statements = append(t.statements, &QueryStatement{
+		query: query,
+	})
+	return t
+}
+
+// Build returns the SurrealQL string and parameters for the transaction
+func (t *TransactionQuery) Build() (sql string, vars map[string]any) {
+	var builder strings.Builder
+
+	builder.WriteString("BEGIN TRANSACTION;\n")
+
+	for _, stmt := range t.statements {
+		builder.WriteString(stmt.build())
+		builder.WriteString(";\n")
+
+		// Merge parameters if this is a QueryStatement
+		if qs, ok := stmt.(*QueryStatement); ok {
+			_, vars := qs.query.Build()
+			for k, v := range vars {
+				t.vars[k] = v
+			}
+		}
+	}
+
+	builder.WriteString("COMMIT TRANSACTION;")
+
+	return builder.String(), t.vars
+}
+
+// String returns the SurrealQL string for the transaction
+func (t *TransactionQuery) String() string {
+	sql, _ := t.Build()
+	return sql
+}
+
+// IfBuilder helps build IF statements
+type IfBuilder struct {
+	transaction *TransactionQuery
+	ifStatement *IfStatement
+}
+
+// Then adds statements to the THEN block
+func (ib *IfBuilder) Then(fn func(*ThenBuilder)) *IfBuilder {
+	tb := &ThenBuilder{
+		statements: &ib.ifStatement.thenBlock,
+	}
+	fn(tb)
+	return ib
+}
+
+// Else adds statements to the ELSE block
+func (ib *IfBuilder) Else(fn func(*ElseBuilder)) *TransactionQuery {
+	eb := &ElseBuilder{
+		statements: &ib.ifStatement.elseBlock,
+	}
+	fn(eb)
+	ib.transaction.statements = append(ib.transaction.statements, ib.ifStatement)
+	return ib.transaction
+}
+
+// End completes the IF statement without an ELSE block
+func (ib *IfBuilder) End() *TransactionQuery {
+	ib.transaction.statements = append(ib.transaction.statements, ib.ifStatement)
+	return ib.transaction
+}
+
+// ThenBuilder helps build the THEN block of an IF statement
+type ThenBuilder struct {
+	statements *[]TransactionStatement
+}
+
+// Throw adds a THROW statement to the THEN block
+func (tb *ThenBuilder) Throw(err any) *ThenBuilder {
+	*tb.statements = append(*tb.statements, &ThrowStatement{
+		err: err,
+	})
+	return tb
+}
+
+// Raw adds a raw SurrealQL statement to the THEN block
+func (tb *ThenBuilder) Raw(sql string) *ThenBuilder {
+	*tb.statements = append(*tb.statements, &RawStatement{
+		sql: sql,
+	})
+	return tb
+}
+
+// ElseBuilder helps build the ELSE block of an IF statement
+type ElseBuilder struct {
+	statements *[]TransactionStatement
+}
+
+// Throw adds a THROW statement to the ELSE block
+func (eb *ElseBuilder) Throw(err any) *ElseBuilder {
+	*eb.statements = append(*eb.statements, &ThrowStatement{
+		err: err,
+	})
+	return eb
+}
+
+// Raw adds a raw SurrealQL statement to the ELSE block
+func (eb *ElseBuilder) Raw(sql string) *ElseBuilder {
+	*eb.statements = append(*eb.statements, &RawStatement{
+		sql: sql,
+	})
+	return eb
+}
+
+// Implementation of build methods for each statement type
+
+func (l *LetStatement) build() string {
+	var builder strings.Builder
+	builder.WriteString("LET ")
+	builder.WriteString(l.variable)
+
+	if l.dataType != "" {
+		builder.WriteString(": ")
+		builder.WriteString(l.dataType)
+	}
+
+	builder.WriteString(" = ")
+
+	switch v := l.value.(type) {
+	case string:
+		builder.WriteString(fmt.Sprintf("%q", v))
+	case Query:
+		sql, _ := v.Build()
+		builder.WriteString("(")
+		builder.WriteString(sql)
+		builder.WriteString(")")
+	default:
+		builder.WriteString(fmt.Sprintf("%v", v))
+	}
+
+	return builder.String()
+}
+
+func (i *IfStatement) build() string {
+	var builder strings.Builder
+	builder.WriteString("IF ")
+	builder.WriteString(i.condition)
+	builder.WriteString(" {\n")
+
+	for _, stmt := range i.thenBlock {
+		builder.WriteString("    ")
+		builder.WriteString(stmt.build())
+		builder.WriteString(";\n")
+	}
+
+	builder.WriteString("}")
+
+	if len(i.elseBlock) > 0 {
+		builder.WriteString(" ELSE {\n")
+		for _, stmt := range i.elseBlock {
+			builder.WriteString("    ")
+			builder.WriteString(stmt.build())
+			builder.WriteString(";\n")
+		}
+		builder.WriteString("}")
+	}
+
+	return builder.String()
+}
+
+func (t *ThrowStatement) build() string {
+	switch v := t.err.(type) {
+	case string:
+		return fmt.Sprintf("THROW %q", v)
+	default:
+		return fmt.Sprintf("THROW %v", v)
+	}
+}
+
+func (r *RawStatement) build() string {
+	return strings.TrimRight(r.sql, ";")
+}
+
+func (q *QueryStatement) build() string {
+	sql, _ := q.query.Build()
+	return strings.TrimRight(sql, ";")
+}

--- a/contrib/surrealql/update.go
+++ b/contrib/surrealql/update.go
@@ -1,0 +1,127 @@
+package surrealql
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// UpdateQuery represents an UPDATE query
+type UpdateQuery struct {
+	baseQuery
+	targets      []string
+	sets         map[string]any
+	whereClause  *whereBuilder
+	returnClause string
+}
+
+// Update starts an UPDATE query
+func Update[T mutationTarget](target T, targets ...T) *UpdateQuery {
+	q := &UpdateQuery{
+		baseQuery: newBaseQuery(),
+		targets:   nil,
+		sets:      make(map[string]any),
+	}
+
+	updateAddTarget(q, target)
+	for _, t := range targets {
+		updateAddTarget(q, t)
+	}
+
+	return q
+}
+
+func updateAddTarget[MT mutationTarget](q *UpdateQuery, target MT) *UpdateQuery {
+	sql, vars := buildTargetExpr(target)
+	q.targets = append(q.targets, sql)
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+	return q
+}
+
+// Set adds a field to update
+func (q *UpdateQuery) Set(field string, value any) *UpdateQuery {
+	q.sets[field] = value
+	return q
+}
+
+// SetMap sets multiple fields from a map
+func (q *UpdateQuery) SetMap(fields map[string]any) *UpdateQuery {
+	for k, v := range fields {
+		q.sets[k] = v
+	}
+	return q
+}
+
+// Where adds a WHERE condition
+func (q *UpdateQuery) Where(condition string, args ...any) *UpdateQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition("AND", condition, args, &q.baseQuery)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *UpdateQuery) Return(clause string) *UpdateQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *UpdateQuery) ReturnNone() *UpdateQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *UpdateQuery) ReturnDiff() *UpdateQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *UpdateQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *UpdateQuery) String() string {
+	sql := ""
+
+	for _, t := range q.targets {
+		if sql != "" {
+			sql += ", "
+		}
+		sql += t
+	}
+
+	sql = fmt.Sprintf("UPDATE %s", sql)
+
+	if len(q.sets) > 0 {
+		setsKeys := sort.StringSlice(slices.Collect(maps.Keys(q.sets)))
+		sort.Stable(setsKeys)
+
+		var setParts []string
+		for _, field := range setsKeys {
+			value := q.sets[field]
+			paramName := q.generateParamName(field)
+			q.addParam(paramName, value)
+			setParts = append(setParts, fmt.Sprintf("%s = $%s", escapeIdent(field), paramName))
+		}
+		sql += " SET " + strings.Join(setParts, ", ")
+	}
+
+	if q.whereClause != nil && q.whereClause.hasConditions() {
+		sql += " WHERE " + q.whereClause.build()
+	}
+
+	if q.returnClause != "" {
+		sql += " RETURN " + q.returnClause
+	}
+
+	return sql
+}

--- a/contrib/surrealql/update_test.go
+++ b/contrib/surrealql/update_test.go
@@ -1,0 +1,42 @@
+package surrealql
+
+import "testing"
+
+func TestUpdate(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     Query
+		wantSurQL string
+	}{
+		{
+			name:      "update all with set",
+			query:     Update("users").Set("active", false),
+			wantSurQL: "UPDATE users SET active = $active_1",
+		},
+		{
+			name:      "update specific record",
+			query:     Update("users:123").Set("name", "Jane"),
+			wantSurQL: "UPDATE users:123 SET name = $name_1",
+		},
+		{
+			name:      "update with where",
+			query:     Update("users").Set("active", false).Where("last_login < ?", "2024-01-01"),
+			wantSurQL: "UPDATE users SET active = $active_1 WHERE last_login < $param_1",
+		},
+		{
+			name:      "update with return diff",
+			query:     Update("users").Set("name", "Jane").ReturnDiff(),
+			wantSurQL: "UPDATE users SET name = $name_1 RETURN DIFF",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSurQL, _ := tt.query.Build()
+
+			if gotSurQL != tt.wantSurQL {
+				t.Errorf("SurrealQL mismatch\ngot:  %q\nwant: %q", gotSurQL, tt.wantSurQL)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/surrealdb/surrealdb.go
 
-go 1.22
+go 1.23
 
 require (
 	github.com/fxamacker/cbor/v2 v2.7.0


### PR DESCRIPTION
This attempts to address #151 and #189 with the new `contrib/surrealql` package, which is a mostly type-safe way to build `sql` and `vars` parameters passed to the `surrealdb.Query` function.

I don't know who wants to review a 5k lines change, but to summarize:

- This is an output of my entire week effort to address those two issues.
- This has three types of tests, unit tests, integration tests (with local surreadb), and testable examples(unit and integration).
- The testable examples are important because I consider them as part of the documentation. 

## Example Usage

There are two ways to use this library: one with less type-safety and one with more.

Here's my preferred and recommended usage, the one with more type-safety, for the select builder, from `example_select_test.go`:

```go
func ExampleSelect_withF_query() {
	// Select users and their orders
	query := surrealql.Select(
		surrealql.F("id"),
		surrealql.F("name"),
		surrealql.F(
			// $parent is a predefined variable.
			// See https://surrealdb.com/docs/surrealql/statements/select#using-parameters
			surrealql.Select("id", "total").FromTable("orders").Where("user_id = $parent.id"),
		).As("orders"),
	).FromTable("users").
		WhereEq("active", true).
		OrderBy("created_at").
		Limit(5)

	sql, vars := query.Build()
	fmt.Println("SurrealQL:", sql)
	fmt.Printf("Vars: %v\n", vars)
	// Output:
	// SurrealQL: SELECT id, name, (SELECT id, total FROM orders WHERE user_id = $parent.id) AS orders FROM users WHERE active = $active_1 ORDER BY created_at LIMIT 5
	// Vars: map[active_1:true]
}
```

## SELECT, INSERT, CREATE, DELETE, and RELATE

I've implemented builders for those statements, as I believe they cover 90% of use cases.

SELECT, INSERT, CREATE, and DELETE received more effort from me.

RELATE is less loved, but I will try to enhance it to be on par with other builders in upcoming releases.

## COUNT

I have `surrealql.Count` and `surrealql.CountByGroup` to directly address #189, but I honestly think it's a bad abstraction. You should use SELECT with some fields and counts, as you often need counts along with other fields, not just counts as mentioned in #151. That's why `surrealql.Count` and `surrealql.CountByGroup` are marked as deprecated already 😃 

## Future Plan

I will also try to implement a builder for UPSERT in upcoming releases too, becaue I believe it serves 9% of the use cases.

But it's not now- This is already too big.

