### PR TITLE
SurrealQL query builder: UPSERT support

### DIFF
--- a/contrib/surrealql/delete.go
+++ b/contrib/surrealql/delete.go
@@ -35,7 +35,7 @@ func (q *DeleteQuery) Where(condition string, args ...any) *DeleteQuery {
 	if q.whereClause == nil {
 		q.whereClause = &whereBuilder{}
 	}
-	q.whereClause.addCondition("AND", condition, args, &q.baseQuery)
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
 	return q
 }
 

--- a/contrib/surrealql/example_upsert_test.go
+++ b/contrib/surrealql/example_upsert_test.go
@@ -1,0 +1,441 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleUpsert_noContent() {
+	// UPSERT without data modification - creates record if it doesn't exist
+	sql, vars := surrealql.Upsert("foo:1").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT foo:1
+	// Variables: map[]
+}
+
+func ExampleUpsert_noContent_multiple() {
+	// UPSERT multiple records without data modification
+	sql, vars := surrealql.Upsert("foo:2", "foo:3").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT foo:2, foo:3
+	// Variables: map[]
+}
+
+func ExampleUpsert_set() {
+	// Basic UPSERT with SET
+	sql, vars := surrealql.Upsert("product:laptop").
+		Set("name", "Laptop Pro").
+		Set("price", 1299).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:laptop SET name = $upsert_name_1, price = $upsert_price_1
+	// Variables: map[upsert_name_1:Laptop Pro upsert_price_1:1299]
+}
+
+func ExampleUpsert_content_returnAfter() {
+	// UPSERT with CONTENT and RETURN AFTER
+	sql, vars := surrealql.Upsert("product:tablet").
+		Content(map[string]any{
+			"name":  "Tablet Pro",
+			"price": 899,
+		}).
+		ReturnAfter().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:tablet CONTENT $upsert_content_1 RETURN AFTER
+	// Variables: map[upsert_content_1:map[name:Tablet Pro price:899]]
+}
+
+func ExampleUpsert_content() {
+	// UPSERT with CONTENT
+	sql, vars := surrealql.Upsert("product:phone").
+		Content(map[string]any{
+			"name":     "Smartphone X",
+			"price":    799,
+			"features": []string{"5G", "OLED", "Wireless Charging"},
+		}).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:phone CONTENT $upsert_content_1
+	// Variables: map[upsert_content_1:map[features:[5G OLED Wireless Charging] name:Smartphone X price:799]]
+}
+
+func ExampleUpsert_merge() {
+	// UPSERT with MERGE - updates specific fields
+	sql, vars := surrealql.Upsert("product:headphones").
+		Merge(map[string]any{
+			"colors": []string{"Black", "White"},
+		}).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:headphones MERGE $upsert_merge_1
+	// Variables: map[upsert_merge_1:map[colors:[Black White]]]
+}
+
+func ExampleUpsert_merge_returnDiff() {
+	// UPSERT with MERGE and RETURN DIFF - shows changes
+	sql, vars := surrealql.Upsert("product:watch").
+		Merge(map[string]any{
+			"available":  true,
+			"updated_at": "2023-01-01",
+		}).
+		ReturnDiff().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:watch MERGE $upsert_merge_1 RETURN DIFF
+	// Variables: map[upsert_merge_1:map[available:true updated_at:2023-01-01]]
+}
+
+func ExampleUpsert_patch() {
+	// UPSERT with JSON Patch operations
+	sql, vars := surrealql.Upsert("product:keyboard").
+		Patch([]surrealql.PatchOp{
+			// Note that `/features/-` appends to the array because
+			// the `-` at the end of the path refers to the end of the array.
+			// See https://jsonpatch.com/#json-pointer
+			{Op: "add", Path: "/features/-", Value: "RGB Lighting"},
+			{Op: "replace", Path: "/price", Value: 149},
+		}).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:keyboard PATCH $upsert_patch_1
+	// Variables: map[upsert_patch_1:[{add /features/- RGB Lighting} {replace /price 149}]]
+}
+
+func ExampleUpsert_patch_returnBefore() {
+	// UPSERT with PATCH and RETURN BEFORE - returns record before changes
+	sql, vars := surrealql.Upsert("product:mouse").
+		Patch([]surrealql.PatchOp{
+			{Op: "remove", Path: "/deprecated"},
+			{Op: "add", Path: "/warranty", Value: true},
+		}).
+		ReturnBefore().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:mouse PATCH $upsert_patch_1 RETURN BEFORE
+	// Variables: map[upsert_patch_1:[{remove /deprecated <nil>} {add /warranty true}]]
+}
+
+func ExampleUpsert_replace_returnFields() {
+	// UPSERT with REPLACE and RETURN specific fields
+	sql, vars := surrealql.Upsert("product:monitor").
+		Replace(map[string]any{
+			"name":     "Ultra Monitor",
+			"price":    599,
+			"category": "displays",
+			"specs":    "4K HDR",
+		}).
+		Return("id, name, category").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:monitor REPLACE $upsert_replace_1 RETURN id, name, category
+	// Variables: map[upsert_replace_1:map[category:displays name:Ultra Monitor price:599 specs:4K HDR]]
+}
+
+func ExampleUpsert_withConditions() {
+	// UPSERT with WHERE condition and RETURN clause
+	sql, vars := surrealql.Upsert("product:speaker").
+		Set("last_updated", "2024-01-01T00:00:00Z").
+		Set("status", "in_stock").
+		Where("price >= ?", 100).
+		ReturnDiff().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:speaker SET last_updated = $upsert_last_updated_1, status = $upsert_status_1 WHERE price >= $param_1 RETURN DIFF
+	// Variables: map[param_1:100 upsert_last_updated_1:2024-01-01T00:00:00Z upsert_status_1:in_stock]
+}
+
+func ExampleUpsertOnly() {
+	// UPSERT ONLY returns a single record instead of an array
+	sql, vars := surrealql.UpsertOnly("product:charger").
+		Set("name", "Fast Charger").
+		Set("available", true).
+		ReturnAfter().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT ONLY product:charger SET available = $upsert_available_1, name = $upsert_name_1 RETURN AFTER
+	// Variables: map[upsert_available_1:true upsert_name_1:Fast Charger]
+}
+
+func ExampleUpsert_unset() {
+	// UPSERT with UNSET to remove fields
+	sql, vars := surrealql.Upsert("product:cable").
+		Set("name", "USB Cable").
+		Unset("deprecated_field", "legacy_data").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:cable SET name = $upsert_name_1, UNSET deprecated_field, legacy_data
+	// Variables: map[upsert_name_1:USB Cable]
+}
+
+func ExampleUpsert_returnNone() {
+	// UPSERT with RETURN NONE - no data returned, improves performance
+	sql, vars := surrealql.Upsert("product:adapter").
+		Set("processed", true).
+		ReturnNone().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:adapter SET processed = $upsert_processed_1 RETURN NONE
+	// Variables: map[upsert_processed_1:true]
+}
+
+func ExampleUpsert_returnAfter() {
+	// UPSERT with RETURN AFTER (default) - returns the record after changes
+	sql, vars := surrealql.Upsert("product:desk").
+		Set("name", "Standing Desk").
+		Set("price", 450).
+		ReturnAfter().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:desk SET name = $upsert_name_1, price = $upsert_price_1 RETURN AFTER
+	// Variables: map[upsert_name_1:Standing Desk upsert_price_1:450]
+}
+
+func ExampleUpsert_returnBefore() {
+	// UPSERT with RETURN BEFORE - returns the record before changes
+	sql, vars := surrealql.Upsert("product:chair").
+		Set("name", "Office Chair").
+		Set("price", 250).
+		ReturnBefore().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:chair SET name = $upsert_name_1, price = $upsert_price_1 RETURN BEFORE
+	// Variables: map[upsert_name_1:Office Chair upsert_price_1:250]
+}
+
+func ExampleUpsert_returnDiff() {
+	// UPSERT with RETURN DIFF - returns the differences before and after
+	sql, vars := surrealql.Upsert("product:lamp").
+		Set("name", "LED Lamp").
+		Set("price", 75).
+		ReturnDiff().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:lamp SET name = $upsert_name_1, price = $upsert_price_1 RETURN DIFF
+	// Variables: map[upsert_name_1:LED Lamp upsert_price_1:75]
+}
+
+func ExampleUpsert_returnFields() {
+	// UPSERT with RETURN specific fields - returns only specified fields
+	sql, vars := surrealql.Upsert("product:webcam").
+		Set("name", "HD Webcam").
+		Set("price", 120).
+		Set("resolution", "1080p").
+		Return("name, price").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:webcam SET name = $upsert_name_1, price = $upsert_price_1, resolution = $upsert_resolution_1 RETURN name, price
+	// Variables: map[upsert_name_1:HD Webcam upsert_price_1:120 upsert_resolution_1:1080p]
+}
+
+func ExampleUpsert_performance() {
+	// UPSERT with performance optimizations using TIMEOUT and PARALLEL
+	sql, vars := surrealql.Upsert("product:microphone").
+		Set("processed", true).
+		Timeout("5s").
+		Parallel().
+		ReturnNone().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:microphone SET processed = $upsert_processed_1 RETURN NONE TIMEOUT 5s PARALLEL
+	// Variables: map[upsert_processed_1:true]
+}
+
+func ExampleUpsert_setRaw() {
+	// UPSERT with raw SET expressions for compound operations (deprecated - use Set instead)
+	sql, vars := surrealql.Upsert("product:book").
+		SetRaw("tags += 'bestseller'").
+		SetRaw("view_count += 1").
+		Set("last_viewed", "2024-01-01T00:00:00Z").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:book SET last_viewed = $upsert_last_viewed_1, tags += 'bestseller', view_count += 1
+	// Variables: map[upsert_last_viewed_1:2024-01-01T00:00:00Z]
+}
+
+func ExampleUpsert_setCompound() {
+	// UPSERT with compound operations using the unified Set function
+	sql, vars := surrealql.Upsert("product:book").
+		Set("tags += ?", "bestseller").
+		Set("view_count += ?", 1).
+		Set("last_viewed", "2024-01-01T00:00:00Z").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:book SET last_viewed = $upsert_last_viewed_1, tags += $upsert_param_1, view_count += $upsert_param_2
+	// Variables: map[upsert_last_viewed_1:2024-01-01T00:00:00Z upsert_param_1:bestseller upsert_param_2:1]
+}
+
+func ExampleUpsert_setRaw_arrayOperations() {
+	// UPSERT with various raw SET expressions for array and numeric operations
+	sql, vars := surrealql.Upsert("product:laptop").
+		SetRaw("categories += ['electronics', 'computers']").
+		SetRaw("stock -= 1").
+		SetRaw("sales_count += 1").
+		Set("available", true).
+		ReturnAfter().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:laptop SET available = $upsert_available_1, categories += ['electronics', 'computers'], stock -= 1, sales_count += 1 RETURN AFTER
+	// Variables: map[upsert_available_1:true]
+}
+
+func ExampleUpsert_setWithTime() {
+	// UPSERT with time.Time values using the unified Set function
+	lastViewed := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	sql, vars := surrealql.Upsert("product:watch").
+		Set("name", "Smart Watch Pro").
+		Set("price", 299.99).
+		Set("last_viewed", lastViewed).
+		Set("view_count += ?", 1).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:watch SET last_viewed = $upsert_last_viewed_1, name = $upsert_name_1, price = $upsert_price_1, view_count += $upsert_param_1
+	// Variables: map[upsert_last_viewed_1:2024-01-15 10:30:00 +0000 UTC upsert_name_1:Smart Watch Pro upsert_param_1:1 upsert_price_1:299.99]
+}
+
+func ExampleUpsert_set_arrayOperations() {
+	// UPSERT with array and numeric operations using the unified Set function
+	sql, vars := surrealql.Upsert("product:laptop").
+		Set("categories += ?", []string{"electronics", "computers"}).
+		Set("stock -= ?", 1).
+		Set("sales_count += ?", 1).
+		Set("available", true).
+		ReturnAfter().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:laptop SET available = $upsert_available_1, categories += $upsert_param_1, stock -= $upsert_param_2, sales_count += $upsert_param_3 RETURN AFTER
+	// Variables: map[upsert_available_1:true upsert_param_1:[electronics computers] upsert_param_2:1 upsert_param_3:1]
+}
+
+func ExampleUpsert_set_mixed() {
+	// UPSERT with mixed operations showing the flexibility of the unified Set function
+	createdAt := time.Date(2024, 1, 20, 15, 30, 0, 0, time.UTC)
+
+	sql, vars := surrealql.Upsert("product:smartphone").
+		Set("name", "Latest Phone").                // Simple string assignment
+		Set("price", 899.99).                       // Simple numeric assignment
+		Set("in_stock", true).                      // Simple boolean assignment
+		Set("created_at", createdAt).               // Simple time.Time assignment
+		Set("tags += ?", "flagship").               // Append single value to array
+		Set("features += ?", []string{"5G", "AI"}). // Append multiple values to array
+		Set("view_count += ?", 1).                  // Increment counter
+		Set("discount_percentage", 10).             // Simple assignment
+		Where("stock > ?", 0).                      // Only update if in stock
+		ReturnAfter().
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:smartphone SET created_at = $upsert_created_at_1, discount_percentage = $upsert_discount_percentage_1, in_stock = $upsert_in_stock_1, name = $upsert_name_1, price = $upsert_price_1, tags += $upsert_param_1, features += $upsert_param_2, view_count += $upsert_param_3 WHERE stock > $param_1 RETURN AFTER
+	// Variables: map[param_1:0 upsert_created_at_1:2024-01-20 15:30:00 +0000 UTC upsert_discount_percentage_1:10 upsert_in_stock_1:true upsert_name_1:Latest Phone upsert_param_1:flagship upsert_param_2:[5G AI] upsert_param_3:1 upsert_price_1:899.99]
+}
+
+func ExampleUpsert_returnValue() {
+	// UPSERT with RETURN VALUE - returns just the field value, not the whole record
+	sql, vars := surrealql.Upsert("product:counter").
+		Set("view_count += ?", 1).
+		ReturnValue("view_count").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:counter SET view_count += $upsert_param_1 RETURN VALUE view_count
+	// Variables: map[upsert_param_1:1]
+}
+
+func ExampleUpsert_returnValue_withContent() {
+	// UPSERT CONTENT with RETURN VALUE - returns just the specified field value
+	sql, vars := surrealql.Upsert("product:item123").
+		Content(map[string]any{
+			"name":  "New Product",
+			"price": 99.99,
+			"stock": 100,
+		}).
+		ReturnValue("price").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPSERT product:item123 CONTENT $upsert_content_1 RETURN VALUE price
+	// Variables: map[upsert_content_1:map[name:New Product price:99.99 stock:100]]
+}

