### PR TITLE
SurrealQL query builder: Fix ident escaping

### DIFF
--- a/contrib/surrealql/query.go
+++ b/contrib/surrealql/query.go
@@ -57,7 +57,8 @@ func (q *baseQuery) generateParamName(prefix string) string {
 func escapeIdent(ident string) string {
 	// If the identifier contains special characters, wrap it in backticks
 	if strings.ContainsAny(ident, " -:`") || isReservedWord(ident) {
-		return "`" + strings.ReplaceAll(ident, "`", "``") + "`"
+		// Escape any backticks in the identifier with backslash
+		return "`" + strings.ReplaceAll(ident, "`", "\\`") + "`"
 	}
 	return ident
 }

--- a/contrib/surrealql/query_test.go
+++ b/contrib/surrealql/query_test.go
@@ -16,7 +16,7 @@ func TestEscapeIdent(t *testing.T) {
 		{"user:id", "`user:id`"},
 		{"SELECT", "`SELECT`"},
 		{"select", "`select`"},
-		{"my`table", "`my``table`"},
+		{"my`table", "`my\\`table`"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In case an ident contains a backquote, you need to escape it using backslashes.

You can confirm it using `surreal sql`:

```
testns/testdb> create `my\`tb`:`1\`23`;
[[{ id: ⟨my`tb⟩:⟨1`23⟩ }]]

testns/testdb> select * from `my\`tb`;
[[{ id: ⟨my`tb⟩:⟨1`23⟩ }]]
```

Ref #289 
Ref #151