### PR TITLE
SurrealQL query builder: SelectFrom

### DIFF
--- a/contrib/surrealql/example_create_test.go
+++ b/contrib/surrealql/example_create_test.go
@@ -77,7 +77,7 @@ func ExampleCreate_integration_thing_recordID() {
 	// Assume we have a *surrealdb.DB instance
 	var db *surrealdb.DB
 
-	db, err := testenv.New("test", "users")
+	db, err := testenv.New("surrealql", "test", "users")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func ExampleCreate_integration_thing_recordID() {
 func ExampleCreate_integration_table() {
 	var db *surrealdb.DB
 
-	db, err := testenv.New("test", "users")
+	db, err := testenv.New("surrealql", "test", "users")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/surrealql/example_select_from_advanced_test.go
+++ b/contrib/surrealql/example_select_from_advanced_test.go
@@ -1,0 +1,82 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelectFrom_edgecase_invalidAdvancedGraphTraversal demonstrates a complex and invalid graph traversal with placeholders
+// As surrealql does not parse `->` expressions on its own, it produces an invalid query.
+// In SurrealQL, you can write `FROM $from_param_1->follows->users->created->posts` which is valid.
+// However, `FROM $from_param_1->$from_param_2` is invalid- you cannot place random variables in the middle of a path.
+func ExampleSelectFrom_edgecase_invalidAdvancedGraphTraversal() {
+	// Imagine building a dynamic social network query where the starting user
+	// and relationship type are parameters
+	startUser := models.NewRecordID("users", "alice")
+	relationshipType := "follows"
+	targetTable := "posts"
+
+	// Build a query to find all posts from users that Alice follows
+	sql, vars := surrealql.SelectFrom("?->?->users->created->?",
+		startUser,
+		relationshipType,
+		targetTable).
+		FieldName("title").
+		FieldName("content").
+		FieldName("created_at").
+		Where("published = ?", true).
+		OrderByDesc("created_at").
+		Limit(10).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("vars count: %d\n", len(vars))
+	// Output: SELECT title, content, created_at FROM $from_param_1->$from_param_2->users->created->$from_param_3 WHERE published = $param_1 ORDER BY created_at DESC LIMIT 10
+	// vars count: 4
+}
+
+// ExampleSelectFrom_dynamicTableSelection demonstrates dynamic table selection
+func ExampleSelectFrom_dynamicTableSelection() {
+	// In a multi-tenant application, you might need to dynamically select
+	// from different tables based on the tenant
+	tenant := "acme_corp"
+	tableName := fmt.Sprintf("events_%s", tenant)
+
+	sql, vars := surrealql.SelectFrom("?", tableName).
+		FieldRaw("count() AS total_events").
+		FieldRaw("math::mean(duration) AS avg_duration").
+		Where("timestamp > ? AND timestamp < ?", "2024-01-01", "2024-12-31").
+		GroupBy("event_type").
+		Build()
+
+	fmt.Println(sql)
+	// Table name is now a parameter
+	fmt.Printf("table param: %v\n", vars["from_param_1"])
+	fmt.Printf("timestamp params: %v, %v\n", vars["param_1"], vars["param_2"])
+	// Output: SELECT count() AS total_events, math::mean(duration) AS avg_duration FROM $from_param_1 WHERE timestamp > $param_1 AND timestamp < $param_2 GROUP BY event_type
+	// table param: events_acme_corp
+	// timestamp params: 2024-01-01, 2024-12-31
+}
+
+// ExampleSelectFrom_complexPlaceholderCombination demonstrates combining different types
+func ExampleSelectFrom_complexPlaceholderCombination() {
+	// Complex scenario: Start from a record, traverse through a dynamic relationship,
+	// and end at a dynamic target
+	user := models.NewRecordID("users", 123)
+	edge := "purchased"
+
+	// Find all products purchased by user 123
+	sql, vars := surrealql.SelectFrom("?->?->products", user, edge).
+		FieldName("name").
+		FieldName("price").
+		FieldRaw("price * 0.1 AS tax").
+		Build()
+
+	fmt.Println(sql)
+	// All placeholders become parameters
+	fmt.Printf("vars: from_param_1 type: %T, from_param_2: %v\n", vars["from_param_1"], vars["from_param_2"])
+	// Output: SELECT name, price, price * 0.1 AS tax FROM $from_param_1->$from_param_2->products
+	// vars: from_param_1 type: models.RecordID, from_param_2: purchased
+}

--- a/contrib/surrealql/example_select_from_models_table_test.go
+++ b/contrib/surrealql/example_select_from_models_table_test.go
@@ -1,0 +1,58 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelectFrom_modelsTable demonstrates using models.Table for type-safe table selection
+func ExampleSelectFrom_modelsTable() {
+	// models.Table provides type safety and proper CBOR encoding for table names
+	table := models.Table("users")
+	sql, vars := surrealql.SelectFrom(table).Build()
+
+	fmt.Println(sql)
+	fmt.Printf("vars: table_1=%v (type: %T)\n", vars["table_1"], vars["table_1"])
+	// Output: SELECT * FROM $table_1
+	// vars: table_1=users (type: models.Table)
+}
+
+// ExampleSelectFrom_modelsTableWithConditions demonstrates using models.Table with WHERE conditions
+func ExampleSelectFrom_modelsTableWithConditions() {
+	// Combine models.Table with other query operations
+	table := models.Table("products")
+	sql, vars := surrealql.SelectFrom(table).
+		FieldName("name").
+		FieldName("price").
+		Where("category = ? AND price > ?", "electronics", 100).
+		OrderBy("price").
+		Limit(10).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Table: %v, Category: %v, MinPrice: %v\n",
+		vars["table_1"], vars["param_1"], vars["param_2"])
+	// Output: SELECT name, price FROM $table_1 WHERE category = $param_1 AND price > $param_2 ORDER BY price LIMIT 10
+	// Table: products, Category: electronics, MinPrice: 100
+}
+
+// ExampleSelectFrom_modelsTableDynamic demonstrates dynamic table selection with models.Table
+func ExampleSelectFrom_modelsTableDynamic() {
+	// Useful when table name comes from configuration or user input
+	// models.Table ensures proper type handling in SurrealDB
+	getTableName := func() string {
+		return "user_sessions"
+	}
+
+	table := models.Table(getTableName())
+	sql, vars := surrealql.SelectFrom(table).
+		FieldRaw("count() AS total").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("Counting records in table: %v\n", vars["table_1"])
+	// Output: SELECT count() AS total FROM $table_1
+	// Counting records in table: user_sessions
+}

--- a/contrib/surrealql/example_select_from_parameter_test.go
+++ b/contrib/surrealql/example_select_from_parameter_test.go
@@ -1,0 +1,46 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelectFrom_parameterRules demonstrates SurrealDB's parameter rules in FROM clauses
+func ExampleSelectFrom_parameterRules() {
+	// Rule 1: Parameters ARE allowed at the START of FROM expressions
+	user := models.NewRecordID("users", "john")
+	sql1, vars1 := surrealql.SelectFrom("?->knows->users", user).Build()
+	fmt.Println("Start position:")
+	fmt.Println(sql1)
+	fmt.Printf("Has parameter: %v\n", len(vars1) > 0)
+
+	// Rule 2: Placeholders in middle/end also generate parameters
+	// SurrealDB will reject these if it doesn't allow them there
+	sql2, vars2 := surrealql.SelectFrom("users->?->?", "knows", "users").Build()
+	fmt.Println("\nMiddle/end positions:")
+	fmt.Println(sql2)
+	fmt.Printf("Has parameter: %v\n", len(vars2) > 0)
+
+	// Rule 3: First placeholder can be parameter, subsequent ones are inlined
+	sql3, vars3 := surrealql.SelectFrom("?->?->?",
+		models.NewRecordID("users", "alice"),
+		"follows",
+		"posts").Build()
+	fmt.Println("\nMixed positions:")
+	fmt.Println(sql3)
+	fmt.Printf("Parameter count: %d\n", len(vars3))
+
+	// Output: Start position:
+	// SELECT * FROM $from_param_1->knows->users
+	// Has parameter: true
+	//
+	// Middle/end positions:
+	// SELECT * FROM users->$from_param_1->$from_param_2
+	// Has parameter: true
+	//
+	// Mixed positions:
+	// SELECT * FROM $from_param_1->$from_param_2->$from_param_3
+	// Parameter count: 3
+}

--- a/contrib/surrealql/example_select_from_record_id_test.go
+++ b/contrib/surrealql/example_select_from_record_id_test.go
@@ -1,0 +1,56 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelectFrom_modelsRecordID demonstrates using models.RecordID for specific record selection
+func ExampleSelectFrom_modelsRecordID() {
+	// models.RecordID provides type safety and proper CBOR encoding for record IDs
+	recordID := models.NewRecordID("users", "john")
+	sql, vars := surrealql.SelectFrom(recordID).Build()
+
+	fmt.Println(sql)
+	recordIDVar := vars["record_id_1"].(models.RecordID)
+	fmt.Printf("vars: record_id_1=%s:%v (type: %T)\n", recordIDVar.Table, recordIDVar.ID, vars["record_id_1"])
+	// Output: SELECT * FROM $record_id_1
+	// vars: record_id_1=users:john (type: models.RecordID)
+}
+
+// ExampleSelectFrom_modelsRecordIDWithFields demonstrates selecting specific fields from a record
+func ExampleSelectFrom_modelsRecordIDWithFields() {
+	// Select specific fields from a record using models.RecordID
+	recordID := models.NewRecordID("products", 12345)
+	sql, vars := surrealql.SelectFrom(&recordID).
+		FieldName("name").
+		FieldName("price").
+		FieldName("stock").
+		Build()
+
+	fmt.Println(sql)
+	recordIDVar := vars["record_id_1"].(models.RecordID)
+	fmt.Printf("Record: %s:%v\n", recordIDVar.Table, recordIDVar.ID)
+	// Output: SELECT name, price, stock FROM $record_id_1
+	// Record: products:12345
+}
+
+// ExampleSelectFrom_modelsRecordIDWithConditions demonstrates using models.RecordID with WHERE
+func ExampleSelectFrom_modelsRecordIDWithConditions() {
+	// Even when selecting from a specific record, you can add conditions
+	// This is useful for conditional field selection or validation
+	recordID := models.NewRecordID("orders", "order_789")
+	sql, vars := surrealql.SelectFrom(recordID).
+		FieldName("items").
+		FieldName("total").
+		Where("status = ?", "completed").
+		Build()
+
+	fmt.Println(sql)
+	recordIDVar := vars["record_id_1"].(models.RecordID)
+	fmt.Printf("Order: %s:%v, Status: %v\n", recordIDVar.Table, recordIDVar.ID, vars["param_1"])
+	// Output: SELECT items, total FROM $record_id_1 WHERE status = $param_1
+	// Order: orders:order_789, Status: completed
+}

--- a/contrib/surrealql/example_select_from_table_test.go
+++ b/contrib/surrealql/example_select_from_table_test.go
@@ -1,0 +1,54 @@
+package surrealql_test
+
+import (
+	"fmt"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelectFrom_tableWithSpecialChars demonstrates using SelectFrom with models.Table for safe table selection
+func ExampleSelectFrom_tableWithSpecialChars() {
+	// When you have a table name that contains special characters
+	// or might be interpreted as an expression, use SelectFrom with models.Table
+	sql, vars := surrealql.SelectFrom(models.Table("user-data")).
+		FieldName("id").
+		FieldName("name").
+		Where("active = ?", true).
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("vars: table_1=%v, param_1=%v\n", vars["table_1"], vars["param_1"])
+	// Output: SELECT id, name FROM $table_1 WHERE active = $param_1
+	// vars: table_1=user-data, param_1=true
+}
+
+// ExampleSelectFrom_tableReservedWord demonstrates handling reserved words as table names
+func ExampleSelectFrom_tableReservedWord() {
+	// Reserved SurrealQL keywords are safely handled using models.Table
+	sql, vars := surrealql.SelectFrom(models.Table("select")).
+		FieldName("id").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("vars: table_1=%v\n", vars["table_1"])
+	// Output: SELECT id FROM $table_1
+	// vars: table_1=select
+}
+
+// ExampleSelectFrom_dynamicTableName demonstrates safe handling of dynamic table names
+func ExampleSelectFrom_dynamicTableName() {
+	// In a multi-tenant system, you might construct table names dynamically
+	// SelectFrom with models.Table provides safe parameterization
+	tenant := "acme-corp"
+	tableName := fmt.Sprintf("events-%s", tenant)
+
+	sql, vars := surrealql.SelectFrom(models.Table(tableName)).
+		FieldRaw("count() AS total").
+		Build()
+
+	fmt.Println(sql)
+	fmt.Printf("vars: table_1=%v\n", vars["table_1"])
+	// Output: SELECT count() AS total FROM $table_1
+	// vars: table_1=events-acme-corp
+}

--- a/contrib/surrealql/example_select_from_test.go
+++ b/contrib/surrealql/example_select_from_test.go
@@ -1,0 +1,188 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelectFrom_table demonstrates selecting all from a table
+func ExampleSelectFrom_table() {
+	sql, _ := surrealql.SelectFrom("users").Build()
+	fmt.Println(sql)
+	// Output: SELECT * FROM users
+}
+
+// ExampleSelectFrom_specificRecord demonstrates selecting from a specific record
+func ExampleSelectFrom_specificRecord() {
+	sql, _ := surrealql.SelectFrom("users:123").Build()
+	fmt.Println(sql)
+	// Output: SELECT * FROM users:123
+}
+
+// ExampleSelectFrom_withFields demonstrates adding specific fields to SelectFrom
+func ExampleSelectFrom_withFields() {
+	sql, _ := surrealql.SelectFrom("users").
+		FieldName("name").
+		FieldName("email").
+		Build()
+	fmt.Println(sql)
+	// Output: SELECT name, email FROM users
+}
+
+// ExampleSelectFrom_withExpression demonstrates using expressions in field selection
+func ExampleSelectFrom_withExpression() {
+	sql, _ := surrealql.SelectFrom("foo:5").
+		FieldRaw(`text + "b" AS aa`).
+		Build()
+	fmt.Println(sql)
+	// Output: SELECT text + "b" AS aa FROM foo:5
+}
+
+// ExampleSelectFrom_array demonstrates selecting from an array literal
+func ExampleSelectFrom_array() {
+	arr := []any{1, 2, 3}
+	sql, vars := surrealql.SelectFrom("?", arr).Build()
+	fmt.Println(sql)
+	fmt.Printf("vars: %v\n", vars)
+	// Output: SELECT * FROM $from_param_1
+	// vars: map[from_param_1:[1 2 3]]
+}
+
+// ExampleSelectFrom_object demonstrates selecting from an object literal
+func ExampleSelectFrom_object() {
+	obj := map[string]any{"a": 1, "b": 2}
+	sql, vars := surrealql.SelectFrom("?", obj).Build()
+	fmt.Println(sql)
+	fmt.Printf("vars: %v\n", vars)
+	// Output: SELECT * FROM $from_param_1
+	// vars: map[from_param_1:map[a:1 b:2]]
+}
+
+// ExampleSelectFrom_arrayOfObjects demonstrates selecting from an array of objects
+func ExampleSelectFrom_arrayOfObjects() {
+	arr := []any{
+		map[string]any{"a": 1},
+		map[string]any{"a": 2},
+	}
+	sql, vars := surrealql.SelectFrom("?", arr).Build()
+	fmt.Println(sql)
+	fmt.Printf("vars: %v\n", vars)
+	// Output: SELECT * FROM $from_param_1
+	// vars: map[from_param_1:[map[a:1] map[a:2]]]
+}
+
+// ExampleSelectFrom_subquery demonstrates using a subquery as the source
+func ExampleSelectFrom_subquery() {
+	subquery := surrealql.Select("name").FromTable("users").Where("age > ?", 18)
+	sql, vars := surrealql.SelectFrom(subquery).Build()
+	fmt.Println(sql)
+	fmt.Printf("vars: %v\n", vars)
+	// Output: SELECT * FROM (SELECT name FROM users WHERE age > $param_1)
+	// vars: map[param_1:18]
+}
+
+// ExampleSelectFrom_target demonstrates using a target struct
+func ExampleSelectFrom_target() {
+	target := surrealql.Thing("users", 123)
+	sql, vars := surrealql.SelectFrom(target).Build()
+	fmt.Println(sql)
+	// Print the RecordID type name instead of the full value for consistent output
+	fmt.Printf("vars keys: %v, id_1 type: %T\n", getMapKeys(vars), vars["id_1"])
+	// Output:
+	// SELECT * FROM $id_1
+	// vars keys: [id_1], id_1 type: models.RecordID
+}
+
+// ExampleSelectFrom_recordID demonstrates using a RecordID
+func ExampleSelectFrom_recordID() {
+	recordID := models.NewRecordID("users", 456)
+	sql, vars := surrealql.SelectFrom(recordID).Build()
+	fmt.Println(sql)
+	// Print the RecordID type name instead of the full value for consistent output
+	fmt.Printf("vars keys: %v, record_id_1 type: %T\n", getMapKeys(vars), vars["record_id_1"])
+	// Output:
+	// SELECT * FROM $record_id_1
+	// vars keys: [record_id_1], record_id_1 type: models.RecordID
+}
+
+// ExampleSelectFrom_complexExpression demonstrates complex field expressions
+func ExampleSelectFrom_complexExpression() {
+	sql, _ := surrealql.SelectFrom("products").
+		FieldRaw("name").
+		FieldRaw("price * 1.1 AS price_with_tax").
+		FieldRaw("count() AS total").
+		Where("category = ?", "electronics").
+		GroupBy("category").
+		Build()
+	fmt.Println(sql)
+	// Output: SELECT name, price * 1.1 AS price_with_tax, count() AS total FROM products WHERE category = $param_1 GROUP BY category
+}
+
+// ExampleSelectFrom_rawExpression demonstrates using a raw expression as the source
+func ExampleSelectFrom_rawExpression() {
+	// You can pass any valid SurrealQL expression as a string
+	sql, _ := surrealql.SelectFrom("(SELECT * FROM users WHERE active = true)").Build()
+	fmt.Println(sql)
+	// Output: SELECT * FROM (SELECT * FROM users WHERE active = true)
+}
+
+// ExampleSelectFrom_graphTraversal demonstrates graph traversal as source
+func ExampleSelectFrom_graphTraversal() {
+	// SurrealDB supports graph traversal in FROM clause
+	sql, _ := surrealql.SelectFrom("users:john->knows->users").
+		FieldName("name").
+		Build()
+	fmt.Println(sql)
+	// Output: SELECT name FROM users:john->knows->users
+}
+
+// ExampleSelectFrom_withPlaceholder demonstrates using a placeholder for parameterized FROM
+func ExampleSelectFrom_withPlaceholder() {
+	// Use ? placeholder at the start - this creates a parameter
+	recordID := models.NewRecordID("users", "john")
+	sql, vars := surrealql.SelectFrom("?->knows->users", recordID).Build()
+	fmt.Println(sql)
+	fmt.Printf("vars: from_param_1 type: %T\n", vars["from_param_1"])
+	// Output: SELECT * FROM $from_param_1->knows->users
+	// vars: from_param_1 type: models.RecordID
+}
+
+// ExampleSelectFrom_multiplePlaceholders demonstrates using multiple placeholders
+func ExampleSelectFrom_multiplePlaceholders() {
+	// Use multiple placeholders in a graph traversal
+	// Note: All placeholders become parameters
+	fromRecord := models.NewRecordID("users", "john")
+	toTable := "users"
+	sql, vars := surrealql.SelectFrom("?->knows->?", fromRecord, toTable).
+		FieldName("name").
+		Build()
+	fmt.Println(sql)
+	fmt.Printf("vars count: %d, from_param_1 type: %T\n", len(vars), vars["from_param_1"])
+	// Output: SELECT name FROM $from_param_1->knows->$from_param_2
+	// vars count: 2, from_param_1 type: models.RecordID
+}
+
+// ExampleSelectFrom_placeholderWithTable demonstrates table placeholder
+func ExampleSelectFrom_placeholderWithTable() {
+	// Dynamically specify table name
+	sql, vars := surrealql.SelectFrom("?", "products").
+		Where("price > ?", 100).
+		Build()
+	fmt.Println(sql)
+	fmt.Printf("vars: from_param_1: %v, param_1: %v\n", vars["from_param_1"], vars["param_1"])
+	// Output: SELECT * FROM $from_param_1 WHERE price > $param_1
+	// vars: from_param_1: products, param_1: 100
+}
+
+// Helper function to get sorted map keys for consistent output
+func getMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/contrib/surrealql/example_select_test.go
+++ b/contrib/surrealql/example_select_test.go
@@ -341,7 +341,7 @@ func ExampleSelect_integration() {
 	// Assume we have a *surrealdb.DB instance
 	var db *surrealdb.DB
 
-	db, err := testenv.New("test", "users")
+	db, err := testenv.New("surrealql", "test", "users")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/surrealql/integration_create_return_test.go
+++ b/contrib/surrealql/integration_create_return_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestIntegrationReturnClauses(t *testing.T) {
-	db := testenv.MustNew("surrealql_test_return_test", "tasks")
+	// Use a unique database/namespace to avoid conflicts with other tests
+	db := testenv.MustNew("surrealql", "return_clauses", "tasks")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_create_return_test.go
+++ b/contrib/surrealql/integration_create_return_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationReturnClauses(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "tasks")
+	db := testenv.MustNew("surrealql_test_return_test", "tasks")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_create_return_test.go
+++ b/contrib/surrealql/integration_create_return_test.go
@@ -18,7 +18,7 @@ func TestIntegrationReturnClauses(t *testing.T) {
 	ctx := context.Background()
 
 	type Task struct {
-		ID        models.RecordID       `json:"id,omitempty"`
+		ID        *models.RecordID      `json:"id,omitempty"`
 		Title     string                `json:"title"`
 		Completed bool                  `json:"completed"`
 		UpdatedAt models.CustomDateTime `json:"updated_at"`

--- a/contrib/surrealql/integration_define_test.go
+++ b/contrib/surrealql/integration_define_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIntegrationDefineTable(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "events")
+	db := testenv.MustNewDeprecated("surrealql_test", "events")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_insert_test.go
+++ b/contrib/surrealql/integration_insert_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIntegrationInsert(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "products", "categories", "product_categories")
+	db := testenv.MustNewDeprecated("surrealql_test", "products", "categories", "product_categories")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_item_crud_test.go
+++ b/contrib/surrealql/integration_item_crud_test.go
@@ -23,7 +23,7 @@ type Item struct {
 }
 
 func TestIntegrationCreateThenUpdate(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "items")
+	db := testenv.MustNewDeprecated("surrealql_test", "items")
 	ctx := context.Background()
 
 	t.Run("Create", func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestIntegrationCreateThenUpdate(t *testing.T) {
 }
 
 func TestIntegrationCreateThenDelete(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "items_delete")
+	db := testenv.MustNewDeprecated("surrealql_test", "items_delete")
 	ctx := context.Background()
 
 	// Setup: Create items with different active states

--- a/contrib/surrealql/integration_product_count_test.go
+++ b/contrib/surrealql/integration_product_count_test.go
@@ -39,7 +39,7 @@ func setupProductData(t *testing.T, ctx context.Context, db *surrealdb.DB, table
 }
 
 func TestIntegrationCount_All(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "products_all")
+	db := testenv.MustNewDeprecated("surrealql_test", "products_all")
 	ctx := context.Background()
 
 	// Setup test data
@@ -92,7 +92,7 @@ func TestIntegrationCount_All(t *testing.T) {
 }
 
 func TestIntegrationCount_WithWhere(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "products_where")
+	db := testenv.MustNewDeprecated("surrealql_test", "products_where")
 	ctx := context.Background()
 
 	// Setup test data
@@ -121,7 +121,7 @@ func TestIntegrationCount_WithWhere(t *testing.T) {
 }
 
 func TestIntegrationCount_GroupBy(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "products_group")
+	db := testenv.MustNewDeprecated("surrealql_test", "products_group")
 	ctx := context.Background()
 
 	// Setup test data

--- a/contrib/surrealql/integration_relate_test.go
+++ b/contrib/surrealql/integration_relate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIntegrationRelate(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "users", "posts", "likes")
+	db := testenv.MustNewDeprecated("surrealql_test", "users", "posts", "likes")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_sales_aggregate_test.go
+++ b/contrib/surrealql/integration_sales_aggregate_test.go
@@ -46,7 +46,7 @@ func setupSalesData(t *testing.T, ctx context.Context, db *surrealdb.DB, table s
 }
 
 func TestIntegrationAggregate_Sum(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "sales_sum")
+	db := testenv.MustNewDeprecated("surrealql_test", "sales_sum")
 	ctx := context.Background()
 
 	// Setup test data
@@ -93,7 +93,7 @@ func TestIntegrationAggregate_Sum(t *testing.T) {
 }
 
 func TestIntegrationAggregate_Average(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "sales_avg")
+	db := testenv.MustNewDeprecated("surrealql_test", "sales_avg")
 	ctx := context.Background()
 
 	// Setup test data
@@ -126,7 +126,7 @@ func TestIntegrationAggregate_Average(t *testing.T) {
 }
 
 func TestIntegrationAggregate_MinMax(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "sales_minmax")
+	db := testenv.MustNewDeprecated("surrealql_test", "sales_minmax")
 	ctx := context.Background()
 
 	// Setup test data

--- a/contrib/surrealql/integration_select_from_record_id_test.go
+++ b/contrib/surrealql/integration_select_from_record_id_test.go
@@ -1,0 +1,136 @@
+package surrealql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestIntegrationSelectFromRecordID(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "select_from_record_id_test")
+	ctx := context.Background()
+
+	tableName := "record_test_data"
+
+	// Clean up any existing data first
+	cleanupQuery := fmt.Sprintf("DELETE %s", tableName)
+	_, _ = surrealdb.Query[any](ctx, db, cleanupQuery, nil)
+
+	t.Run("SelectFrom with models.RecordID", func(t *testing.T) {
+		// First insert a specific record
+		insertQuery := fmt.Sprintf("CREATE %s:test_user SET name = 'Test User', active = true", tableName)
+		_, err := surrealdb.Query[any](ctx, db, insertQuery, nil)
+		assert.NoError(t, err)
+
+		// Test using models.RecordID directly with SelectFrom
+		recordID := models.NewRecordID(tableName, "test_user")
+
+		sql, vars := surrealql.SelectFrom(recordID).
+			FieldName("name").
+			FieldName("active").
+			Build()
+
+		t.Logf("RecordID query SQL: %s", sql)
+		t.Logf("RecordID query vars: %+v", vars)
+
+		// Execute the query
+		type UserData struct {
+			Name   string `json:"name"`
+			Active bool   `json:"active"`
+		}
+
+		results, err := surrealdb.Query[[]UserData](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Verify we get the specific record
+		if len(*results) > 0 && (*results)[0].Result != nil {
+			users := (*results)[0].Result
+			assert.Len(t, users, 1, "Should find exactly 1 user")
+			if len(users) == 1 {
+				assert.Equal(t, "Test User", users[0].Name)
+				assert.Equal(t, true, users[0].Active)
+			}
+		}
+	})
+
+	t.Run("SelectFrom with models.RecordID pointer", func(t *testing.T) {
+		// First insert a specific record
+		insertQuery := fmt.Sprintf("CREATE %s:ptr_user SET name = 'Pointer User', active = false", tableName)
+		_, err := surrealdb.Query[any](ctx, db, insertQuery, nil)
+		assert.NoError(t, err)
+
+		// Test using pointer to models.RecordID with SelectFrom
+		recordID := models.NewRecordID(tableName, "ptr_user")
+
+		sql, vars := surrealql.SelectFrom(&recordID).Build()
+
+		t.Logf("RecordID pointer query SQL: %s", sql)
+		t.Logf("RecordID pointer query vars: %+v", vars)
+
+		// Execute the query
+		type UserData struct {
+			Name   string `json:"name"`
+			Active bool   `json:"active"`
+		}
+
+		results, err := surrealdb.Query[[]UserData](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Verify we get the specific record
+		if len(*results) > 0 && (*results)[0].Result != nil {
+			users := (*results)[0].Result
+			assert.Len(t, users, 1, "Should find exactly 1 user")
+			if len(users) == 1 {
+				assert.Equal(t, "Pointer User", users[0].Name)
+				assert.Equal(t, false, users[0].Active)
+			}
+		}
+	})
+
+	t.Run("SelectFrom RecordID with WHERE conditions", func(t *testing.T) {
+		// Insert multiple records with same ID pattern
+		insertQuery1 := fmt.Sprintf("CREATE %s:order_1 SET status = 'pending', total = 100", tableName)
+		insertQuery2 := fmt.Sprintf("CREATE %s:order_2 SET status = 'completed', total = 200", tableName)
+		_, err := surrealdb.Query[any](ctx, db, insertQuery1, nil)
+		assert.NoError(t, err)
+		_, err = surrealdb.Query[any](ctx, db, insertQuery2, nil)
+		assert.NoError(t, err)
+
+		// Select specific record with additional WHERE clause
+		recordID := models.NewRecordID(tableName, "order_2")
+
+		sql, vars := surrealql.SelectFrom(recordID).
+			FieldName("status").
+			FieldName("total").
+			Where("status = ?", "completed").
+			Build()
+
+		// Execute the query
+		type OrderData struct {
+			Status string `json:"status"`
+			Total  int    `json:"total"`
+		}
+
+		results, err := surrealdb.Query[[]OrderData](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Verify we get the correct record
+		if len(*results) > 0 && (*results)[0].Result != nil {
+			orders := (*results)[0].Result
+			assert.Len(t, orders, 1, "Should find exactly 1 order")
+			if len(orders) == 1 {
+				assert.Equal(t, "completed", orders[0].Status)
+				assert.Equal(t, 200, orders[0].Total)
+			}
+		}
+	})
+}

--- a/contrib/surrealql/integration_select_from_record_id_test.go
+++ b/contrib/surrealql/integration_select_from_record_id_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationSelectFromRecordID(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "select_from_record_id_test")
+	db := testenv.MustNewDeprecated("surrealql_test", "select_from_record_id_test")
 	ctx := context.Background()
 
 	tableName := "record_test_data"

--- a/contrib/surrealql/integration_select_from_table_test.go
+++ b/contrib/surrealql/integration_select_from_table_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationSelectFromTable(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "select_from_table_test")
+	db := testenv.MustNewDeprecated("surrealql_test", "select_from_table_test")
 	ctx := context.Background()
 
 	// Create test data in a table with special characters

--- a/contrib/surrealql/integration_select_from_table_test.go
+++ b/contrib/surrealql/integration_select_from_table_test.go
@@ -1,0 +1,163 @@
+package surrealql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestIntegrationSelectFromTable(t *testing.T) {
+	db := testenv.MustNew("surrealql_test", "select_from_table_test")
+	ctx := context.Background()
+
+	// Create test data in a table with special characters
+	tableName := "user_data_test" // Using a unique table name
+
+	// Clean up any existing data first
+	cleanupQuery := fmt.Sprintf("DELETE %s", tableName)
+	_, _ = surrealdb.Query[any](ctx, db, cleanupQuery, nil)
+
+	// Insert test data using raw query
+	insertQuery := fmt.Sprintf("INSERT INTO %s [{ name: 'Alice', active: true }, { name: 'Bob', active: false }, { name: 'Charlie', active: true }]", tableName)
+	_, err := surrealdb.Query[any](ctx, db, insertQuery, nil)
+	assert.NoError(t, err)
+
+	t.Run("SelectFrom with models.Table and special characters", func(t *testing.T) {
+		// Build query using SelectFrom with models.Table
+		sql, vars := surrealql.SelectFrom(models.Table(tableName)).
+			Where("active = ?", true).
+			OrderBy("name").
+			Build()
+
+		// Execute the query
+		type UserData struct {
+			Name   string `json:"name"`
+			Active bool   `json:"active"`
+		}
+
+		results, err := surrealdb.Query[[]UserData](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Verify results
+		if len(*results) > 0 && (*results)[0].Result != nil {
+			users := (*results)[0].Result
+			assert.Len(t, users, 2, "Should find 2 active users")
+			if len(users) == 2 {
+				assert.Equal(t, "Alice", users[0].Name)
+				assert.Equal(t, "Charlie", users[1].Name)
+			}
+		}
+	})
+
+	t.Run("SelectFrom with models.Table all records", func(t *testing.T) {
+		// Build query to select all records
+		sql, vars := surrealql.SelectFrom(models.Table(tableName)).Build()
+
+		t.Logf("Select all query SQL: %s", sql)
+		t.Logf("Select all query vars: %+v", vars)
+
+		// Execute the query
+		type UserData struct {
+			Name   string `json:"name"`
+			Active bool   `json:"active"`
+		}
+
+		results, err := surrealdb.Query[[]UserData](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Verify we get all 3 records
+		if len(*results) > 0 && (*results)[0].Result != nil {
+			assert.Len(t, (*results)[0].Result, 3, "Should find all 3 users")
+		}
+	})
+
+	// Test with dynamic table name
+	t.Run("SelectFrom with models.Table dynamic name", func(t *testing.T) {
+		// This simulates a scenario where table name comes from user input or config
+		dynamicTable := tableName // In real scenario, this could come from elsewhere
+
+		sql, vars := surrealql.SelectFrom(models.Table(dynamicTable)).
+			FieldName("name").
+			Build()
+
+		// Execute the query
+		type NameResult struct {
+			Name string `json:"name"`
+		}
+
+		results, err := surrealdb.Query[[]NameResult](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Verify we got results
+		if len(*results) > 0 && (*results)[0].Result != nil {
+			assert.Len(t, (*results)[0].Result, 3, "Should find all 3 users")
+		}
+	})
+
+	t.Run("SelectFrom with models.Table", func(t *testing.T) {
+		// Test using models.Table directly with SelectFrom
+		table := models.Table(tableName)
+
+		sql, vars := surrealql.SelectFrom(table).
+			Where("active = ?", true).
+			OrderBy("name").
+			Build()
+
+		// Execute the query
+		type UserData struct {
+			Name   string `json:"name"`
+			Active bool   `json:"active"`
+		}
+
+		results, err := surrealdb.Query[[]UserData](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Verify results
+		if len(*results) > 0 && (*results)[0].Result != nil {
+			users := (*results)[0].Result
+			assert.Len(t, users, 2, "Should find 2 active users")
+			if len(users) == 2 {
+				assert.Equal(t, "Alice", users[0].Name)
+				assert.Equal(t, "Charlie", users[1].Name)
+			}
+		}
+	})
+
+	t.Run("SelectFrom models.Table with aggregation", func(t *testing.T) {
+		// Test using models.Table with aggregation
+		table := models.Table(tableName)
+
+		// Count active vs inactive users
+		sql, vars := surrealql.SelectFrom(table).
+			FieldRaw("active").
+			FieldRaw("count() AS total").
+			GroupBy("active").
+			OrderBy("active").
+			Build()
+
+		// Execute the query
+		type CountResult struct {
+			Active bool `json:"active"`
+			Total  int  `json:"total"`
+		}
+
+		results, err := surrealdb.Query[[]CountResult](ctx, db, sql, vars)
+		assert.NoError(t, err)
+		assert.NotNil(t, results)
+
+		// Log for debugging
+		if results != nil && len(*results) > 0 {
+			t.Logf("Aggregation results: %+v", (*results)[0].Result)
+		}
+	})
+}

--- a/contrib/surrealql/integration_transaction_test.go
+++ b/contrib/surrealql/integration_transaction_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIntegrationTransaction(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "accounts")
+	db := testenv.MustNewDeprecated("surrealql_test", "accounts")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_update_return_test.go
+++ b/contrib/surrealql/integration_update_return_test.go
@@ -17,7 +17,7 @@ func TestIntegrationUpdateReturnNone(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	db := testenv.MustNew("surrealql_test", "update_table")
+	db := testenv.MustNewDeprecated("surrealql_test", "update_table")
 	ctx := context.Background()
 
 	// Setup: Create test records

--- a/contrib/surrealql/integration_upsert_test.go
+++ b/contrib/surrealql/integration_upsert_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIntegration_UpsertSet(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_set", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_set", "product")
 	ctx := context.Background()
 
 	t.Run("creates new record", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestIntegration_UpsertSet(t *testing.T) {
 }
 
 func TestIntegration_UpsertContent(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_content", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_content", "product")
 	ctx := context.Background()
 
 	// UPSERT with CONTENT
@@ -86,7 +86,7 @@ func TestIntegration_UpsertContent(t *testing.T) {
 }
 
 func TestIntegration_UpsertMerge(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_merge", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_merge", "product")
 	ctx := context.Background()
 
 	// First, create a record with initial data
@@ -115,7 +115,7 @@ func TestIntegration_UpsertMerge(t *testing.T) {
 }
 
 func TestIntegration_UpsertWhere(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_where", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_where", "product")
 	ctx := context.Background()
 
 	// Create a record
@@ -159,7 +159,7 @@ func TestIntegration_UpsertWhere(t *testing.T) {
 }
 
 func TestIntegration_UpsertOnly(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_only", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_only", "product")
 	ctx := context.Background()
 
 	// UPSERT ONLY
@@ -179,7 +179,7 @@ func TestIntegration_UpsertOnly(t *testing.T) {
 }
 
 func TestIntegration_UpsertReturnNone(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_return_none", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_return_none", "product")
 	ctx := context.Background()
 
 	// UPSERT with RETURN NONE
@@ -199,7 +199,7 @@ func TestIntegration_UpsertReturnNone(t *testing.T) {
 }
 
 func TestIntegration_UpsertReturnDiff(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_return_diff", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_return_diff", "product")
 	ctx := context.Background()
 
 	// First create a record
@@ -223,7 +223,7 @@ func TestIntegration_UpsertReturnDiff(t *testing.T) {
 }
 
 func TestIntegration_UpsertSetRaw(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_setraw", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_setraw", "product")
 	ctx := context.Background()
 
 	// First create a record with initial values
@@ -259,7 +259,7 @@ func TestIntegration_UpsertSetRaw(t *testing.T) {
 }
 
 func TestIntegration_UpsertUnifiedSet(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_unified", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_unified", "product")
 	ctx := context.Background()
 
 	// First create a record with initial values
@@ -290,7 +290,7 @@ func TestIntegration_UpsertUnifiedSet(t *testing.T) {
 }
 
 func TestIntegration_UpsertSetArrayOperations(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_arrays", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_arrays", "product")
 	ctx := context.Background()
 
 	// First create a record with initial array values
@@ -327,7 +327,7 @@ func TestIntegration_UpsertSetArrayOperations(t *testing.T) {
 }
 
 func TestIntegration_UpsertReturnValue(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "upsert_return_value", "product")
+	db := testenv.MustNewDeprecated("surrealql_test", "upsert_return_value", "product")
 	ctx := context.Background()
 
 	// First create a record with initial value

--- a/contrib/surrealql/integration_user_select_test.go
+++ b/contrib/surrealql/integration_user_select_test.go
@@ -37,7 +37,7 @@ func setupUserData(t *testing.T, ctx context.Context, db *surrealdb.DB, table st
 }
 
 func TestIntegrationSelect_All(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "users_all")
+	db := testenv.MustNewDeprecated("surrealql_test", "users_all")
 	ctx := context.Background()
 
 	// Setup test data
@@ -66,7 +66,7 @@ func TestIntegrationSelect_All(t *testing.T) {
 }
 
 func TestIntegrationSelect_WhereEq(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "users_whereeq")
+	db := testenv.MustNewDeprecated("surrealql_test", "users_whereeq")
 	ctx := context.Background()
 
 	// Setup test data
@@ -96,7 +96,7 @@ func TestIntegrationSelect_WhereEq(t *testing.T) {
 }
 
 func TestIntegrationSelect_WhereWithParams(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "users_params")
+	db := testenv.MustNewDeprecated("surrealql_test", "users_params")
 	ctx := context.Background()
 
 	// Setup test data
@@ -125,7 +125,7 @@ func TestIntegrationSelect_WhereWithParams(t *testing.T) {
 }
 
 func TestIntegrationSelect_WithPagination(t *testing.T) {
-	db := testenv.MustNew("surrealql_test", "users_page")
+	db := testenv.MustNewDeprecated("surrealql_test", "users_page")
 	ctx := context.Background()
 
 	// Setup test data

--- a/contrib/surrealql/select.go
+++ b/contrib/surrealql/select.go
@@ -82,7 +82,12 @@ func Select[T selectField](field T, fields ...T) *SelectQuery {
 // Field adds a field to the SELECT query.
 func (q *SelectQuery) Field(field *field) *SelectQuery {
 	sql, vars := field.Build()
-	q.fields = append(q.fields, sql)
+	// If fields only contains "*", replace it
+	if len(q.fields) == 1 && q.fields[0] == "*" {
+		q.fields = []string{sql}
+	} else {
+		q.fields = append(q.fields, sql)
+	}
 	for k, v := range vars {
 		q.addParam(k, v)
 	}
@@ -91,20 +96,35 @@ func (q *SelectQuery) Field(field *field) *SelectQuery {
 
 // FieldName adds a field to the SELECT query.
 func (q *SelectQuery) FieldName(field string) *SelectQuery {
-	q.fields = append(q.fields, escapeIdent(field))
+	// If fields only contains "*", replace it
+	if len(q.fields) == 1 && q.fields[0] == "*" {
+		q.fields = []string{escapeIdent(field)}
+	} else {
+		q.fields = append(q.fields, escapeIdent(field))
+	}
 	return q
 }
 
 // FieldNameAs adds a field with an alias to the SELECT query.
 func (q *SelectQuery) FieldNameAs(field, alias string) *SelectQuery {
-	q.fields = append(q.fields, fmt.Sprintf("%s AS %s", escapeIdent(field), escapeIdent(alias)))
+	// If fields only contains "*", replace it
+	if len(q.fields) == 1 && q.fields[0] == "*" {
+		q.fields = []string{fmt.Sprintf("%s AS %s", escapeIdent(field), escapeIdent(alias))}
+	} else {
+		q.fields = append(q.fields, fmt.Sprintf("%s AS %s", escapeIdent(field), escapeIdent(alias)))
+	}
 	return q
 }
 
 // AddQuery adds another SelectQuery as a field to the current query.
 func (q *SelectQuery) FieldQueryAs(query *SelectQuery, alias string) *SelectQuery {
 	sql, vars := F(query).As(alias).Build()
-	q.fields = append(q.fields, sql)
+	// If fields only contains "*", replace it
+	if len(q.fields) == 1 && q.fields[0] == "*" {
+		q.fields = []string{sql}
+	} else {
+		q.fields = append(q.fields, sql)
+	}
 	for k, v := range vars {
 		q.addParam(k, v)
 	}
@@ -114,7 +134,12 @@ func (q *SelectQuery) FieldQueryAs(query *SelectQuery, alias string) *SelectQuer
 // FieldFunCallAs adds a function call as a field to the SELECT query.
 func (q *SelectQuery) FieldFunCallAs(fun *FunCall, alias string) *SelectQuery {
 	sql, vars := F(fun).As(alias).Build()
-	q.fields = append(q.fields, sql)
+	// If fields only contains "*", replace it
+	if len(q.fields) == 1 && q.fields[0] == "*" {
+		q.fields = []string{sql}
+	} else {
+		q.fields = append(q.fields, sql)
+	}
 	for k, v := range vars {
 		q.addParam(k, v)
 	}
@@ -124,8 +149,12 @@ func (q *SelectQuery) FieldFunCallAs(fun *FunCall, alias string) *SelectQuery {
 // FieldRaw adds a raw field to the SELECT query without escaping.
 // This is useful for fields that should not be escaped, such as function calls.
 func (q *SelectQuery) FieldRaw(field string) *SelectQuery {
-	// Add raw field without escaping
-	q.fields = append(q.fields, field)
+	// If fields only contains "*", replace it
+	if len(q.fields) == 1 && q.fields[0] == "*" {
+		q.fields = []string{field}
+	} else {
+		q.fields = append(q.fields, field)
+	}
 	return q
 }
 

--- a/contrib/surrealql/select_from.go
+++ b/contrib/surrealql/select_from.go
@@ -1,0 +1,170 @@
+package surrealql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// selectTarget is an interface for targets in SELECT queries.
+// It supports tables, records, subqueries, and raw values.
+type selectTarget interface {
+	string | *target | models.RecordID | *models.RecordID | *SelectQuery | models.Table
+}
+
+// SelectFrom creates a new SELECT query starting with the FROM clause.
+// This allows for more natural query building where you first specify what to select from,
+// then optionally add fields. If no fields are specified, it defaults to SELECT *.
+//
+// The target can be:
+// - A string for raw expressions: "users", "users:123", or any SurrealQL expression
+//   - Supports placeholders with "?" that will be replaced by args
+//   - For arrays and objects, use SelectFrom("?", myArray) or SelectFrom("?", myMap)
+//
+// - A models.Table for safe table name specification
+// - A *target for programmatic table/record specification
+// - A *models.RecordID for specific records
+// - A *SelectQuery for subqueries
+//
+// Examples:
+//
+//	// Select all from a table
+//	SelectFrom("users")  // SELECT * FROM users
+//
+//	// Select from a specific record
+//	SelectFrom("users:123")  // SELECT * FROM users:123
+//
+//	// Select from a parameterized graph traversal
+//	SelectFrom("?->knows->users", models.NewRecordID("users", "john"))
+//	// SELECT * FROM $from_param_1->knows->users
+//
+//	// Select from a subquery
+//	subquery := Select("name").FromTable("users")
+//	SelectFrom(subquery)  // SELECT * FROM (SELECT name FROM users)
+//
+//	// Select from a table using models.Table for type safety
+//	SelectFrom(models.Table("users"))  // SELECT * FROM $table_1
+//
+//	// Select from an array or object using placeholders
+//	SelectFrom("?", []any{1, 2, 3})  // SELECT * FROM $from_param_1
+//	SelectFrom("?", map[string]any{"a": 1})  // SELECT * FROM $from_param_1
+func SelectFrom[T selectTarget](target T, args ...any) *SelectQuery {
+	bq := newBaseQuery()
+	fromExpr := buildSelectTargetExprWithArgs(target, args, &bq)
+
+	return &SelectQuery{
+		baseQuery: bq,
+		fields:    []string{"*"}, // Default to SELECT *
+		from:      fromExpr,
+	}
+}
+
+// buildSelectTargetExprWithArgs builds a FROM expression for SELECT queries with placeholder support.
+// It supports various source types including tables, records, subqueries, arrays, and objects.
+// When the target is a string with placeholders (?), the args will be used to replace them.
+func buildSelectTargetExprWithArgs(f any, args []any, bq *baseQuery) string {
+	if f == nil {
+		return ""
+	}
+
+	switch v := f.(type) {
+	case string:
+		return handleStringTarget(v, args, bq)
+	case *target:
+		return handleTargetStruct(v, bq)
+	case models.RecordID:
+		return handleRecordID(v, bq)
+	case *models.RecordID:
+		return handleRecordID(*v, bq)
+	case *SelectQuery:
+		return handleSubquery(v, bq)
+	case models.Table:
+		return handleTable(v, bq)
+	default:
+		panic(fmt.Sprintf("unsupported select target type: %T", f))
+	}
+}
+
+// handleStringTarget processes string targets with optional placeholder support
+func handleStringTarget(v string, args []any, bq *baseQuery) string {
+	if len(args) > 0 && strings.Contains(v, "?") {
+		// Replace placeholders with properly formatted values
+		processedExpr := v
+		for _, arg := range args {
+			replacement := formatFromArgument(arg, bq)
+			processedExpr = strings.Replace(processedExpr, "?", replacement, 1)
+		}
+		return processedExpr
+	}
+	// No placeholders or args, return as-is
+	return v
+}
+
+// formatFromArgument formats an argument for use in a FROM clause
+// Generates parameters for all placeholders - SurrealDB will validate if they're allowed
+func formatFromArgument(arg any, bq *baseQuery) string {
+	switch v := arg.(type) {
+	case string:
+		// String values always become parameters
+		paramName := bq.generateParamName("from_param")
+		bq.addParam(paramName, v)
+		return "$" + paramName
+	case models.RecordID:
+		// RecordID always becomes a parameter
+		paramName := bq.generateParamName("from_param")
+		bq.addParam(paramName, v)
+		return "$" + paramName
+	case *models.RecordID:
+		// RecordID pointer always becomes a parameter
+		paramName := bq.generateParamName("from_param")
+		bq.addParam(paramName, *v)
+		return "$" + paramName
+	case *target:
+		// Target struct - build it and use its parameters
+		sql, vars := v.Build()
+		for k, val := range vars {
+			bq.addParam(k, val)
+		}
+		return sql
+	default:
+		// For other types, always create a parameter
+		paramName := bq.generateParamName("from_param")
+		bq.addParam(paramName, arg)
+		return "$" + paramName
+	}
+}
+
+// handleTargetStruct processes target struct types
+func handleTargetStruct(v *target, bq *baseQuery) string {
+	sql, targetVars := v.Build()
+	for k, val := range targetVars {
+		bq.addParam(k, val)
+	}
+	return sql
+}
+
+// handleRecordID processes RecordID types
+// models.RecordID already has the correct CBOR type, so we just parameterize it
+func handleRecordID(v models.RecordID, bq *baseQuery) string {
+	paramName := bq.generateParamName("record_id")
+	bq.addParam(paramName, v)
+	return fmt.Sprintf("$%s", paramName)
+}
+
+// handleSubquery processes subquery types
+func handleSubquery(v *SelectQuery, bq *baseQuery) string {
+	sql, subVars := v.Build()
+	for k, val := range subVars {
+		bq.addParam(k, val)
+	}
+	return fmt.Sprintf("(%s)", sql)
+}
+
+// handleTable processes models.Table types
+// models.Table already has the correct CBOR type, so we just parameterize it
+func handleTable(v models.Table, bq *baseQuery) string {
+	paramName := bq.generateParamName("table")
+	bq.addParam(paramName, v)
+	return fmt.Sprintf("$%s", paramName)
+}

--- a/contrib/surrealql/select_from_safety_test.go
+++ b/contrib/surrealql/select_from_safety_test.go
@@ -1,0 +1,29 @@
+package surrealql_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// TestSelectFrom_Safety verifies that placeholder replacement is safe
+func TestSelectFrom_Safety(t *testing.T) {
+	t.Run("record_id_preserved", func(t *testing.T) {
+		// Record IDs become parameters when using placeholder
+		sql, vars := surrealql.SelectFrom("?", "users:123").Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, "users:123", vars["from_param_1"])
+	})
+
+	t.Run("first_position_parameter", func(t *testing.T) {
+		// RecordID at first position becomes a parameter
+		recordID := models.NewRecordID("users", "admin")
+		sql, vars := surrealql.SelectFrom("?->manages->projects", recordID).Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1->manages->projects", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.IsType(t, models.RecordID{}, vars["from_param_1"])
+	})
+}

--- a/contrib/surrealql/select_from_table_test.go
+++ b/contrib/surrealql/select_from_table_test.go
@@ -1,0 +1,82 @@
+package surrealql_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestSelectFromTable(t *testing.T) {
+	t.Run("normal_table_name", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("users")).Build()
+		assert.Equal(t, "SELECT * FROM $table_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("users"), vars["table_1"])
+	})
+
+	t.Run("table_with_special_chars", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("user-data")).Build()
+		assert.Equal(t, "SELECT * FROM $table_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("user-data"), vars["table_1"])
+	})
+
+	t.Run("reserved_word_table", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("select")).Build()
+		assert.Equal(t, "SELECT * FROM $table_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("select"), vars["table_1"])
+	})
+
+	t.Run("with_fields", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("products")).
+			FieldName("name").
+			FieldName("price").
+			Build()
+		assert.Equal(t, "SELECT name, price FROM $table_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("products"), vars["table_1"])
+	})
+
+	t.Run("with_where_clause", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("users")).
+			Where("age > ?", 18).
+			Build()
+		assert.Equal(t, "SELECT * FROM $table_1 WHERE age > $param_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("users"), vars["table_1"])
+		assert.Contains(t, vars, "param_1")
+		assert.Equal(t, 18, vars["param_1"])
+	})
+
+	t.Run("table_with_underscore", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("user_accounts")).Build()
+		assert.Equal(t, "SELECT * FROM $table_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("user_accounts"), vars["table_1"])
+	})
+
+	t.Run("table_with_multiple_special_chars", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("user-data-2024")).Build()
+		assert.Equal(t, "SELECT * FROM $table_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("user-data-2024"), vars["table_1"])
+	})
+
+	t.Run("complete_query", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom(models.Table("user-profiles")).
+			FieldName("name").
+			FieldName("email").
+			Where("active = ?", true).
+			OrderBy("created_at").
+			Limit(10).
+			Build()
+		assert.Equal(t, "SELECT name, email FROM $table_1 WHERE active = $param_1 ORDER BY created_at LIMIT 10", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("user-profiles"), vars["table_1"])
+		assert.Contains(t, vars, "param_1")
+		assert.Equal(t, true, vars["param_1"])
+	})
+}

--- a/contrib/surrealql/select_from_test.go
+++ b/contrib/surrealql/select_from_test.go
@@ -1,0 +1,230 @@
+package surrealql_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+func TestSelectFrom(t *testing.T) {
+	t.Run("from_table", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("users").Build()
+		assert.Equal(t, "SELECT * FROM users", sql)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("from_record", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("users:123").Build()
+		assert.Equal(t, "SELECT * FROM users:123", sql)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("from_target", func(t *testing.T) {
+		target := surrealql.Thing("users", 123)
+		sql, vars := surrealql.SelectFrom(target).Build()
+		assert.Equal(t, "SELECT * FROM $id_1", sql)
+		assert.Contains(t, vars, "id_1")
+		assert.IsType(t, models.RecordID{}, vars["id_1"])
+	})
+
+	t.Run("from_models_table", func(t *testing.T) {
+		table := models.Table("users")
+		sql, vars := surrealql.SelectFrom(table).Build()
+		assert.Equal(t, "SELECT * FROM $table_1", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.IsType(t, models.Table(""), vars["table_1"])
+		assert.Equal(t, models.Table("users"), vars["table_1"])
+	})
+
+	t.Run("from_models_record_id", func(t *testing.T) {
+		recordID := models.NewRecordID("users", "john")
+		sql, vars := surrealql.SelectFrom(recordID).Build()
+		assert.Equal(t, "SELECT * FROM $record_id_1", sql)
+		assert.Contains(t, vars, "record_id_1")
+		assert.IsType(t, models.RecordID{}, vars["record_id_1"])
+		assert.Equal(t, models.NewRecordID("users", "john"), vars["record_id_1"])
+	})
+
+	t.Run("from_models_record_id_pointer", func(t *testing.T) {
+		recordID := models.NewRecordID("users", 123)
+		sql, vars := surrealql.SelectFrom(&recordID).Build()
+		assert.Equal(t, "SELECT * FROM $record_id_1", sql)
+		assert.Contains(t, vars, "record_id_1")
+		assert.IsType(t, models.RecordID{}, vars["record_id_1"])
+		assert.Equal(t, models.NewRecordID("users", 123), vars["record_id_1"])
+	})
+
+	t.Run("from_array", func(t *testing.T) {
+		arr := []any{1, 2, 3}
+		sql, vars := surrealql.SelectFrom("?", arr).Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, []any{1, 2, 3}, vars["from_param_1"])
+	})
+
+	t.Run("from_object", func(t *testing.T) {
+		obj := map[string]any{"a": 1}
+		sql, vars := surrealql.SelectFrom("?", obj).Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, map[string]any{"a": 1}, vars["from_param_1"])
+	})
+
+	t.Run("from_subquery", func(t *testing.T) {
+		subquery := surrealql.Select("name").FromTable("users")
+		sql, vars := surrealql.SelectFrom(subquery).Build()
+		assert.Equal(t, "SELECT * FROM (SELECT name FROM users)", sql)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("with_fields", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("users").
+			FieldName("name").
+			FieldName("email").
+			Build()
+		assert.Equal(t, "SELECT name, email FROM users", sql)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("with_raw_expression", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("products").
+			FieldRaw("price * 1.1 AS price_with_tax").
+			Build()
+		assert.Equal(t, "SELECT price * 1.1 AS price_with_tax FROM products", sql)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("with_where_clause", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("users").
+			FieldName("name").
+			Where("age > ?", 18).
+			Build()
+		assert.Equal(t, "SELECT name FROM users WHERE age > $param_1", sql)
+		assert.Contains(t, vars, "param_1")
+		assert.Equal(t, 18, vars["param_1"])
+	})
+
+	t.Run("graph_traversal", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("users:john->knows->users").Build()
+		assert.Equal(t, "SELECT * FROM users:john->knows->users", sql)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("with_placeholder", func(t *testing.T) {
+		recordID := models.NewRecordID("users", "john")
+		sql, vars := surrealql.SelectFrom("?->knows->users", recordID).Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1->knows->users", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.IsType(t, models.RecordID{}, vars["from_param_1"])
+	})
+
+	t.Run("multiple_placeholders", func(t *testing.T) {
+		fromRecord := models.NewRecordID("users", "john")
+		toTable := "users"
+		sql, vars := surrealql.SelectFrom("?->knows->?", fromRecord, toTable).Build()
+		// Both placeholders become parameters
+		assert.Equal(t, "SELECT * FROM $from_param_1->knows->$from_param_2", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.IsType(t, models.RecordID{}, vars["from_param_1"])
+		assert.Contains(t, vars, "from_param_2")
+		assert.Equal(t, "users", vars["from_param_2"])
+	})
+
+	t.Run("placeholder_with_table", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("?", "products").Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, "products", vars["from_param_1"])
+	})
+
+	t.Run("placeholder_with_fields_and_where", func(t *testing.T) {
+		sql, vars := surrealql.SelectFrom("?", "products").
+			FieldName("name").
+			FieldName("price").
+			Where("price > ?", 100).
+			Build()
+		assert.Equal(t, "SELECT name, price FROM $from_param_1 WHERE price > $param_1", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, "products", vars["from_param_1"])
+		assert.Contains(t, vars, "param_1")
+		assert.Equal(t, 100, vars["param_1"])
+	})
+
+	t.Run("mixed_placeholder_types", func(t *testing.T) {
+		// Test with different argument types
+		// All placeholders become parameters
+		sql, vars := surrealql.SelectFrom("?->?->?",
+			models.NewRecordID("users", "john"),
+			"knows",
+			models.NewRecordID("users", "jane")).Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1->$from_param_2->$from_param_3", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.IsType(t, models.RecordID{}, vars["from_param_1"])
+		assert.Contains(t, vars, "from_param_2")
+		assert.Equal(t, "knows", vars["from_param_2"])
+		assert.Contains(t, vars, "from_param_3")
+		assert.IsType(t, models.RecordID{}, vars["from_param_3"])
+	})
+
+	t.Run("string_at_first_position", func(t *testing.T) {
+		// When a string is at the first position, it becomes a parameter
+		sql, vars := surrealql.SelectFrom("?->follows->users", "users:alice").Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1->follows->users", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, "users:alice", vars["from_param_1"])
+	})
+
+	t.Run("table_name_with_special_chars", func(t *testing.T) {
+		// String at first position becomes a parameter (not escaped)
+		sql, vars := surrealql.SelectFrom("?", "user-data").Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, "user-data", vars["from_param_1"])
+	})
+
+	t.Run("table_name_with_reserved_word", func(t *testing.T) {
+		// String at first position becomes a parameter (not escaped)
+		sql, vars := surrealql.SelectFrom("?", "select").Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, "select", vars["from_param_1"])
+	})
+
+	t.Run("complex_traversal_string", func(t *testing.T) {
+		// Complex traversals - all placeholders are parameterized
+		// This is an INVALID SurrealQL query- In SurrealQL, you can say `$var->likes->products` but
+		// cannot say `$var->$rel->$target`.
+		// However, surrealql cannot complain on it because it does not parse `->` expressions.
+		// It's SurrealQL's limitation that you cannot place random variables in the middle of a path.
+		// It's the surrealql libary's limitation that it does not validate this.
+		// So surrealql will produce an invalid query, without panic or error.
+		sql, vars := surrealql.SelectFrom("?->?->?",
+			"users:admin",
+			"manages",
+			"projects").Build()
+		assert.Equal(t, "SELECT * FROM $from_param_1->$from_param_2->$from_param_3", sql)
+		assert.Contains(t, vars, "from_param_1")
+		assert.Equal(t, "users:admin", vars["from_param_1"])
+		assert.Contains(t, vars, "from_param_2")
+		assert.Equal(t, "manages", vars["from_param_2"])
+		assert.Contains(t, vars, "from_param_3")
+		assert.Equal(t, "projects", vars["from_param_3"])
+	})
+
+	t.Run("models_table_with_where", func(t *testing.T) {
+		table := models.Table("products")
+		sql, vars := surrealql.SelectFrom(table).
+			FieldName("name").
+			FieldName("price").
+			Where("price > ?", 100).
+			OrderBy("price").
+			Build()
+		assert.Equal(t, "SELECT name, price FROM $table_1 WHERE price > $param_1 ORDER BY price", sql)
+		assert.Contains(t, vars, "table_1")
+		assert.Equal(t, models.Table("products"), vars["table_1"])
+		assert.Contains(t, vars, "param_1")
+		assert.Equal(t, 100, vars["param_1"])
+	})
+}

--- a/contrib/testenv/connection.go
+++ b/contrib/testenv/connection.go
@@ -65,8 +65,16 @@ func GetSurrealDBWSURL() string {
 	return strings.ReplaceAll(currentURL, "http", "ws")
 }
 
-func MustNew(database string, tables ...string) *surrealdb.DB {
-	db, err := New(database, tables...)
+func MustNewDeprecated(database string, tables ...string) *surrealdb.DB {
+	db, err := New("examples", database, tables...)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create SurrealDB connection: %v", err))
+	}
+	return db
+}
+
+func MustNew(namespace, database string, tables ...string) *surrealdb.DB {
+	db, err := New(namespace, database, tables...)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create SurrealDB connection: %v", err))
 	}
@@ -76,7 +84,7 @@ func MustNew(database string, tables ...string) *surrealdb.DB {
 // New creates a new SurrealDB connection with the specified database and tables.
 // The connection information is derived from environment variables.
 // It supports both WebSocket and HTTP connections based on the URL scheme.
-func New(database string, tables ...string) (*surrealdb.DB, error) {
+func New(namespace, database string, tables ...string) (*surrealdb.DB, error) {
 	if database == "" {
 		return nil, fmt.Errorf("database name must be specified")
 	}
@@ -139,7 +147,7 @@ func New(database string, tables ...string) (*surrealdb.DB, error) {
 		return nil, fmt.Errorf("failed to connect to SurrealDB: %w", err)
 	}
 
-	return initConnection(db, "examples", database, tables...)
+	return initConnection(db, namespace, database, tables...)
 }
 
 func MustNewHTTP(database string, tables ...string) *surrealdb.DB {

--- a/example/example_create_test.go
+++ b/example/example_create_test.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:funlen
 func ExampleCreate() {
-	db := testenv.MustNew("example_create", "persons")
+	db := testenv.MustNewDeprecated("example_create", "persons")
 
 	type Person struct {
 		Name string `json:"name"`
@@ -119,7 +119,7 @@ func ExampleCreate() {
 }
 
 func ExampleCreate_server_unmarshal_error() {
-	db := testenv.MustNew("query", "person")
+	db := testenv.MustNewDeprecated("query", "person")
 
 	type Person struct {
 		ID   models.RecordID `json:"id,omitempty"`

--- a/example/example_create_test.go
+++ b/example/example_create_test.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:funlen
 func ExampleCreate() {
-	db := testenv.MustNew("query", "persons")
+	db := testenv.MustNew("example_create", "persons")
 
 	type Person struct {
 		Name string `json:"name"`

--- a/example/example_db_record_user_test.go
+++ b/example/example_db_record_user_test.go
@@ -10,7 +10,7 @@ import (
 
 //nolint:funlen
 func ExampleDB_record_user_auth_struct() {
-	db := testenv.MustNew("record_auth_demo", "user")
+	db := testenv.MustNewDeprecated("record_auth_demo", "user")
 
 	setupQuery := `
 		-- Define the user table with schema
@@ -91,7 +91,7 @@ func ExampleDB_record_user_auth_struct() {
 }
 
 func ExampleDB_record_user_custom_struct() {
-	db := testenv.MustNew("record_user_custom", "user")
+	db := testenv.MustNewDeprecated("record_user_custom", "user")
 
 	setupQuery := `
 		-- Define the user table with schema

--- a/example/example_db_send_select_test.go
+++ b/example/example_db_send_select_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleDB_send_select() {
-	db := testenv.MustNew("update", "person")
+	db := testenv.MustNewDeprecated("update", "person")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_insert_relation_test.go
+++ b/example/example_insert_relation_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ExampleInsertRelation() {
-	db := testenv.MustNew("query", "person", "follow")
+	db := testenv.MustNewDeprecated("query", "person", "follow")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_insert_test.go
+++ b/example/example_insert_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleInsert_table() {
-	db := testenv.MustNew("query", "persons")
+	db := testenv.MustNewDeprecated("query", "persons")
 
 	type Person struct {
 		Name string `json:"name"`
@@ -110,7 +110,7 @@ func ExampleInsert_table() {
 }
 
 func ExampleInsert_bulk_isnert_record() {
-	db := testenv.MustNew("query", "person")
+	db := testenv.MustNewDeprecated("query", "person")
 
 	type Person struct {
 		ID models.RecordID `json:"id"`
@@ -154,7 +154,7 @@ func ExampleInsert_bulk_isnert_record() {
 }
 
 func ExampleInsert_bulk_insert_relation_workaround_for_rpcv1() {
-	db := testenv.MustNew("query", "person", "follow")
+	db := testenv.MustNewDeprecated("query", "person", "follow")
 
 	type Person struct {
 		ID models.RecordID `json:"id"`

--- a/example/example_query_bulk_insert_upsert_test.go
+++ b/example/example_query_bulk_insert_upsert_test.go
@@ -15,7 +15,7 @@ import (
 //
 //nolint:funlen
 func ExampleQuery_bluk_insert_upsert() {
-	db := testenv.MustNew("query", "persons")
+	db := testenv.MustNewDeprecated("query", "persons")
 
 	/// You can make it a schemaful table by defining fields like this:
 	//

--- a/example/example_query_count_test.go
+++ b/example/example_query_count_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleQuery_count_groupAll() {
-	db := testenv.MustNew("querytest", "product")
+	db := testenv.MustNewDeprecated("querytest", "product")
 
 	type Product struct {
 		ID       models.RecordID `json:"id,omitempty"`
@@ -73,7 +73,7 @@ func ExampleQuery_count_groupAll() {
 }
 
 func ExampleQuery_count_groupBy() {
-	db := testenv.MustNew("querytest", "product")
+	db := testenv.MustNewDeprecated("querytest", "product")
 
 	type Product struct {
 		ID       models.RecordID `json:"id,omitempty"`

--- a/example/example_query_embedded_struct_test.go
+++ b/example/example_query_embedded_struct_test.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:funlen
 func ExampleQuery_embedded_struct() {
-	db := testenv.MustNew("query", "persons")
+	db := testenv.MustNewDeprecated("query", "persons")
 
 	type Base struct {
 		ID *models.RecordID `json:"id,omitempty"`

--- a/example/example_query_none_null_test.go
+++ b/example/example_query_none_null_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleQuery_none_and_null_handling() {
-	db := testenv.MustNew("query", "t")
+	db := testenv.MustNewDeprecated("query", "t")
 
 	_, err := surrealdb.Query[[]any](
 		context.Background(),

--- a/example/example_query_return_test.go
+++ b/example/example_query_return_test.go
@@ -15,7 +15,7 @@ import (
 //
 //nolint:funlen
 func ExampleQuery_return() {
-	db := testenv.MustNew("query", "persons")
+	db := testenv.MustNewDeprecated("query", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/example_query_test.go
+++ b/example/example_query_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleQuery() {
-	db := testenv.MustNew("query", "persons")
+	db := testenv.MustNewDeprecated("query", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/example_query_transaction_let_return_test.go
+++ b/example/example_query_transaction_let_return_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleQuery_transaction_let_return() {
-	db := testenv.MustNew("query", "t")
+	db := testenv.MustNewDeprecated("query", "t")
 
 	createQueryResults, err := surrealdb.Query[[]any](
 		context.Background(),

--- a/example/example_query_transaction_test.go
+++ b/example/example_query_transaction_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleQuery_transaction_return() {
-	db := testenv.MustNew("query", "person")
+	db := testenv.MustNewDeprecated("query", "person")
 
 	var err error
 
@@ -34,7 +34,7 @@ func ExampleQuery_transaction_return() {
 }
 
 func ExampleQuery_transaction_throw() {
-	db := testenv.MustNew("query", "person")
+	db := testenv.MustNewDeprecated("query", "person")
 
 	var (
 		queryResults *[]surrealdb.QueryResult[*int]
@@ -106,7 +106,7 @@ func ExampleQuery_transaction_throw() {
 
 // See https://github.com/surrealdb/surrealdb.go/issues/177
 func ExampleQuery_transaction_issue_177_return_before_commit() {
-	db := testenv.MustNew("query", "t")
+	db := testenv.MustNewDeprecated("query", "t")
 
 	var err error
 
@@ -150,7 +150,7 @@ func ExampleQuery_transaction_issue_177_return_before_commit() {
 
 // See https://github.com/surrealdb/surrealdb.go/issues/177
 func ExampleQuery_transaction_issue_177_commit() {
-	db := testenv.MustNew("query", "t")
+	db := testenv.MustNewDeprecated("query", "t")
 
 	var err error
 

--- a/example/example_relate_test.go
+++ b/example/example_relate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ExampleRelate() {
-	db := testenv.MustNew("query", "person", "follow")
+	db := testenv.MustNewDeprecated("query", "person", "follow")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_select_test.go
+++ b/example/example_select_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleSelect() {
-	db := testenv.MustNew("update", "person")
+	db := testenv.MustNewDeprecated("update", "person")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_update_test.go
+++ b/example/example_update_test.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:funlen // ExampleUpdate demonstrates how to update records in SurrealDB.
 func ExampleUpdate() {
-	db := testenv.MustNew("update", "persons")
+	db := testenv.MustNewDeprecated("update", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/example_upsert_test.go
+++ b/example/example_upsert_test.go
@@ -13,7 +13,7 @@ import (
 
 //nolint:funlen
 func ExampleUpsert() {
-	db := testenv.MustNew("query", "persons")
+	db := testenv.MustNewDeprecated("query", "persons")
 
 	type Person struct {
 		ID   *models.RecordID `json:"id,omitempty"`
@@ -110,7 +110,7 @@ func ExampleUpsert() {
 }
 
 func ExampleUpsert_unmarshal_error() {
-	db := testenv.MustNew("query", "person")
+	db := testenv.MustNewDeprecated("query", "person")
 
 	type Person struct {
 		Name string `json:"name"`
@@ -143,7 +143,7 @@ func ExampleUpsert_unmarshal_error() {
 }
 
 func ExampleUpsert_rpc_error() {
-	db := testenv.MustNew("query", "person")
+	db := testenv.MustNewDeprecated("query", "person")
 
 	type Person struct {
 		Name string `json:"name"`

--- a/example/example_version_test.go
+++ b/example/example_version_test.go
@@ -9,14 +9,14 @@ import (
 
 //nolint:lll,govet
 func ExampleDB_Version() {
-	ws := testenv.MustNew("version")
+	ws := testenv.MustNewDeprecated("version")
 	v, err := ws.Version(context.Background())
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("VersionData (WebSocket): %+v\n", v)
 
-	http := testenv.MustNew("version")
+	http := testenv.MustNewDeprecated("version")
 	v, err = http.Version(context.Background())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This enhances the surrealql library added in #289 by adding the new `SelectFrom`.

Unlike the existing `Select(fields).FromTable("mytable")` specifying fields earlier than the target,
`SelectFrom(target).FieldName(...).FieldRaw(...)` specifies the target first.

This is preferable in the sense that you can use generics to enforce type-safety without having different functions depending on the target type. For example, `Select()` has `FromTable` or `FromRecordID` for type-safe ways to specify the target.
If we reverse the order, we can use the same `SelectFrom` to specify either.

Ref #151