--- a/contrib/surrealql/integration_upsert_test.go
+++ b/contrib/surrealql/integration_upsert_test.go
@@ -1,0 +1,352 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+)
+
+func TestIntegration_UpsertSet(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_set", "product")
+	ctx := context.Background()
+
+	t.Run("creates new record", func(t *testing.T) {
+		// UPSERT with SET
+		sql, vars := surrealql.Upsert("product:upsert_test1").
+			Set("name", "Test Product").
+			Set("price", 99).
+			ReturnAfter().
+			Build()
+
+		resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Len(t, *resp, 1)
+
+		// Verify the record was created
+		products := (*resp)[0].Result
+		require.Len(t, products, 1)
+		assert.Equal(t, "Test Product", products[0]["name"])
+		assert.EqualValues(t, 99, products[0]["price"])
+	})
+
+	t.Run("updates existing record", func(t *testing.T) {
+		// First, create a record
+		_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test2 SET name = 'Original', price = 50", nil)
+		require.NoError(t, err)
+
+		// UPSERT to update it
+		sql, vars := surrealql.Upsert("product:upsert_test2").
+			Set("name", "Updated").
+			Set("price", 75).
+			ReturnAfter().
+			Build()
+
+		resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+		require.NoError(t, err)
+
+		// Verify the record was updated
+		products := (*resp)[0].Result
+		require.Len(t, products, 1)
+		assert.Equal(t, "Updated", products[0]["name"])
+		assert.EqualValues(t, 75, products[0]["price"])
+	})
+}
+
+func TestIntegration_UpsertContent(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_content", "product")
+	ctx := context.Background()
+
+	// UPSERT with CONTENT
+	sql, vars := surrealql.Upsert("product:upsert_test3").
+		Content(map[string]any{
+			"name":      "Content Product",
+			"price":     199,
+			"category":  "electronics",
+			"available": true,
+		}).
+		ReturnAfter().
+		Build()
+
+	resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// Verify the record
+	products := (*resp)[0].Result
+	require.Len(t, products, 1)
+	assert.Equal(t, "Content Product", products[0]["name"])
+	assert.EqualValues(t, 199, products[0]["price"])
+	assert.Equal(t, "electronics", products[0]["category"])
+	assert.Equal(t, true, products[0]["available"])
+}
+
+func TestIntegration_UpsertMerge(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_merge", "product")
+	ctx := context.Background()
+
+	// First, create a record with initial data
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test4 SET name = 'Merge Product', price = 150, brand = 'TechCorp'", nil)
+	require.NoError(t, err)
+
+	// UPSERT with MERGE to add/update fields
+	sql, vars := surrealql.Upsert("product:upsert_test4").
+		Merge(map[string]any{
+			"price":    175,       // Update existing field
+			"warranty": "2 years", // Add new field
+		}).
+		ReturnAfter().
+		Build()
+
+	resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// Verify the merge
+	products := (*resp)[0].Result
+	require.Len(t, products, 1)
+	assert.Equal(t, "Merge Product", products[0]["name"]) // Original field preserved
+	assert.EqualValues(t, 175, products[0]["price"])      // Updated field
+	assert.Equal(t, "TechCorp", products[0]["brand"])     // Original field preserved
+	assert.Equal(t, "2 years", products[0]["warranty"])   // New field added
+}
+
+func TestIntegration_UpsertWhere(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_where", "product")
+	ctx := context.Background()
+
+	// Create a record
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test5 SET name = 'Premium Item', price = 500", nil)
+	require.NoError(t, err)
+
+	// UPSERT with condition that matches
+	sql, vars := surrealql.Upsert("product:upsert_test5").
+		Set("tier", "premium").
+		Where("price >= ?", 500).
+		ReturnAfter().
+		Build()
+
+	resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	products := (*resp)[0].Result
+	require.Len(t, products, 1)
+	assert.Equal(t, "premium", products[0]["tier"])
+
+	// UPSERT with condition that doesn't match
+	sql, vars = surrealql.Upsert("product:upsert_test5").
+		Set("tier", "budget").
+		Where("price < ?", 100).
+		ReturnAfter().
+		Build()
+
+	resp, err = surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// When the WHERE condition doesn't match, UPSERT returns empty results
+	products = (*resp)[0].Result
+	require.Len(t, products, 0) // No records returned when WHERE doesn't match
+
+	// Verify the record wasn't updated by querying it directly
+	verifyResp, err := surrealdb.Query[[]map[string]any](ctx, db, "SELECT * FROM product:upsert_test5", nil)
+	require.NoError(t, err)
+	verifyProducts := (*verifyResp)[0].Result
+	require.Len(t, verifyProducts, 1)
+	assert.Equal(t, "premium", verifyProducts[0]["tier"]) // Tier unchanged
+}
+
+func TestIntegration_UpsertOnly(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_only", "product")
+	ctx := context.Background()
+
+	// UPSERT ONLY
+	sql, vars := surrealql.UpsertOnly("product:upsert_test6").
+		Set("name", "Single Product").
+		Set("type", "unique").
+		Build()
+
+	// Note: ONLY returns a single record, not wrapped in an array
+	resp, err := surrealdb.Query[map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// Should return a single record
+	product := (*resp)[0].Result
+	assert.Equal(t, "Single Product", product["name"])
+	assert.Equal(t, "unique", product["type"])
+}
+
+func TestIntegration_UpsertReturnNone(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_return_none", "product")
+	ctx := context.Background()
+
+	// UPSERT with RETURN NONE
+	sql, vars := surrealql.Upsert("product:upsert_test7").
+		Set("name", "No Return Product").
+		ReturnNone().
+		Build()
+
+	resp, err := surrealdb.Query[[]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// With RETURN NONE, the result should be empty
+	if len(*resp) > 0 && (*resp)[0].Result != nil {
+		result := (*resp)[0].Result
+		assert.Empty(t, result)
+	}
+}
+
+func TestIntegration_UpsertReturnDiff(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_return_diff", "product")
+	ctx := context.Background()
+
+	// First create a record
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test8 SET name = 'Original Product', price = 250", nil)
+	require.NoError(t, err)
+
+	// UPSERT with RETURN DIFF
+	sql, vars := surrealql.Upsert("product:upsert_test8").
+		Set("name", "Modified Product").
+		Set("price", 299).
+		Set("new_field", "added").
+		ReturnDiff().
+		Build()
+
+	resp, err := surrealdb.Query[[]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// The diff should show changes
+	// The exact format of DIFF depends on SurrealDB's implementation
+	require.NotNil(t, resp)
+}
+
+func TestIntegration_UpsertSetRaw(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_setraw", "product")
+	ctx := context.Background()
+
+	// First create a record with initial values
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test9 SET name = 'Counter Product', views = 100, tags = ['new']", nil)
+	require.NoError(t, err)
+
+	// UPSERT with SetRaw for compound operations
+	sql, vars := surrealql.Upsert("product:upsert_test9").
+		SetRaw("views += 1").
+		SetRaw("tags += 'popular'").
+		Set("last_viewed", "2024-01-01").
+		ReturnAfter().
+		Build()
+
+	resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// Verify the updates
+	products := (*resp)[0].Result
+	require.Len(t, products, 1)
+
+	product := products[0]
+	assert.Equal(t, "Counter Product", product["name"])
+	assert.EqualValues(t, 101, product["views"]) // Should be incremented
+	assert.Equal(t, "2024-01-01", product["last_viewed"])
+
+	// Check that tags array contains both original and new tag
+	tags, ok := product["tags"].([]any)
+	if ok {
+		assert.Contains(t, tags, "new")
+		assert.Contains(t, tags, "popular")
+	}
+}
+
+func TestIntegration_UpsertUnifiedSet(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_unified", "product")
+	ctx := context.Background()
+
+	// First create a record with initial values
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test10 SET name = 'Unified Product', stock = 50, price = 100", nil)
+	require.NoError(t, err)
+
+	// UPSERT with unified Set for both simple and compound operations
+	sql, vars := surrealql.Upsert("product:upsert_test10").
+		Set("name", "Updated Product").               // Simple assignment
+		Set("stock -= ?", 5).                         // Compound operation with parameter
+		Set("price += ?", 20).                        // Add to price
+		Set("last_modified", "2024-01-15T10:00:00Z"). // Simple assignment
+		ReturnAfter().
+		Build()
+
+	resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// Verify the updates
+	products := (*resp)[0].Result
+	require.Len(t, products, 1)
+
+	product := products[0]
+	assert.Equal(t, "Updated Product", product["name"])
+	assert.EqualValues(t, 45, product["stock"])  // 50 - 5
+	assert.EqualValues(t, 120, product["price"]) // 100 + 20
+	assert.Equal(t, "2024-01-15T10:00:00Z", product["last_modified"])
+}
+
+func TestIntegration_UpsertSetArrayOperations(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_arrays", "product")
+	ctx := context.Background()
+
+	// First create a record with initial array values
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test11 SET name = 'Array Product', tags = ['new'], stock = 10", nil)
+	require.NoError(t, err)
+
+	// UPSERT with unified Set for array operations
+	sql, vars := surrealql.Upsert("product:upsert_test11").
+		Set("tags += ?", []string{"featured", "sale"}). // Append multiple tags
+		Set("stock -= ?", 2).                           // Decrement stock
+		Set("last_updated", "2024-01-20").              // Simple assignment
+		ReturnAfter().
+		Build()
+
+	resp, err := surrealdb.Query[[]map[string]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// Verify the updates
+	products := (*resp)[0].Result
+	require.Len(t, products, 1)
+
+	product := products[0]
+	assert.Equal(t, "Array Product", product["name"])
+	assert.EqualValues(t, 8, product["stock"]) // 10 - 2
+	assert.Equal(t, "2024-01-20", product["last_updated"])
+
+	// Check that tags array contains all tags
+	tags, ok := product["tags"].([]any)
+	if ok {
+		assert.Contains(t, tags, "new")
+		assert.Contains(t, tags, "featured")
+		assert.Contains(t, tags, "sale")
+	}
+}
+
+func TestIntegration_UpsertReturnValue(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "upsert_return_value", "product")
+	ctx := context.Background()
+
+	// First create a record with initial value
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:counter SET view_count = 5, name = 'Counter Product'", nil)
+	require.NoError(t, err)
+
+	// UPSERT with RETURN VALUE - should return just the field value
+	sql, vars := surrealql.Upsert("product:counter").
+		Set("view_count += ?", 1).
+		ReturnValue("view_count").
+		Build()
+
+	// The response should be just the value of the field
+	resp, err := surrealdb.Query[[]any](ctx, db, sql, vars)
+	require.NoError(t, err)
+
+	// RETURN VALUE returns just the field value, not a full record
+	result := (*resp)[0].Result
+	// The result should be [6] (the new view_count value)
+	require.Len(t, result, 1)
+	assert.EqualValues(t, 6, result[0]) // 5 + 1
+}

--- a/contrib/surrealql/query.go
+++ b/contrib/surrealql/query.go
@@ -14,6 +14,8 @@ const (
 	ReturnBeforeClause = "BEFORE"
 	ReturnAfterClause  = "AFTER"
 	StatusOK           = "OK"
+	ExplainClause      = "EXPLAIN"
+	ExplainFullClause  = "EXPLAIN FULL"
 )
 
 // Query represents a SurrealQL query that can be built and executed.

--- a/contrib/surrealql/select.go
+++ b/contrib/surrealql/select.go
@@ -197,7 +197,7 @@ func (q *SelectQuery) Where(condition string, args ...any) *SelectQuery {
 	if q.whereClause == nil {
 		q.whereClause = &whereBuilder{}
 	}
-	q.whereClause.addCondition("AND", condition, args, &q.baseQuery)
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
 	return q
 }
 
@@ -546,7 +546,7 @@ type whereCondition struct {
 	condition string
 }
 
-func (w *whereBuilder) addCondition(operator, condition string, args []any, base *baseQuery) {
+func (w *whereBuilder) addCondition(condition string, args []any, base *baseQuery) {
 	// Replace ? placeholders with named parameters
 	processedCondition := condition
 	for _, arg := range args {
@@ -556,7 +556,7 @@ func (w *whereBuilder) addCondition(operator, condition string, args []any, base
 	}
 
 	w.conditions = append(w.conditions, whereCondition{
-		operator:  operator,
+		operator:  "AND",
 		condition: processedCondition,
 	})
 }

--- a/contrib/surrealql/update.go
+++ b/contrib/surrealql/update.go
@@ -61,7 +61,7 @@ func (q *UpdateQuery) Where(condition string, args ...any) *UpdateQuery {
 	if q.whereClause == nil {
 		q.whereClause = &whereBuilder{}
 	}
-	q.whereClause.addCondition("AND", condition, args, &q.baseQuery)
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
 	return q
 }
 

--- a/contrib/surrealql/upsert.go
+++ b/contrib/surrealql/upsert.go
@@ -1,0 +1,792 @@
+package surrealql
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// PatchOp represents a JSON Patch operation
+//
+// See https://jsonpatch.com/ for details on JSON Patch operations.
+type PatchOp struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}
+
+// UpsertQuery represents the initial UPSERT query that can be converted to specific types
+type UpsertQuery struct {
+	baseQuery
+	only    bool
+	targets []string
+}
+
+// upsertCommon contains common functionality for all UPSERT query types
+type upsertCommon struct {
+	*UpsertQuery
+	whereClause  *whereBuilder
+	returnClause string
+	timeout      string
+	parallel     bool
+	explain      string
+}
+
+// UpsertSetQuery represents an UPSERT query with SET/UNSET
+type UpsertSetQuery struct {
+	upsertCommon
+	sets    map[string]any
+	setsRaw []string
+	unsets  []string
+}
+
+// UpsertContentQuery represents an UPSERT query with CONTENT
+type UpsertContentQuery struct {
+	upsertCommon
+	content map[string]any
+}
+
+// UpsertMergeQuery represents an UPSERT query with MERGE
+type UpsertMergeQuery struct {
+	upsertCommon
+	merge map[string]any
+}
+
+// UpsertPatchQuery represents an UPSERT query with PATCH
+type UpsertPatchQuery struct {
+	upsertCommon
+	patch []PatchOp
+}
+
+// UpsertReplaceQuery represents an UPSERT query with REPLACE
+type UpsertReplaceQuery struct {
+	upsertCommon
+	replace map[string]any
+}
+
+// Upsert starts an UPSERT query
+func Upsert[T mutationTarget](target T, targets ...T) *UpsertQuery {
+	q := &UpsertQuery{
+		baseQuery: newBaseQuery(),
+	}
+
+	upsertAddTarget(q, target)
+	for _, t := range targets {
+		upsertAddTarget(q, t)
+	}
+
+	return q
+}
+
+// UpsertOnly starts an UPSERT ONLY query (returns single record)
+func UpsertOnly[T mutationTarget](target T) *UpsertQuery {
+	q := &UpsertQuery{
+		baseQuery: newBaseQuery(),
+		only:      true,
+	}
+	upsertAddTarget(q, target)
+	return q
+}
+
+func upsertAddTarget[MT mutationTarget](q *UpsertQuery, target MT) {
+	sql, vars := buildTargetExpr(target)
+	q.targets = append(q.targets, sql)
+	for k, v := range vars {
+		q.addParam(k, v)
+	}
+}
+
+// Set converts to UpsertSetQuery and adds a field or expression
+// Can be used for simple assignment: Set("name", "value")
+// Or for compound operations: Set("count += ?", 1)
+func (q *UpsertQuery) Set(expr string, args ...any) *UpsertSetQuery {
+	setQuery := &UpsertSetQuery{
+		upsertCommon: upsertCommon{UpsertQuery: q},
+		sets:         make(map[string]any),
+	}
+	return setQuery.Set(expr, args...)
+}
+
+// SetMap converts to UpsertSetQuery and sets multiple fields
+func (q *UpsertQuery) SetMap(fields map[string]any) *UpsertSetQuery {
+	setQuery := &UpsertSetQuery{
+		upsertCommon: upsertCommon{UpsertQuery: q},
+		sets:         fields,
+	}
+	return setQuery
+}
+
+// SetRaw converts to UpsertSetQuery and adds a raw SET expression
+// Deprecated: Use Set() instead, which now supports raw expressions
+func (q *UpsertQuery) SetRaw(expr string) *UpsertSetQuery {
+	setQuery := &UpsertSetQuery{
+		upsertCommon: upsertCommon{UpsertQuery: q},
+		sets:         make(map[string]any),
+	}
+	setQuery.setsRaw = append(setQuery.setsRaw, expr)
+	return setQuery
+}
+
+// Content converts to UpsertContentQuery
+func (q *UpsertQuery) Content(content map[string]any) *UpsertContentQuery {
+	return &UpsertContentQuery{
+		upsertCommon: upsertCommon{UpsertQuery: q},
+		content:      content,
+	}
+}
+
+// Merge converts to UpsertMergeQuery
+func (q *UpsertQuery) Merge(data map[string]any) *UpsertMergeQuery {
+	return &UpsertMergeQuery{
+		upsertCommon: upsertCommon{UpsertQuery: q},
+		merge:        data,
+	}
+}
+
+// Patch converts to UpsertPatchQuery
+func (q *UpsertQuery) Patch(ops []PatchOp) *UpsertPatchQuery {
+	return &UpsertPatchQuery{
+		upsertCommon: upsertCommon{UpsertQuery: q},
+		patch:        ops,
+	}
+}
+
+// Replace converts to UpsertReplaceQuery
+func (q *UpsertQuery) Replace(data map[string]any) *UpsertReplaceQuery {
+	return &UpsertReplaceQuery{
+		upsertCommon: upsertCommon{UpsertQuery: q},
+		replace:      data,
+	}
+}
+
+// Build returns the SurrealQL string and parameters for an UPSERT without data modification
+// This is valid in SurrealDB and will create the record if it doesn't exist
+func (q *UpsertQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string for an UPSERT without data modification
+func (q *UpsertQuery) String() string {
+	var sql strings.Builder
+
+	sql.WriteString("UPSERT")
+
+	if q.only {
+		sql.WriteString(" ONLY")
+	}
+
+	sql.WriteString(" ")
+	for i, t := range q.targets {
+		if i > 0 {
+			sql.WriteString(", ")
+		}
+		sql.WriteString(t)
+	}
+
+	return sql.String()
+}
+
+// Methods for UpsertSetQuery
+
+// Set adds another field or expression to upsert
+// Can be used for simple assignment: Set("name", "value")
+// Or for compound operations: Set("count += ?", 1)
+func (q *UpsertSetQuery) Set(expr string, args ...any) *UpsertSetQuery {
+	// Check if this is a simple field assignment or an expression
+	if len(args) == 1 && !strings.ContainsAny(expr, "?+=<>!-*/") {
+		// Simple field assignment
+		q.sets[expr] = args[0]
+	} else if len(args) > 0 {
+		// Expression with placeholders
+		processedExpr := expr
+		for _, arg := range args {
+			paramName := q.generateParamName("upsert_param")
+			processedExpr = strings.Replace(processedExpr, "?", "$"+paramName, 1)
+			q.addParam(paramName, arg)
+		}
+		q.setsRaw = append(q.setsRaw, processedExpr)
+	} else {
+		// Raw expression without placeholders
+		q.setsRaw = append(q.setsRaw, expr)
+	}
+	return q
+}
+
+// SetMap adds multiple fields from a map
+func (q *UpsertSetQuery) SetMap(fields map[string]any) *UpsertSetQuery {
+	maps.Copy(q.sets, fields)
+	return q
+}
+
+// SetRaw adds a raw SET expression
+// Deprecated: Use Set() instead, which now supports raw expressions
+func (q *UpsertSetQuery) SetRaw(expr string) *UpsertSetQuery {
+	q.setsRaw = append(q.setsRaw, expr)
+	return q
+}
+
+// Unset removes fields
+func (q *UpsertSetQuery) Unset(fields ...string) *UpsertSetQuery {
+	q.unsets = append(q.unsets, fields...)
+	return q
+}
+
+// Where adds a WHERE condition
+func (q *UpsertSetQuery) Where(condition string, args ...any) *UpsertSetQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *UpsertSetQuery) Return(clause string) *UpsertSetQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *UpsertSetQuery) ReturnNone() *UpsertSetQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnBefore sets RETURN BEFORE
+func (q *UpsertSetQuery) ReturnBefore() *UpsertSetQuery {
+	q.returnClause = ReturnBeforeClause
+	return q
+}
+
+// ReturnAfter sets RETURN AFTER
+func (q *UpsertSetQuery) ReturnAfter() *UpsertSetQuery {
+	q.returnClause = ReturnAfterClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *UpsertSetQuery) ReturnDiff() *UpsertSetQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// ReturnValue sets RETURN VALUE for a specific field
+//
+// Although the original RETURN VALUE clause supports
+// any expression, including a SELECT query within it,
+// this implementation only supports a single field name.
+// This is because SurrealDB's RETURN VALUE clause
+// is typically used to return a specific field value
+// after an UPSERT operation, rather than a complex expression.
+// If you need to return a complex expression, consider using
+// the RETURN clause with a full SELECT query instead.
+// For example, use `Return("VALUE (SELECT * FROM product WHERE parent = $parent.id)")`
+func (q *UpsertSetQuery) ReturnValue(field string) *UpsertSetQuery {
+	q.returnClause = "VALUE " + escapeIdent(field)
+	return q
+}
+
+// Timeout sets the timeout duration
+func (q *UpsertSetQuery) Timeout(duration string) *UpsertSetQuery {
+	q.timeout = duration
+	return q
+}
+
+// Parallel enables parallel execution
+func (q *UpsertSetQuery) Parallel() *UpsertSetQuery {
+	q.parallel = true
+	return q
+}
+
+// Explain adds EXPLAIN clause
+func (q *UpsertSetQuery) Explain() *UpsertSetQuery {
+	q.explain = ExplainClause
+	return q
+}
+
+// ExplainFull adds EXPLAIN FULL clause
+func (q *UpsertSetQuery) ExplainFull() *UpsertSetQuery {
+	q.explain = ExplainFullClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *UpsertSetQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *UpsertSetQuery) String() string {
+	var sql strings.Builder
+
+	if q.explain != "" {
+		sql.WriteString(q.explain)
+		sql.WriteString(" ")
+	}
+
+	q.buildPrefix(&sql)
+
+	if len(q.sets) > 0 || len(q.setsRaw) > 0 || len(q.unsets) > 0 {
+		sql.WriteString(" SET ")
+		var setParts []string
+
+		// Handle SET fields
+		if len(q.sets) > 0 {
+			setsKeys := sort.StringSlice(slices.Collect(maps.Keys(q.sets)))
+			sort.Stable(setsKeys)
+
+			for _, field := range setsKeys {
+				value := q.sets[field]
+				paramName := q.generateParamName("upsert_" + field)
+				q.addParam(paramName, value)
+				setParts = append(setParts, fmt.Sprintf("%s = $%s", escapeIdent(field), paramName))
+			}
+		}
+
+		// Handle raw SET expressions
+		setParts = append(setParts, q.setsRaw...)
+
+		// Handle UNSET fields - single UNSET followed by comma-separated fields
+		if len(q.unsets) > 0 {
+			unsetFields := make([]string, len(q.unsets))
+			for i, field := range q.unsets {
+				unsetFields[i] = escapeIdent(field)
+			}
+			setParts = append(setParts, "UNSET "+strings.Join(unsetFields, ", "))
+		}
+
+		sql.WriteString(strings.Join(setParts, ", "))
+	}
+
+	q.buildSuffix(&sql)
+	return sql.String()
+}
+
+// Methods for UpsertContentQuery
+
+// Where adds a WHERE condition
+func (q *UpsertContentQuery) Where(condition string, args ...any) *UpsertContentQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *UpsertContentQuery) Return(clause string) *UpsertContentQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *UpsertContentQuery) ReturnNone() *UpsertContentQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnBefore sets RETURN BEFORE
+func (q *UpsertContentQuery) ReturnBefore() *UpsertContentQuery {
+	q.returnClause = ReturnBeforeClause
+	return q
+}
+
+// ReturnAfter sets RETURN AFTER
+func (q *UpsertContentQuery) ReturnAfter() *UpsertContentQuery {
+	q.returnClause = ReturnAfterClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *UpsertContentQuery) ReturnDiff() *UpsertContentQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// ReturnValue sets RETURN VALUE for a specific field
+func (q *UpsertContentQuery) ReturnValue(field string) *UpsertContentQuery {
+	q.returnClause = "VALUE " + escapeIdent(field)
+	return q
+}
+
+// Timeout sets the timeout duration
+func (q *UpsertContentQuery) Timeout(duration string) *UpsertContentQuery {
+	q.timeout = duration
+	return q
+}
+
+// Parallel enables parallel execution
+func (q *UpsertContentQuery) Parallel() *UpsertContentQuery {
+	q.parallel = true
+	return q
+}
+
+// Explain adds EXPLAIN clause
+func (q *UpsertContentQuery) Explain() *UpsertContentQuery {
+	q.explain = ExplainClause
+	return q
+}
+
+// ExplainFull adds EXPLAIN FULL clause
+func (q *UpsertContentQuery) ExplainFull() *UpsertContentQuery {
+	q.explain = ExplainFullClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *UpsertContentQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *UpsertContentQuery) String() string {
+	var sql strings.Builder
+
+	if q.explain != "" {
+		sql.WriteString(q.explain)
+		sql.WriteString(" ")
+	}
+
+	q.buildPrefix(&sql)
+
+	if len(q.content) > 0 {
+		paramName := q.generateParamName("upsert_content")
+		q.addParam(paramName, q.content)
+		sql.WriteString(fmt.Sprintf(" CONTENT $%s", paramName))
+	}
+
+	q.buildSuffix(&sql)
+	return sql.String()
+}
+
+// Methods for UpsertMergeQuery
+
+// Where adds a WHERE condition
+func (q *UpsertMergeQuery) Where(condition string, args ...any) *UpsertMergeQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *UpsertMergeQuery) Return(clause string) *UpsertMergeQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *UpsertMergeQuery) ReturnNone() *UpsertMergeQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnBefore sets RETURN BEFORE
+func (q *UpsertMergeQuery) ReturnBefore() *UpsertMergeQuery {
+	q.returnClause = ReturnBeforeClause
+	return q
+}
+
+// ReturnAfter sets RETURN AFTER
+func (q *UpsertMergeQuery) ReturnAfter() *UpsertMergeQuery {
+	q.returnClause = ReturnAfterClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *UpsertMergeQuery) ReturnDiff() *UpsertMergeQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// ReturnValue sets RETURN VALUE for a specific field
+func (q *UpsertMergeQuery) ReturnValue(field string) *UpsertMergeQuery {
+	q.returnClause = "VALUE " + escapeIdent(field)
+	return q
+}
+
+// Timeout sets the timeout duration
+func (q *UpsertMergeQuery) Timeout(duration string) *UpsertMergeQuery {
+	q.timeout = duration
+	return q
+}
+
+// Parallel enables parallel execution
+func (q *UpsertMergeQuery) Parallel() *UpsertMergeQuery {
+	q.parallel = true
+	return q
+}
+
+// Explain adds EXPLAIN clause
+func (q *UpsertMergeQuery) Explain() *UpsertMergeQuery {
+	q.explain = ExplainClause
+	return q
+}
+
+// ExplainFull adds EXPLAIN FULL clause
+func (q *UpsertMergeQuery) ExplainFull() *UpsertMergeQuery {
+	q.explain = ExplainFullClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *UpsertMergeQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *UpsertMergeQuery) String() string {
+	var sql strings.Builder
+
+	if q.explain != "" {
+		sql.WriteString(q.explain)
+		sql.WriteString(" ")
+	}
+
+	q.buildPrefix(&sql)
+
+	if len(q.merge) > 0 {
+		paramName := q.generateParamName("upsert_merge")
+		q.addParam(paramName, q.merge)
+		sql.WriteString(fmt.Sprintf(" MERGE $%s", paramName))
+	}
+
+	q.buildSuffix(&sql)
+	return sql.String()
+}
+
+// Methods for UpsertPatchQuery
+
+// Where adds a WHERE condition
+func (q *UpsertPatchQuery) Where(condition string, args ...any) *UpsertPatchQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *UpsertPatchQuery) Return(clause string) *UpsertPatchQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *UpsertPatchQuery) ReturnNone() *UpsertPatchQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnBefore sets RETURN BEFORE
+func (q *UpsertPatchQuery) ReturnBefore() *UpsertPatchQuery {
+	q.returnClause = ReturnBeforeClause
+	return q
+}
+
+// ReturnAfter sets RETURN AFTER
+func (q *UpsertPatchQuery) ReturnAfter() *UpsertPatchQuery {
+	q.returnClause = ReturnAfterClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *UpsertPatchQuery) ReturnDiff() *UpsertPatchQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// ReturnValue sets RETURN VALUE for a specific field
+func (q *UpsertPatchQuery) ReturnValue(field string) *UpsertPatchQuery {
+	q.returnClause = "VALUE " + escapeIdent(field)
+	return q
+}
+
+// Timeout sets the timeout duration
+func (q *UpsertPatchQuery) Timeout(duration string) *UpsertPatchQuery {
+	q.timeout = duration
+	return q
+}
+
+// Parallel enables parallel execution
+func (q *UpsertPatchQuery) Parallel() *UpsertPatchQuery {
+	q.parallel = true
+	return q
+}
+
+// Explain adds EXPLAIN clause
+func (q *UpsertPatchQuery) Explain() *UpsertPatchQuery {
+	q.explain = ExplainClause
+	return q
+}
+
+// ExplainFull adds EXPLAIN FULL clause
+func (q *UpsertPatchQuery) ExplainFull() *UpsertPatchQuery {
+	q.explain = ExplainFullClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *UpsertPatchQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *UpsertPatchQuery) String() string {
+	var sql strings.Builder
+
+	if q.explain != "" {
+		sql.WriteString(q.explain)
+		sql.WriteString(" ")
+	}
+
+	q.buildPrefix(&sql)
+
+	if len(q.patch) > 0 {
+		paramName := q.generateParamName("upsert_patch")
+		q.addParam(paramName, q.patch)
+		sql.WriteString(fmt.Sprintf(" PATCH $%s", paramName))
+	}
+
+	q.buildSuffix(&sql)
+	return sql.String()
+}
+
+// Methods for UpsertReplaceQuery
+
+// Where adds a WHERE condition
+func (q *UpsertReplaceQuery) Where(condition string, args ...any) *UpsertReplaceQuery {
+	if q.whereClause == nil {
+		q.whereClause = &whereBuilder{}
+	}
+	q.whereClause.addCondition(condition, args, &q.baseQuery)
+	return q
+}
+
+// Return sets the RETURN clause
+func (q *UpsertReplaceQuery) Return(clause string) *UpsertReplaceQuery {
+	q.returnClause = clause
+	return q
+}
+
+// ReturnNone sets RETURN NONE
+func (q *UpsertReplaceQuery) ReturnNone() *UpsertReplaceQuery {
+	q.returnClause = ReturnNoneClause
+	return q
+}
+
+// ReturnBefore sets RETURN BEFORE
+func (q *UpsertReplaceQuery) ReturnBefore() *UpsertReplaceQuery {
+	q.returnClause = ReturnBeforeClause
+	return q
+}
+
+// ReturnAfter sets RETURN AFTER
+func (q *UpsertReplaceQuery) ReturnAfter() *UpsertReplaceQuery {
+	q.returnClause = ReturnAfterClause
+	return q
+}
+
+// ReturnDiff sets RETURN DIFF
+func (q *UpsertReplaceQuery) ReturnDiff() *UpsertReplaceQuery {
+	q.returnClause = ReturnDiffClause
+	return q
+}
+
+// ReturnValue sets RETURN VALUE for a specific field
+func (q *UpsertReplaceQuery) ReturnValue(field string) *UpsertReplaceQuery {
+	q.returnClause = "VALUE " + escapeIdent(field)
+	return q
+}
+
+// Timeout sets the timeout duration
+func (q *UpsertReplaceQuery) Timeout(duration string) *UpsertReplaceQuery {
+	q.timeout = duration
+	return q
+}
+
+// Parallel enables parallel execution
+func (q *UpsertReplaceQuery) Parallel() *UpsertReplaceQuery {
+	q.parallel = true
+	return q
+}
+
+// Explain adds EXPLAIN clause
+func (q *UpsertReplaceQuery) Explain() *UpsertReplaceQuery {
+	q.explain = ExplainClause
+	return q
+}
+
+// ExplainFull adds EXPLAIN FULL clause
+func (q *UpsertReplaceQuery) ExplainFull() *UpsertReplaceQuery {
+	q.explain = ExplainFullClause
+	return q
+}
+
+// Build returns the SurrealQL string and parameters
+func (q *UpsertReplaceQuery) Build() (sql string, vars map[string]any) {
+	return q.String(), q.vars
+}
+
+// String returns the SurrealQL string
+func (q *UpsertReplaceQuery) String() string {
+	var sql strings.Builder
+
+	if q.explain != "" {
+		sql.WriteString(q.explain)
+		sql.WriteString(" ")
+	}
+
+	q.buildPrefix(&sql)
+
+	if len(q.replace) > 0 {
+		paramName := q.generateParamName("upsert_replace")
+		q.addParam(paramName, q.replace)
+		sql.WriteString(fmt.Sprintf(" REPLACE $%s", paramName))
+	}
+
+	q.buildSuffix(&sql)
+	return sql.String()
+}
+
+// Helper methods for upsertCommon
+
+func (c *upsertCommon) buildPrefix(sql *strings.Builder) {
+	sql.WriteString("UPSERT")
+
+	if c.only {
+		sql.WriteString(" ONLY")
+	}
+
+	sql.WriteString(" ")
+	for i, t := range c.targets {
+		if i > 0 {
+			sql.WriteString(", ")
+		}
+		sql.WriteString(t)
+	}
+}
+
+func (c *upsertCommon) buildSuffix(sql *strings.Builder) {
+	if c.whereClause != nil && c.whereClause.hasConditions() {
+		sql.WriteString(" WHERE ")
+		sql.WriteString(c.whereClause.build())
+	}
+
+	if c.returnClause != "" {
+		sql.WriteString(" RETURN ")
+		sql.WriteString(c.returnClause)
+	}
+
+	if c.timeout != "" {
+		sql.WriteString(" TIMEOUT ")
+		sql.WriteString(c.timeout)
+	}
+
+	if c.parallel {
+		sql.WriteString(" PARALLEL")
+	}
+}

