### PR TITLE
SurrealQL query builder: Enhance Set for compound ops

### DIFF
--- a/contrib/surrealql/create.go
+++ b/contrib/surrealql/create.go
@@ -1,19 +1,12 @@
 package surrealql
 
-import (
-	"fmt"
-	"maps"
-	"slices"
-	"sort"
-	"strings"
-)
+import "fmt"
 
 // CreateQuery represents a CREATE query
 type CreateQuery struct {
 	baseQuery
+	setsBuilder
 	thing        string
-	sets         map[string]any
-	setsRaw      []string
 	content      map[string]any
 	useContent   bool
 	returnClause string
@@ -33,10 +26,10 @@ func Create[T mutationTarget](thing T) *CreateQuery {
 		bq.addParam(k, v)
 	}
 	return &CreateQuery{
-		baseQuery: bq,
-		thing:     sql,
-		sets:      make(map[string]any),
-		content:   make(map[string]any),
+		baseQuery:   bq,
+		setsBuilder: newSetsBuilder(),
+		thing:       sql,
+		content:     make(map[string]any),
 	}
 }
 
@@ -44,29 +37,13 @@ func Create[T mutationTarget](thing T) *CreateQuery {
 // Can be used for simple assignment: Set("name", "value")
 // Or for compound operations: Set("count += ?", 1)
 func (q *CreateQuery) Set(expr string, args ...any) *CreateQuery {
-	// Check if this is a simple field assignment or an expression
-	if len(args) == 1 && !strings.ContainsAny(expr, "?+=<>!-*/") {
-		// Simple field assignment
-		q.sets[expr] = args[0]
-	} else if len(args) > 0 {
-		// Expression with placeholders
-		processedExpr := expr
-		for _, arg := range args {
-			paramName := q.generateParamName("param")
-			processedExpr = strings.Replace(processedExpr, "?", "$"+paramName, 1)
-			q.addParam(paramName, arg)
-		}
-		q.setsRaw = append(q.setsRaw, processedExpr)
-	} else {
-		// Raw expression without placeholders
-		q.setsRaw = append(q.setsRaw, expr)
-	}
+	q.addSet(expr, args, &q.baseQuery, "param")
 	return q
 }
 
 // SetMap sets multiple fields from a map
 func (q *CreateQuery) SetMap(fields map[string]any) *CreateQuery {
-	maps.Copy(q.sets, fields)
+	q.addSetMap(fields)
 	return q
 }
 
@@ -102,26 +79,8 @@ func (q *CreateQuery) String() string {
 		paramName := q.generateParamName("content")
 		q.addParam(paramName, q.content)
 		sql += fmt.Sprintf(" CONTENT $%s", paramName)
-	} else if len(q.sets) > 0 || len(q.setsRaw) > 0 {
-		var setParts []string
-
-		// Handle SET fields
-		if len(q.sets) > 0 {
-			setsKeys := sort.StringSlice(slices.Collect(maps.Keys(q.sets)))
-			sort.Stable(setsKeys)
-
-			for _, field := range setsKeys {
-				value := q.sets[field]
-				paramName := q.generateParamName(field)
-				q.addParam(paramName, value)
-				setParts = append(setParts, fmt.Sprintf("%s = $%s", escapeIdent(field), paramName))
-			}
-		}
-
-		// Handle raw SET expressions
-		setParts = append(setParts, q.setsRaw...)
-
-		sql += " SET " + strings.Join(setParts, ", ")
+	} else if setClause := q.buildSetClause(&q.baseQuery, ""); setClause != "" {
+		sql += " SET " + setClause
 	}
 
 	if q.returnClause != "" {

--- a/contrib/surrealql/create_test.go
+++ b/contrib/surrealql/create_test.go
@@ -12,22 +12,18 @@ func TestCreate(t *testing.T) {
 		{
 			name:   "create with set",
 			query:  Create("users").Set("name", "John").Set("email", "john@example.com"),
-			wantQL: "CREATE users CONTENT $content_1",
+			wantQL: "CREATE users SET email = $email_1, name = $name_1",
 			wantArgs: map[string]any{
-				"content_1": map[string]any{
-					"name":  "John",
-					"email": "john@example.com",
-				},
+				"name_1":  "John",
+				"email_1": "john@example.com",
 			},
 		},
 		{
 			name:   "create with return none",
 			query:  Create("users").Set("name", "John").ReturnNone(),
-			wantQL: "CREATE users CONTENT $content_1 RETURN NONE",
+			wantQL: "CREATE users SET name = $name_1 RETURN NONE",
 			wantArgs: map[string]any{
-				"content_1": map[string]any{
-					"name": "John",
-				},
+				"name_1": "John",
 			},
 		},
 		{
@@ -44,6 +40,15 @@ func TestCreate(t *testing.T) {
 					"age":   30,
 					"roles": []string{"admin", "user"},
 				},
+			},
+		},
+		{
+			name:   "create with compound operation",
+			query:  Create("stats").Set("views", 0).Set("clicks += ?", 1),
+			wantQL: "CREATE stats SET views = $views_1, clicks += $param_1",
+			wantArgs: map[string]any{
+				"views_1": 0,
+				"param_1": 1,
 			},
 		},
 	}

--- a/contrib/surrealql/example_create_test.go
+++ b/contrib/surrealql/example_create_test.go
@@ -26,8 +26,23 @@ func ExampleCreate() {
 	fmt.Printf("Vars: %v\n", vars)
 
 	// Output:
-	// SurrealQL: CREATE users CONTENT $content_1 RETURN id, name, email
-	// Vars: map[content_1:map[created_at:2023-10-01 12:00:00 +0000 UTC email:john@example.com name:John Doe]]
+	// SurrealQL: CREATE users SET created_at = $created_at_1, email = $email_1, name = $name_1 RETURN id, name, email
+	// Vars: map[created_at_1:2023-10-01 12:00:00 +0000 UTC email_1:john@example.com name_1:John Doe]
+}
+
+func ExampleCreate_compoundOperations() {
+	// CREATE with compound operations using the Set function
+	sql, vars := surrealql.Create("stats:daily").
+		Set("date", "2024-01-01").
+		Set("page_views", 0).
+		Set("unique_visitors += ?", 1). // Compound operation in CREATE
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// CREATE stats:daily SET date = $date_1, page_views = $page_views_1, unique_visitors += $param_1
+	// Variables: map[date_1:2024-01-01 page_views_1:0 param_1:1]
 }
 
 func ExampleCreate_withThing() {
@@ -47,9 +62,11 @@ func ExampleCreate_withThing() {
 	}
 
 	// Output:
-	// SurrealQL: CREATE $id_1 CONTENT $content_1 RETURN id, name, email
-	// Var content_1: map[created_at:2023-10-01 12:00:00 +0000 UTC email:alice@example.com name:Alice]
+	// SurrealQL: CREATE $id_1 SET created_at = $created_at_1, email = $email_1, name = $name_1 RETURN id, name, email
+	// Var created_at_1: 2023-10-01 12:00:00 +0000 UTC
+	// Var email_1: alice@example.com
 	// Var id_1: {users 123}
+	// Var name_1: Alice
 }
 
 // ExampleCreate_integration_f_recordID demonstrates creating a record with a specific RecordID using the query builder.

--- a/contrib/surrealql/example_relate_test.go
+++ b/contrib/surrealql/example_relate_test.go
@@ -18,6 +18,21 @@ func ExampleRelate() {
 	fmt.Printf("Vars: %v\n", vars)
 
 	// Output:
-	// SurrealQL: RELATE users:123->likes->posts:456 CONTENT $content_1
-	// Vars: map[content_1:map[liked_at:2023-10-01 12:00:00 +0000 UTC reaction:heart]]
+	// SurrealQL: RELATE users:123->likes->posts:456 SET liked_at = $liked_at_1, reaction = $reaction_1
+	// Vars: map[liked_at_1:2023-10-01 12:00:00 +0000 UTC reaction_1:heart]
+}
+
+func ExampleRelate_compoundOperations() {
+	// RELATE with compound operations using the Set function
+	sql, vars := surrealql.Relate("users:123", "views", "posts:456").
+		Set("count += ?", 1).             // Increment view count
+		Set("last_viewed", "2024-01-01"). // Simple assignment
+		Set("duration_seconds += ?", 30). // Add to duration
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// RELATE users:123->views->posts:456 SET last_viewed = $last_viewed_1, count += $param_1, duration_seconds += $param_2
+	// Variables: map[last_viewed_1:2024-01-01 param_1:1 param_2:30]
 }

--- a/contrib/surrealql/example_transaction_query_test.go
+++ b/contrib/surrealql/example_transaction_query_test.go
@@ -28,13 +28,13 @@ func ExampleTransactionQuery_Query() {
 	}
 	// Output:
 	// BEGIN TRANSACTION;
-	// CREATE users:123 CONTENT $content_1;
+	// CREATE users:123 SET name = $name_1;
 	// UPDATE users:123 SET email = $email_1;
 	// COMMIT TRANSACTION;
-	// Var content_1: map[name:Alice]
-	// Var content_2: map[name:Alice]
 	// Var email_1: alice@example.com
 	// Var email_2: alice@example.com
+	// Var name_1: Alice
+	// Var name_2: Alice
 }
 
 func ExampleTransactionQuery_If() {
@@ -88,8 +88,8 @@ func ExampleTransactionQuery_returningEarly() {
 	fmt.Println(sql)
 	// Output:
 	// BEGIN TRANSACTION;
-	// CREATE account:one CONTENT $content_1;
-	// CREATE account:two CONTENT $content_1;
+	// CREATE account:one SET balance = $balance_1;
+	// CREATE account:two SET balance = $balance_1;
 	// IF !account:two.wants_to_send_money {
 	//     THROW "Customer doesn't want to send any money!";
 	// };

--- a/contrib/surrealql/example_update_test.go
+++ b/contrib/surrealql/example_update_test.go
@@ -158,6 +158,37 @@ func ExampleUpdate_thingAndTable() {
 	// Var tb_1: products
 }
 
+func ExampleUpdate_compoundOperations() {
+	// UPDATE with compound operations using the Set function
+	sql, vars := surrealql.Update("products").
+		Set("stock -= ?", 5).                     // Decrement stock
+		Set("sales_count += ?", 1).               // Increment sales counter
+		Set("last_sold", "2024-01-01T00:00:00Z"). // Simple assignment
+		Where("stock > ?", 0).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPDATE products SET last_sold = $last_sold_1, stock -= $param_1, sales_count += $param_2 WHERE stock > $param_3
+	// Variables: map[last_sold_1:2024-01-01T00:00:00Z param_1:5 param_2:1 param_3:0]
+}
+
+func ExampleUpdate_arrayOperations() {
+	// UPDATE with array operations
+	sql, vars := surrealql.Update("products:laptop").
+		Set("tags += ?", []string{"featured", "sale"}). // Append to array
+		Set("categories -= ?", "deprecated").           // Remove from array
+		Set("stock", 100).                              // Simple assignment
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Variables: %v\n", vars)
+	// Output:
+	// UPDATE products:laptop SET stock = $stock_1, tags += $param_1, categories -= $param_2
+	// Variables: map[param_1:[featured sale] param_2:deprecated stock_1:100]
+}
+
 func ExampleUpdate_returnNone() {
 	// Use RETURN NONE for better performance when results aren't needed
 

--- a/contrib/surrealql/example_upsert_test.go
+++ b/contrib/surrealql/example_upsert_test.go
@@ -318,7 +318,7 @@ func ExampleUpsert_setRaw() {
 }
 
 func ExampleUpsert_setCompound() {
-	// UPSERT with compound operations using the unified Set function
+	// UPSERT with compound operations using the Set function
 	sql, vars := surrealql.Upsert("product:book").
 		Set("tags += ?", "bestseller").
 		Set("view_count += ?", 1).
@@ -350,7 +350,7 @@ func ExampleUpsert_setRaw_arrayOperations() {
 }
 
 func ExampleUpsert_setWithTime() {
-	// UPSERT with time.Time values using the unified Set function
+	// UPSERT with time.Time values using the Set function
 	lastViewed := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 
 	sql, vars := surrealql.Upsert("product:watch").
@@ -368,7 +368,7 @@ func ExampleUpsert_setWithTime() {
 }
 
 func ExampleUpsert_set_arrayOperations() {
-	// UPSERT with array and numeric operations using the unified Set function
+	// UPSERT with array and numeric operations using the Set function
 	sql, vars := surrealql.Upsert("product:laptop").
 		Set("categories += ?", []string{"electronics", "computers"}).
 		Set("stock -= ?", 1).
@@ -385,7 +385,7 @@ func ExampleUpsert_set_arrayOperations() {
 }
 
 func ExampleUpsert_set_mixed() {
-	// UPSERT with mixed operations showing the flexibility of the unified Set function
+	// UPSERT with mixed operations showing the flexibility of the Set function
 	createdAt := time.Date(2024, 1, 20, 15, 30, 0, 0, time.UTC)
 
 	sql, vars := surrealql.Upsert("product:smartphone").

--- a/contrib/surrealql/integration_upsert_test.go
+++ b/contrib/surrealql/integration_upsert_test.go
@@ -266,7 +266,7 @@ func TestIntegration_UpsertUnifiedSet(t *testing.T) {
 	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test10 SET name = 'Unified Product', stock = 50, price = 100", nil)
 	require.NoError(t, err)
 
-	// UPSERT with unified Set for both simple and compound operations
+	// UPSERT with Set for both simple and compound operations
 	sql, vars := surrealql.Upsert("product:upsert_test10").
 		Set("name", "Updated Product").               // Simple assignment
 		Set("stock -= ?", 5).                         // Compound operation with parameter
@@ -297,7 +297,7 @@ func TestIntegration_UpsertSetArrayOperations(t *testing.T) {
 	_, err := surrealdb.Query[[]any](ctx, db, "CREATE product:upsert_test11 SET name = 'Array Product', tags = ['new'], stock = 10", nil)
 	require.NoError(t, err)
 
-	// UPSERT with unified Set for array operations
+	// UPSERT with Set for array operations
 	sql, vars := surrealql.Upsert("product:upsert_test11").
 		Set("tags += ?", []string{"featured", "sale"}). // Append multiple tags
 		Set("stock -= ?", 2).                           // Decrement stock

--- a/contrib/surrealql/relate.go
+++ b/contrib/surrealql/relate.go
@@ -1,6 +1,12 @@
 package surrealql
 
-import "fmt"
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+)
 
 // RelateQuery represents a RELATE query
 type RelateQuery struct {
@@ -8,7 +14,10 @@ type RelateQuery struct {
 	from         string
 	edge         string
 	to           string
+	sets         map[string]any
+	setsRaw      []string
 	content      map[string]any
+	useContent   bool
 	returnClause string
 }
 
@@ -19,19 +28,45 @@ func Relate(from, edge, to string) *RelateQuery {
 		from:      from,
 		edge:      edge,
 		to:        to,
+		sets:      make(map[string]any),
 		content:   make(map[string]any),
 	}
 }
 
-// Set adds a field to the relation
-func (q *RelateQuery) Set(field string, value any) *RelateQuery {
-	q.content[field] = value
+// Set adds a field or expression to the relation
+// Can be used for simple assignment: Set("name", "value")
+// Or for compound operations: Set("count += ?", 1)
+func (q *RelateQuery) Set(expr string, args ...any) *RelateQuery {
+	// Check if this is a simple field assignment or an expression
+	if len(args) == 1 && !strings.ContainsAny(expr, "?+=<>!-*/") {
+		// Simple field assignment
+		q.sets[expr] = args[0]
+	} else if len(args) > 0 {
+		// Expression with placeholders
+		processedExpr := expr
+		for _, arg := range args {
+			paramName := q.generateParamName("param")
+			processedExpr = strings.Replace(processedExpr, "?", "$"+paramName, 1)
+			q.addParam(paramName, arg)
+		}
+		q.setsRaw = append(q.setsRaw, processedExpr)
+	} else {
+		// Raw expression without placeholders
+		q.setsRaw = append(q.setsRaw, expr)
+	}
 	return q
 }
 
 // Content sets the entire content for the relation
 func (q *RelateQuery) Content(content map[string]any) *RelateQuery {
 	q.content = content
+	q.useContent = true
+	return q
+}
+
+// SetMap sets multiple fields from a map
+func (q *RelateQuery) SetMap(fields map[string]any) *RelateQuery {
+	maps.Copy(q.sets, fields)
 	return q
 }
 
@@ -54,10 +89,30 @@ func (q *RelateQuery) String() string {
 		escapeIdent(q.edge),
 		q.to)
 
-	if len(q.content) > 0 {
+	if q.useContent && len(q.content) > 0 {
 		paramName := q.generateParamName("content")
 		q.addParam(paramName, q.content)
 		sql += fmt.Sprintf(" CONTENT $%s", paramName)
+	} else if len(q.sets) > 0 || len(q.setsRaw) > 0 {
+		var setParts []string
+
+		// Handle SET fields
+		if len(q.sets) > 0 {
+			setsKeys := sort.StringSlice(slices.Collect(maps.Keys(q.sets)))
+			sort.Stable(setsKeys)
+
+			for _, field := range setsKeys {
+				value := q.sets[field]
+				paramName := q.generateParamName(field)
+				q.addParam(paramName, value)
+				setParts = append(setParts, fmt.Sprintf("%s = $%s", escapeIdent(field), paramName))
+			}
+		}
+
+		// Handle raw SET expressions
+		setParts = append(setParts, q.setsRaw...)
+
+		sql += " SET " + strings.Join(setParts, ", ")
 	}
 
 	if q.returnClause != "" {

--- a/contrib/surrealql/relate_test.go
+++ b/contrib/surrealql/relate_test.go
@@ -14,9 +14,19 @@ func TestRelate(t *testing.T) {
 			wantSurQL: "RELATE users:123->likes->posts:456",
 		},
 		{
-			name:      "relate with content",
+			name:      "relate with set",
 			query:     Relate("users:123", "likes", "posts:456").Set("rating", 5),
+			wantSurQL: "RELATE users:123->likes->posts:456 SET rating = $rating_1",
+		},
+		{
+			name:      "relate with content",
+			query:     Relate("users:123", "likes", "posts:456").Content(map[string]any{"rating": 5, "timestamp": "2024-01-01"}),
 			wantSurQL: "RELATE users:123->likes->posts:456 CONTENT $content_1",
+		},
+		{
+			name:      "relate with compound operation",
+			query:     Relate("users:123", "views", "posts:456").Set("count += ?", 1).Set("last_viewed", "2024-01-01"),
+			wantSurQL: "RELATE users:123->views->posts:456 SET last_viewed = $last_viewed_1, count += $param_1",
 		},
 	}
 

--- a/contrib/surrealql/sets_builder.go
+++ b/contrib/surrealql/sets_builder.go
@@ -1,0 +1,82 @@
+package surrealql
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// setsBuilder provides common functionality for building SET clauses
+type setsBuilder struct {
+	sets    map[string]any
+	setsRaw []string
+}
+
+// newSetsBuilder creates a new setsBuilder
+func newSetsBuilder() setsBuilder {
+	return setsBuilder{
+		sets: make(map[string]any),
+	}
+}
+
+// addSet adds a field or expression to the SET clause
+// Can be used for simple assignment: addSet("name", "value")
+// Or for compound operations: addSet("count += ?", 1)
+func (sb *setsBuilder) addSet(expr string, args []any, base *baseQuery, paramPrefix string) {
+	// Check if this is a simple field assignment or an expression
+	if len(args) == 1 && !strings.ContainsAny(expr, "?+=<>!-*/") {
+		// Simple field assignment
+		sb.sets[expr] = args[0]
+	} else if len(args) > 0 {
+		// Expression with placeholders
+		processedExpr := expr
+		for _, arg := range args {
+			paramName := base.generateParamName(paramPrefix)
+			processedExpr = strings.Replace(processedExpr, "?", "$"+paramName, 1)
+			base.addParam(paramName, arg)
+		}
+		sb.setsRaw = append(sb.setsRaw, processedExpr)
+	} else {
+		// Raw expression without placeholders
+		sb.setsRaw = append(sb.setsRaw, expr)
+	}
+}
+
+// addSetMap adds multiple fields from a map
+func (sb *setsBuilder) addSetMap(fields map[string]any) {
+	maps.Copy(sb.sets, fields)
+}
+
+// buildSetClause builds the SET clause and adds parameters to the base query
+func (sb *setsBuilder) buildSetClause(base *baseQuery, paramPrefix string) string {
+	if len(sb.sets) == 0 && len(sb.setsRaw) == 0 {
+		return ""
+	}
+
+	var setParts []string
+
+	// Handle SET fields
+	if len(sb.sets) > 0 {
+		setsKeys := sort.StringSlice(slices.Collect(maps.Keys(sb.sets)))
+		sort.Stable(setsKeys)
+
+		for _, field := range setsKeys {
+			value := sb.sets[field]
+			var paramName string
+			if paramPrefix != "" {
+				paramName = base.generateParamName(paramPrefix + "_" + field)
+			} else {
+				paramName = base.generateParamName(field)
+			}
+			base.addParam(paramName, value)
+			setParts = append(setParts, fmt.Sprintf("%s = $%s", escapeIdent(field), paramName))
+		}
+	}
+
+	// Handle raw SET expressions
+	setParts = append(setParts, sb.setsRaw...)
+
+	return strings.Join(setParts, ", ")
+}

--- a/contrib/surrealql/update.go
+++ b/contrib/surrealql/update.go
@@ -13,6 +13,7 @@ type UpdateQuery struct {
 	baseQuery
 	targets      []string
 	sets         map[string]any
+	setsRaw      []string
 	whereClause  *whereBuilder
 	returnClause string
 }
@@ -42,17 +43,33 @@ func updateAddTarget[MT mutationTarget](q *UpdateQuery, target MT) *UpdateQuery 
 	return q
 }
 
-// Set adds a field to update
-func (q *UpdateQuery) Set(field string, value any) *UpdateQuery {
-	q.sets[field] = value
+// Set adds a field or expression to update
+// Can be used for simple assignment: Set("name", "value")
+// Or for compound operations: Set("count += ?", 1)
+func (q *UpdateQuery) Set(expr string, args ...any) *UpdateQuery {
+	// Check if this is a simple field assignment or an expression
+	if len(args) == 1 && !strings.ContainsAny(expr, "?+=<>!-*/") {
+		// Simple field assignment
+		q.sets[expr] = args[0]
+	} else if len(args) > 0 {
+		// Expression with placeholders
+		processedExpr := expr
+		for _, arg := range args {
+			paramName := q.generateParamName("param")
+			processedExpr = strings.Replace(processedExpr, "?", "$"+paramName, 1)
+			q.addParam(paramName, arg)
+		}
+		q.setsRaw = append(q.setsRaw, processedExpr)
+	} else {
+		// Raw expression without placeholders
+		q.setsRaw = append(q.setsRaw, expr)
+	}
 	return q
 }
 
 // SetMap sets multiple fields from a map
 func (q *UpdateQuery) SetMap(fields map[string]any) *UpdateQuery {
-	for k, v := range fields {
-		q.sets[k] = v
-	}
+	maps.Copy(q.sets, fields)
 	return q
 }
 
@@ -101,17 +118,25 @@ func (q *UpdateQuery) String() string {
 
 	sql = fmt.Sprintf("UPDATE %s", sql)
 
-	if len(q.sets) > 0 {
-		setsKeys := sort.StringSlice(slices.Collect(maps.Keys(q.sets)))
-		sort.Stable(setsKeys)
-
+	if len(q.sets) > 0 || len(q.setsRaw) > 0 {
 		var setParts []string
-		for _, field := range setsKeys {
-			value := q.sets[field]
-			paramName := q.generateParamName(field)
-			q.addParam(paramName, value)
-			setParts = append(setParts, fmt.Sprintf("%s = $%s", escapeIdent(field), paramName))
+
+		// Handle SET fields
+		if len(q.sets) > 0 {
+			setsKeys := sort.StringSlice(slices.Collect(maps.Keys(q.sets)))
+			sort.Stable(setsKeys)
+
+			for _, field := range setsKeys {
+				value := q.sets[field]
+				paramName := q.generateParamName(field)
+				q.addParam(paramName, value)
+				setParts = append(setParts, fmt.Sprintf("%s = $%s", escapeIdent(field), paramName))
+			}
 		}
+
+		// Handle raw SET expressions
+		setParts = append(setParts, q.setsRaw...)
+
 		sql += " SET " + strings.Join(setParts, ", ")
 	}
 

--- a/contrib/surrealql/update_test.go
+++ b/contrib/surrealql/update_test.go
@@ -28,6 +28,16 @@ func TestUpdate(t *testing.T) {
 			query:     Update("users").Set("name", "Jane").ReturnDiff(),
 			wantSurQL: "UPDATE users SET name = $name_1 RETURN DIFF",
 		},
+		{
+			name:      "update with compound operation",
+			query:     Update("products").Set("stock -= ?", 5).Set("last_sold", "2024-01-01"),
+			wantSurQL: "UPDATE products SET last_sold = $last_sold_1, stock -= $param_1",
+		},
+		{
+			name:      "update with multiple compound operations",
+			query:     Update("stats").Set("views += ?", 1).Set("clicks += ?", 1),
+			wantSurQL: "UPDATE stats SET views += $param_1, clicks += $param_2",
+		},
 	}
 
 	for _, tt := range tests {

--- a/contrib/surrealql/upsert_test.go
+++ b/contrib/surrealql/upsert_test.go
@@ -352,7 +352,7 @@ func TestUpsert_Basic(t *testing.T) {
 			},
 		},
 		{
-			name: "upsert with unified Set for compound operations",
+			name: "upsert with Set for compound operations",
 			build: func() (string, map[string]any) {
 				return Upsert("product:item").
 					Set("name", "Test Item").
@@ -368,7 +368,7 @@ func TestUpsert_Basic(t *testing.T) {
 			},
 		},
 		{
-			name: "upsert with unified Set mixing simple and compound",
+			name: "upsert with Set mixing simple and compound",
 			build: func() (string, map[string]any) {
 				return Upsert("product:mix").
 					Set("count += ?", 1).


### PR DESCRIPTION
This enhances the surrealql library added in #289 to have the `Set` function that supports compound ops, making those on part with the implementation of `Set` in #293.

Ref #151