--- a/contrib/surrealql/upsert_test.go
+++ b/contrib/surrealql/upsert_test.go
@@ -1,0 +1,518 @@
+package surrealql
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUpsert_Basic(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func() (string, map[string]any)
+		wantSQL  string
+		wantVars map[string]any
+	}{
+		{
+			name: "basic upsert with SET",
+			build: func() (string, map[string]any) {
+				return Upsert("product:laptop").
+					Set("name", "Laptop Pro").
+					Set("price", 1299).
+					Build()
+			},
+			wantSQL: "UPSERT product:laptop SET name = $upsert_name_1, price = $upsert_price_1",
+			wantVars: map[string]any{
+				"upsert_name_1":  "Laptop Pro",
+				"upsert_price_1": 1299,
+			},
+		},
+		{
+			name: "upsert with CONTENT",
+			build: func() (string, map[string]any) {
+				return Upsert("product:phone").
+					Content(map[string]any{
+						"name":  "Smartphone X",
+						"price": 799,
+					}).
+					Build()
+			},
+			wantSQL: "UPSERT product:phone CONTENT $upsert_content_1",
+			wantVars: map[string]any{
+				"upsert_content_1": map[string]any{
+					"name":  "Smartphone X",
+					"price": 799,
+				},
+			},
+		},
+		{
+			name: "upsert with MERGE",
+			build: func() (string, map[string]any) {
+				return Upsert("product:headphones").
+					Merge(map[string]any{
+						"colors": []string{"Black", "White"},
+					}).
+					Build()
+			},
+			wantSQL: "UPSERT product:headphones MERGE $upsert_merge_1",
+			wantVars: map[string]any{
+				"upsert_merge_1": map[string]any{
+					"colors": []string{"Black", "White"},
+				},
+			},
+		},
+		{
+			name: "upsert with REPLACE",
+			build: func() (string, map[string]any) {
+				return Upsert("product:tablet").
+					Replace(map[string]any{
+						"name":  "Tablet Pro",
+						"price": 899,
+					}).
+					Build()
+			},
+			wantSQL: "UPSERT product:tablet REPLACE $upsert_replace_1",
+			wantVars: map[string]any{
+				"upsert_replace_1": map[string]any{
+					"name":  "Tablet Pro",
+					"price": 899,
+				},
+			},
+		},
+		{
+			name: "upsert with PATCH",
+			build: func() (string, map[string]any) {
+				return Upsert("product:keyboard").
+					Patch([]PatchOp{
+						{Op: "add", Path: "/features", Value: []string{"RGB Lighting"}},
+					}).
+					Build()
+			},
+			wantSQL: "UPSERT product:keyboard PATCH $upsert_patch_1",
+			wantVars: map[string]any{
+				"upsert_patch_1": []PatchOp{
+					{Op: "add", Path: "/features", Value: []string{"RGB Lighting"}},
+				},
+			},
+		},
+		{
+			name: "upsert ONLY with SET",
+			build: func() (string, map[string]any) {
+				return UpsertOnly("product:charger").
+					Set("name", "Fast Charger").
+					Build()
+			},
+			wantSQL: "UPSERT ONLY product:charger SET name = $upsert_name_1",
+			wantVars: map[string]any{
+				"upsert_name_1": "Fast Charger",
+			},
+		},
+		{
+			name: "upsert with WHERE clause",
+			build: func() (string, map[string]any) {
+				return Upsert("product:monitor").
+					Set("updated", true).
+					Where("price > ?", 100).
+					Build()
+			},
+			wantSQL: "UPSERT product:monitor SET updated = $upsert_updated_1 WHERE price > $param_1",
+			wantVars: map[string]any{
+				"upsert_updated_1": true,
+				"param_1":          100,
+			},
+		},
+		{
+			name: "upsert with RETURN NONE",
+			build: func() (string, map[string]any) {
+				return Upsert("product:adapter").
+					Set("name", "Power Adapter").
+					ReturnNone().
+					Build()
+			},
+			wantSQL: "UPSERT product:adapter SET name = $upsert_name_1 RETURN NONE",
+			wantVars: map[string]any{
+				"upsert_name_1": "Power Adapter",
+			},
+		},
+		{
+			name: "upsert with RETURN DIFF",
+			build: func() (string, map[string]any) {
+				return Upsert("product:lamp").
+					Set("name", "LED Lamp").
+					ReturnDiff().
+					Build()
+			},
+			wantSQL: "UPSERT product:lamp SET name = $upsert_name_1 RETURN DIFF",
+			wantVars: map[string]any{
+				"upsert_name_1": "LED Lamp",
+			},
+		},
+		{
+			name: "upsert with RETURN BEFORE",
+			build: func() (string, map[string]any) {
+				return Upsert("product:chair").
+					Set("name", "Office Chair").
+					ReturnBefore().
+					Build()
+			},
+			wantSQL: "UPSERT product:chair SET name = $upsert_name_1 RETURN BEFORE",
+			wantVars: map[string]any{
+				"upsert_name_1": "Office Chair",
+			},
+		},
+		{
+			name: "upsert with RETURN AFTER",
+			build: func() (string, map[string]any) {
+				return Upsert("product:desk").
+					Set("name", "Standing Desk").
+					ReturnAfter().
+					Build()
+			},
+			wantSQL: "UPSERT product:desk SET name = $upsert_name_1 RETURN AFTER",
+			wantVars: map[string]any{
+				"upsert_name_1": "Standing Desk",
+			},
+		},
+		{
+			name: "upsert with TIMEOUT",
+			build: func() (string, map[string]any) {
+				return Upsert("product:webcam").
+					Set("name", "HD Webcam").
+					Timeout("5s").
+					Build()
+			},
+			wantSQL: "UPSERT product:webcam SET name = $upsert_name_1 TIMEOUT 5s",
+			wantVars: map[string]any{
+				"upsert_name_1": "HD Webcam",
+			},
+		},
+		{
+			name: "upsert with PARALLEL",
+			build: func() (string, map[string]any) {
+				return Upsert("product:mouse").
+					Set("name", "Wireless Mouse").
+					Parallel().
+					Build()
+			},
+			wantSQL: "UPSERT product:mouse SET name = $upsert_name_1 PARALLEL",
+			wantVars: map[string]any{
+				"upsert_name_1": "Wireless Mouse",
+			},
+		},
+		{
+			name: "upsert with UNSET",
+			build: func() (string, map[string]any) {
+				return Upsert("product:cable").
+					Set("name", "USB Cable").
+					Unset("deprecated_field").
+					Build()
+			},
+			wantSQL: "UPSERT product:cable SET name = $upsert_name_1, UNSET deprecated_field",
+			wantVars: map[string]any{
+				"upsert_name_1": "USB Cable",
+			},
+		},
+		{
+			name: "upsert with multiple UNSET",
+			build: func() (string, map[string]any) {
+				return Upsert("product:storage").
+					Set("name", "SSD Storage").
+					Unset("deprecated_field", "legacy_data", "old_column").
+					Build()
+			},
+			wantSQL: "UPSERT product:storage SET name = $upsert_name_1, UNSET deprecated_field, legacy_data, old_column",
+			wantVars: map[string]any{
+				"upsert_name_1": "SSD Storage",
+			},
+		},
+		{
+			name: "upsert with SetMap",
+			build: func() (string, map[string]any) {
+				return Upsert("product:speaker").
+					SetMap(map[string]any{
+						"name":  "Bluetooth Speaker",
+						"price": 89,
+					}).
+					Build()
+			},
+			wantSQL: "UPSERT product:speaker SET name = $upsert_name_1, price = $upsert_price_1",
+			wantVars: map[string]any{
+				"upsert_name_1":  "Bluetooth Speaker",
+				"upsert_price_1": 89,
+			},
+		},
+		{
+			name: "upsert multiple targets",
+			build: func() (string, map[string]any) {
+				return Upsert("product:item1", "product:item2").
+					Set("active", true).
+					Build()
+			},
+			wantSQL: "UPSERT product:item1, product:item2 SET active = $upsert_active_1",
+			wantVars: map[string]any{
+				"upsert_active_1": true,
+			},
+		},
+		{
+			name: "upsert table without ID",
+			build: func() (string, map[string]any) {
+				return Upsert("product").
+					Set("name", "Generic Product").
+					Build()
+			},
+			wantSQL: "UPSERT product SET name = $upsert_name_1",
+			wantVars: map[string]any{
+				"upsert_name_1": "Generic Product",
+			},
+		},
+		{
+			name: "upsert with all features",
+			build: func() (string, map[string]any) {
+				return Upsert("product:premium").
+					Set("name", "Premium Product").
+					Set("updated_at", "2024-01-01T00:00:00Z").
+					Where("price >= ?", 1000).
+					ReturnDiff().
+					Timeout("10s").
+					Parallel().
+					Build()
+			},
+			wantSQL: "UPSERT product:premium SET name = $upsert_name_1, updated_at = $upsert_updated_at_1 WHERE price >= $param_1 RETURN DIFF TIMEOUT 10s PARALLEL",
+			wantVars: map[string]any{
+				"upsert_name_1":       "Premium Product",
+				"upsert_updated_at_1": "2024-01-01T00:00:00Z",
+				"param_1":             1000,
+			},
+		},
+		{
+			name: "upsert with EXPLAIN",
+			build: func() (string, map[string]any) {
+				return Upsert("product:example").
+					Set("name", "Example Product").
+					Explain().
+					Build()
+			},
+			wantSQL: "EXPLAIN UPSERT product:example SET name = $upsert_name_1",
+			wantVars: map[string]any{
+				"upsert_name_1": "Example Product",
+			},
+		},
+		{
+			name: "upsert with EXPLAIN FULL",
+			build: func() (string, map[string]any) {
+				return Upsert("product:demo").
+					Set("name", "Demo Product").
+					ExplainFull().
+					Build()
+			},
+			wantSQL: "EXPLAIN FULL UPSERT product:demo SET name = $upsert_name_1",
+			wantVars: map[string]any{
+				"upsert_name_1": "Demo Product",
+			},
+		},
+		{
+			name: "upsert without content single record",
+			build: func() (string, map[string]any) {
+				return Upsert("foo:1").Build()
+			},
+			wantSQL:  "UPSERT foo:1",
+			wantVars: map[string]any{},
+		},
+		{
+			name: "upsert without content multiple records",
+			build: func() (string, map[string]any) {
+				return Upsert("foo:2", "foo:3").Build()
+			},
+			wantSQL:  "UPSERT foo:2, foo:3",
+			wantVars: map[string]any{},
+		},
+		{
+			name: "upsert with SetRaw",
+			build: func() (string, map[string]any) {
+				return Upsert("product:widget").
+					SetRaw("stock += 10").
+					SetRaw("views += 1").
+					Build()
+			},
+			wantSQL:  "UPSERT product:widget SET stock += 10, views += 1",
+			wantVars: map[string]any{},
+		},
+		{
+			name: "upsert with SetRaw and regular Set",
+			build: func() (string, map[string]any) {
+				return Upsert("product:gadget").
+					Set("name", "Smart Gadget").
+					SetRaw("popularity += 1").
+					Set("updated", true).
+					Build()
+			},
+			wantSQL: "UPSERT product:gadget SET name = $upsert_name_1, updated = $upsert_updated_1, popularity += 1",
+			wantVars: map[string]any{
+				"upsert_name_1":    "Smart Gadget",
+				"upsert_updated_1": true,
+			},
+		},
+		{
+			name: "upsert with unified Set for compound operations",
+			build: func() (string, map[string]any) {
+				return Upsert("product:item").
+					Set("name", "Test Item").
+					Set("stock += ?", 10).
+					Set("price -= ?", 5).
+					Build()
+			},
+			wantSQL: "UPSERT product:item SET name = $upsert_name_1, stock += $upsert_param_1, price -= $upsert_param_2",
+			wantVars: map[string]any{
+				"upsert_name_1":  "Test Item",
+				"upsert_param_1": 10,
+				"upsert_param_2": 5,
+			},
+		},
+		{
+			name: "upsert with unified Set mixing simple and compound",
+			build: func() (string, map[string]any) {
+				return Upsert("product:mix").
+					Set("count += ?", 1).
+					Set("updated", true).
+					Set("tags -= ?", "old").
+					Build()
+			},
+			wantSQL: "UPSERT product:mix SET updated = $upsert_updated_1, count += $upsert_param_1, tags -= $upsert_param_2",
+			wantVars: map[string]any{
+				"upsert_updated_1": true,
+				"upsert_param_1":   1,
+				"upsert_param_2":   "old",
+			},
+		},
+		{
+			name: "upsert with RETURN VALUE",
+			build: func() (string, map[string]any) {
+				return Upsert("product:counter").
+					Set("count += ?", 1).
+					ReturnValue("count").
+					Build()
+			},
+			wantSQL: "UPSERT product:counter SET count += $upsert_param_1 RETURN VALUE count",
+			wantVars: map[string]any{
+				"upsert_param_1": 1,
+			},
+		},
+		{
+			name: "upsert content with RETURN VALUE",
+			build: func() (string, map[string]any) {
+				return Upsert("product:item").
+					Content(map[string]any{
+						"name":  "Test Product",
+						"price": 99.99,
+					}).
+					ReturnValue("price").
+					Build()
+			},
+			wantSQL: "UPSERT product:item CONTENT $upsert_content_1 RETURN VALUE price",
+			wantVars: map[string]any{
+				"upsert_content_1": map[string]any{
+					"name":  "Test Product",
+					"price": 99.99,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSQL, gotVars := tt.build()
+
+			if gotSQL != tt.wantSQL {
+				t.Errorf("SQL mismatch\ngot:  %q\nwant: %q", gotSQL, tt.wantSQL)
+			}
+
+			if len(gotVars) != len(tt.wantVars) {
+				t.Errorf("Variables count mismatch\ngot:  %d\nwant: %d", len(gotVars), len(tt.wantVars))
+			}
+
+			for k, wantVal := range tt.wantVars {
+				gotVal, exists := gotVars[k]
+				if !exists {
+					t.Errorf("Missing variable %q", k)
+					continue
+				}
+
+				if !reflect.DeepEqual(gotVal, wantVal) {
+					t.Errorf("Variable %q mismatch\ngot:  %v (%T)\nwant: %v (%T)",
+						k, gotVal, gotVal, wantVal, wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestUpsert_TypeSafety(t *testing.T) {
+	// Test that the API prevents mixing incompatible data modes at compile time
+
+	t.Run("SET mode allows multiple Set and Unset", func(t *testing.T) {
+		q := Upsert("product:gadget").
+			Set("name", "Smart Gadget").
+			Set("price", 199).
+			Unset("deprecated")
+
+		sql, _ := q.Build()
+		expected := "UPSERT product:gadget SET name = $upsert_name_1, price = $upsert_price_1, UNSET deprecated"
+		if sql != expected {
+			t.Errorf("Expected %q, got %q", expected, sql)
+		}
+	})
+
+	t.Run("CONTENT mode is immutable after setting", func(t *testing.T) {
+		q := Upsert("product:device").
+			Content(map[string]any{
+				"name":  "Smart Device",
+				"price": 349,
+			})
+
+		// The type system prevents calling Set() on UpsertContentQuery
+		// This is enforced at compile time, not runtime
+		sql, _ := q.Build()
+		expected := "UPSERT product:device CONTENT $upsert_content_1"
+		if sql != expected {
+			t.Errorf("Expected %q, got %q", expected, sql)
+		}
+	})
+
+	t.Run("Each mode returns appropriate type", func(t *testing.T) {
+		// These are all different types, enforced at compile time
+		setQuery := Upsert("product:item").Set("name", "Test Item")
+		contentQuery := Upsert("product:item").Content(map[string]any{"name": "Test Item"})
+		mergeQuery := Upsert("product:item").Merge(map[string]any{"name": "Test Item"})
+		patchQuery := Upsert("product:item").Patch([]PatchOp{{Op: "add", Path: "/name", Value: "Test Item"}})
+		replaceQuery := Upsert("product:item").Replace(map[string]any{"name": "Test Item"})
+
+		// Each returns the expected SQL
+		if sql, _ := setQuery.Build(); !contains(sql, "SET") {
+			t.Errorf("SET query should contain SET: %q", sql)
+		}
+		if sql, _ := contentQuery.Build(); !contains(sql, "CONTENT") {
+			t.Errorf("CONTENT query should contain CONTENT: %q", sql)
+		}
+		if sql, _ := mergeQuery.Build(); !contains(sql, "MERGE") {
+			t.Errorf("MERGE query should contain MERGE: %q", sql)
+		}
+		if sql, _ := patchQuery.Build(); !contains(sql, "PATCH") {
+			t.Errorf("PATCH query should contain PATCH: %q", sql)
+		}
+		if sql, _ := replaceQuery.Build(); !contains(sql, "REPLACE") {
+			t.Errorf("REPLACE query should contain REPLACE: %q", sql)
+		}
+	})
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This enhances the surrealql library added in #289 to support UPSERTs.

Please take a look at the new testable examples for usage- they are considered part of the documentation.

Ref #151