### PR TITLE
surrealcbor: Compatibility and performance improvements

### DIFF
--- a/surrealcbor/cbor.go
+++ b/surrealcbor/cbor.go
@@ -58,6 +58,9 @@ import (
 	"reflect"
 )
 
+// globalFieldResolver is a shared field resolver used by Unmarshal functions
+var globalFieldResolver = NewCachedFieldResolver()
+
 func New() *Codec {
 	return &Codec{
 		encMode: getEncMode(),
@@ -79,6 +82,7 @@ func Unmarshal(data []byte, v any) error {
 		data:           data,
 		pos:            0,
 		defaultMapType: reflect.TypeOf(map[string]any{}), // Default to string keys for backward compatibility
+		fieldResolver:  globalFieldResolver,
 	}
 	return d.decode(v)
 }
@@ -99,6 +103,7 @@ func UnmarshalWithOptions(data []byte, v any, opts UnmarshalOptions) error {
 		data:           data,
 		pos:            0,
 		defaultMapType: mapType,
+		fieldResolver:  globalFieldResolver,
 	}
 	return d.decode(v)
 }

--- a/surrealcbor/cbor_fxamacker_compat_test.go
+++ b/surrealcbor/cbor_fxamacker_compat_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
-// TestCompatibilityWithFxamacker tests that data encoded with fxamacker can be decoded with our implementation
-func TestCompatibilityWithFxamacker(t *testing.T) {
+// TestCompatibilityWithFxamacker_types tests that data encoded with fxamacker can be decoded with our implementation
+func TestCompatibilityWithFxamacker_types(t *testing.T) {
 	// Create test data
 	testData := map[string]any{
 		"string": "hello",
@@ -67,4 +67,604 @@ func TestCompatibilityWithFxamacker(t *testing.T) {
 	require.NoError(t, err, "fxamacker Unmarshal of our data failed")
 
 	assert.Equal(t, "value", fxDecoded["test"], "Test value mismatch")
+}
+
+// TestCompatibilityWithFxamacker_fieldResolver verifies how fxamacker/cbor handles different field tags
+// This serves as a reference for our field resolver behavior
+func TestCompatibilityWithFxamacker_fieldResolver(t *testing.T) {
+	// Create reusable marshaler and unmarshaler
+	marshaler := &models.CborMarshaler{}
+	unmarshaler := &models.CborUnmarshaler{}
+	t.Run("empty json tag", func(t *testing.T) {
+		type EmptyTag struct {
+			Field1 string `json:""`
+			Field2 int
+		}
+
+		original := EmptyTag{
+			Field1: "test",
+			Field2: 42,
+		}
+
+		// Test with fxamacker/cbor via pkg/models
+		encoded, err := marshaler.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded EmptyTag
+		err = unmarshaler.Unmarshal(encoded, &decoded)
+		require.NoError(t, err)
+
+		// With empty tag, the field should still be included
+		assert.Equal(t, original, decoded)
+
+		// Test with our implementation
+		var ourDecoded EmptyTag
+		err = Unmarshal(encoded, &ourDecoded)
+		require.NoError(t, err)
+		assert.Equal(t, original, ourDecoded)
+	})
+
+	t.Run("dash json tag", func(t *testing.T) {
+		type DashTag struct {
+			Field1 string `json:"-"`
+			Field2 int
+		}
+
+		original := DashTag{
+			Field1: "test",
+			Field2: 42,
+		}
+
+		// Test with fxamacker/cbor
+		encoded, err := marshaler.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded DashTag
+		err = unmarshaler.Unmarshal(encoded, &decoded)
+		require.NoError(t, err)
+
+		// With dash tag, Field1 should be omitted during encoding
+		assert.Equal(t, "", decoded.Field1) // Field1 should be zero value
+		assert.Equal(t, original.Field2, decoded.Field2)
+
+		// Test with our implementation
+		var ourDecoded DashTag
+		err = Unmarshal(encoded, &ourDecoded)
+		require.NoError(t, err)
+		assert.Equal(t, "", ourDecoded.Field1)
+		assert.Equal(t, original.Field2, ourDecoded.Field2)
+	})
+
+	t.Run("omitempty json tag", func(t *testing.T) {
+		type OmitEmptyTag struct {
+			Field1 string `json:",omitempty"`
+			Field2 string `json:",omitempty"`
+			Field3 int    `json:",omitempty"`
+			Field4 int    `json:",omitempty"`
+		}
+
+		// Test with non-empty values
+		original := OmitEmptyTag{
+			Field1: "test",
+			Field2: "", // empty, should be omitted
+			Field3: 42,
+			Field4: 0, // zero, should be omitted
+		}
+
+		// Test with fxamacker/cbor
+		encoded, err := marshaler.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded OmitEmptyTag
+		err = unmarshaler.Unmarshal(encoded, &decoded)
+		require.NoError(t, err)
+
+		// Only non-zero fields should be present
+		assert.Equal(t, "test", decoded.Field1)
+		assert.Equal(t, "", decoded.Field2) // zero value
+		assert.Equal(t, 42, decoded.Field3)
+		assert.Equal(t, 0, decoded.Field4) // zero value
+
+		// Test with our implementation
+		var ourDecoded OmitEmptyTag
+		err = Unmarshal(encoded, &ourDecoded)
+		require.NoError(t, err)
+		assert.Equal(t, decoded, ourDecoded)
+	})
+
+	t.Run("named field with omitempty", func(t *testing.T) {
+		type NamedOmitEmpty struct {
+			Field1 string `json:"field_one,omitempty"`
+			Field2 string `json:"field_two,omitempty"`
+		}
+
+		original := NamedOmitEmpty{
+			Field1: "test",
+			Field2: "", // empty, should be omitted during encoding
+		}
+
+		// Test with fxamacker/cbor
+		encoded, err := marshaler.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded NamedOmitEmpty
+		err = unmarshaler.Unmarshal(encoded, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, "test", decoded.Field1)
+		assert.Equal(t, "", decoded.Field2)
+
+		// Test with our implementation
+		var ourDecoded NamedOmitEmpty
+		err = Unmarshal(encoded, &ourDecoded)
+		require.NoError(t, err)
+		assert.Equal(t, decoded, ourDecoded)
+	})
+
+	t.Run("field name resolution priority", func(t *testing.T) {
+		// Test how fxamacker/cbor resolves field names when decoding
+		type Priority struct {
+			Field1 string `cbor:"cbor_name" json:"json_name"`
+			Field2 string `json:"json_only"`
+			Field3 string // no tags
+		}
+
+		// Create a map with different field names to test resolution
+		testCases := []struct {
+			name              string
+			inputMap          map[string]any
+			expectedFxamacker Priority
+			expectedOurs      Priority
+		}{
+			{
+				name: "cbor tag takes precedence",
+				inputMap: map[string]any{
+					"cbor_name": "value1",
+					"Field2":    "value2",
+					"Field3":    "value3",
+				},
+				expectedFxamacker: Priority{
+					Field1: "value1",
+					Field2: "", // fxamacker doesn't fallback to field name when tag exists
+					Field3: "value3",
+				},
+				expectedOurs: Priority{
+					Field1: "value1",
+					Field2: "", // Now matches fxamacker - no fallback when tag exists
+					Field3: "value3",
+				},
+			},
+			{
+				name: "json tag used when no cbor tag",
+				inputMap: map[string]any{
+					"Field1":    "value1", // Field name (Field1 has tags, won't match)
+					"json_only": "value2",
+					"Field3":    "value3",
+				},
+				expectedFxamacker: Priority{
+					Field1: "", // fxamacker doesn't fallback when tags exist
+					Field2: "value2",
+					Field3: "value3",
+				},
+				expectedOurs: Priority{
+					Field1: "", // Now matches fxamacker - no fallback when tags exist
+					Field2: "value2",
+					Field3: "value3",
+				},
+			},
+			{
+				name: "field name fallback behavior",
+				inputMap: map[string]any{
+					"Field1": "value1",
+					"Field2": "value2",
+					"Field3": "value3",
+				},
+				// This is where the difference is most clear
+				expectedFxamacker: Priority{
+					Field1: "", // fxamacker: no match because Field1 has tags
+					Field2: "", // fxamacker: no match because Field2 has tags
+					Field3: "value3",
+				},
+				expectedOurs: Priority{
+					Field1: "", // Now matches fxamacker - no fallback
+					Field2: "", // Now matches fxamacker - no fallback
+					Field3: "value3",
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Encode the map with fxamacker/cbor
+				encoded, err := marshaler.Marshal(tc.inputMap)
+				require.NoError(t, err)
+
+				// Decode with fxamacker/cbor
+				var decoded Priority
+				err = unmarshaler.Unmarshal(encoded, &decoded)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedFxamacker, decoded, "fxamacker/cbor decoding")
+
+				// Decode with our implementation
+				var ourDecoded Priority
+				err = Unmarshal(encoded, &ourDecoded)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedOurs, ourDecoded, "our implementation")
+			})
+		}
+	})
+
+	t.Run("field name conflicts", func(t *testing.T) {
+		// Test what happens when a field's tag matches another field's name
+		type Conflict struct {
+			Field1 string // no tag
+			Field2 string `json:"Field1"` // tag conflicts with Field1's name
+		}
+
+		testCases := []struct {
+			name              string
+			inputMap          map[string]any
+			expectedFxamacker Conflict
+			expectedOurs      Conflict
+			desc              string
+		}{
+			{
+				name: "tag matches another field name",
+				inputMap: map[string]any{
+					"Field1": "value1",
+				},
+				expectedFxamacker: Conflict{
+					Field1: "",       // Field1 has no tag, doesn't match
+					Field2: "value1", // Field2's tag "Field1" matches
+				},
+				expectedOurs: Conflict{
+					Field1: "",       // Same as fxamacker
+					Field2: "value1", // Same as fxamacker
+				},
+				desc: "Both implementations agree: tag takes precedence",
+			},
+			{
+				name: "both field names present",
+				inputMap: map[string]any{
+					"Field1": "value1",
+					"Field2": "value2",
+				},
+				expectedFxamacker: Conflict{
+					Field1: "",       // Field1 still doesn't get value
+					Field2: "value1", // Field2's tag wins over Field2 name
+				},
+				expectedOurs: Conflict{
+					Field1: "",       // Field1 doesn't get value
+					Field2: "value1", // Now matches fxamacker - tag takes precedence
+				},
+				desc: "Both implementations now agree: tag always takes precedence",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Encode the map with fxamacker/cbor
+				encoded, err := marshaler.Marshal(tc.inputMap)
+				require.NoError(t, err)
+
+				// Decode with fxamacker/cbor
+				var decodedFx Conflict
+				err = unmarshaler.Unmarshal(encoded, &decodedFx)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedFxamacker, decodedFx, "fxamacker/cbor result")
+
+				// Decode with our implementation
+				var decodedOur Conflict
+				err = Unmarshal(encoded, &decodedOur)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedOurs, decodedOur, "our implementation result")
+			})
+		}
+	})
+
+	t.Run("tag precedence conflicts", func(t *testing.T) {
+		// More complex scenario with multiple conflicts
+		type ComplexConflict struct {
+			Name     string `json:"title"` // Field Name, tag "title"
+			Title    string `json:"name"`  // Field Title, tag "name"
+			Untitled string // Field Untitled, no tag
+		}
+
+		// NOTE: We don't test cases where both exact and case-insensitive matches
+		// exist (e.g., both "title" and "Title" as keys) because the result depends
+		// on the non-deterministic iteration order of Go maps during encoding.
+
+		testCases := []struct {
+			name             string
+			inputMap         map[string]any
+			expectedName     string
+			expectedTitle    string
+			expectedUntitled string
+		}{
+			{
+				name: "cross-referenced tags",
+				inputMap: map[string]any{
+					"name":  "name-value",
+					"title": "title-value",
+				},
+				// Tags are swapped: Name has tag "title", Title has tag "name"
+				expectedName:     "title-value", // Name field gets value from "title" key
+				expectedTitle:    "name-value",  // Title field gets value from "name" key
+				expectedUntitled: "",            // No value for Untitled
+			},
+			{
+				name: "field names matching",
+				inputMap: map[string]any{
+					"Name":  "Name-value",
+					"Title": "Title-value",
+				},
+				// Case-insensitive tag matching applies
+				expectedName:     "Title-value", // "Title" matches tag "title" case-insensitively
+				expectedTitle:    "Name-value",  // "Name" matches tag "name" case-insensitively
+				expectedUntitled: "",            // No value for Untitled
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Encode the map
+				encoded, err := marshaler.Marshal(tc.inputMap)
+				require.NoError(t, err)
+
+				// Decode with fxamacker/cbor
+				var decodedFx ComplexConflict
+				err = unmarshaler.Unmarshal(encoded, &decodedFx)
+				require.NoError(t, err)
+
+				// Decode with our implementation
+				var decodedOur ComplexConflict
+				err = Unmarshal(encoded, &decodedOur)
+				require.NoError(t, err)
+
+				// Assert expected values for fxamacker
+				assert.Equal(t, tc.expectedName, decodedFx.Name, "fxamacker Name field")
+				assert.Equal(t, tc.expectedTitle, decodedFx.Title, "fxamacker Title field")
+				assert.Equal(t, tc.expectedUntitled, decodedFx.Untitled, "fxamacker Untitled field")
+
+				// Assert our implementation matches fxamacker
+				assert.Equal(t, decodedFx, decodedOur, "our implementation should match fxamacker")
+			})
+		}
+	})
+
+	t.Run("case sensitivity", func(t *testing.T) {
+		type CaseSensitive struct {
+			FieldOne string `json:"fieldone"`
+			FieldTwo string
+		}
+
+		// Test with exact match
+		exactMatch := map[string]any{
+			"fieldone": "value1",
+			"FieldTwo": "value2",
+		}
+
+		encoded, err := marshaler.Marshal(exactMatch)
+		require.NoError(t, err)
+
+		var decoded CaseSensitive
+		err = unmarshaler.Unmarshal(encoded, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, "value1", decoded.FieldOne)
+		assert.Equal(t, "value2", decoded.FieldTwo)
+
+		// Test with case mismatch - fxamacker/cbor behavior
+		caseMismatch := map[string]any{
+			"FieldOne": "value1", // Wrong case for tag
+			"fieldtwo": "value2", // Wrong case for field name
+		}
+
+		encoded, err = marshaler.Marshal(caseMismatch)
+		require.NoError(t, err)
+
+		var decodedMismatch CaseSensitive
+		err = unmarshaler.Unmarshal(encoded, &decodedMismatch)
+		require.NoError(t, err)
+
+		// Verify fxamacker/cbor's case sensitivity behavior
+		// Tags are case-sensitive, field names may have fallback
+		assert.Equal(t, "value1", decodedMismatch.FieldOne) // Field name match
+		assert.Equal(t, "value2", decodedMismatch.FieldTwo) // Case-insensitive fallback
+
+		// Test with our implementation
+		var ourDecoded CaseSensitive
+		err = Unmarshal(encoded, &ourDecoded)
+		require.NoError(t, err)
+		assert.Equal(t, decodedMismatch, ourDecoded)
+	})
+
+	t.Run("embedded struct position", func(t *testing.T) {
+		// Test embedded structs in different positions within the parent struct
+		type EmbeddedFields struct {
+			ID     string `json:"id"`
+			Type   string `json:"type"`
+			Status string // no tag
+		}
+
+		// Embedded as first field
+		type EmbeddedFirst struct {
+			EmbeddedFields
+			Name  string `json:"name"`
+			Value int    `json:"value"`
+		}
+
+		// Embedded as middle field
+		type EmbeddedMiddle struct {
+			Name string `json:"name"`
+			EmbeddedFields
+			Value int `json:"value"`
+		}
+
+		// Embedded as last field
+		type EmbeddedLast struct {
+			Name  string `json:"name"`
+			Value int    `json:"value"`
+			EmbeddedFields
+		}
+
+		// Multiple embedded structs
+		type AnotherEmbedded struct {
+			Code  string `json:"code"`
+			Count int
+		}
+
+		type MultipleEmbedded struct {
+			Name string `json:"name"`
+			EmbeddedFields
+			Value int `json:"value"`
+			AnotherEmbedded
+			Extra string
+		}
+
+		testData := map[string]any{
+			"id":     "test-id",
+			"type":   "test-type",
+			"Status": "test-status",
+			"name":   "test-name",
+			"value":  42,
+			"code":   "test-code",
+			"Count":  99,
+			"Extra":  "test-extra",
+		}
+
+		// Test embedded as first field
+		t.Run("embedded first", func(t *testing.T) {
+			encoded, err := marshaler.Marshal(testData)
+			require.NoError(t, err)
+
+			var fxFirst EmbeddedFirst
+			err = unmarshaler.Unmarshal(encoded, &fxFirst)
+			require.NoError(t, err)
+
+			var ourFirst EmbeddedFirst
+			err = Unmarshal(encoded, &ourFirst)
+			require.NoError(t, err)
+
+			// Verify both implementations handle embedded fields correctly
+			assert.Equal(t, "test-id", fxFirst.ID, "fxamacker embedded ID")
+			assert.Equal(t, "test-type", fxFirst.Type, "fxamacker embedded Type")
+			assert.Equal(t, "test-status", fxFirst.Status, "fxamacker embedded Status")
+			assert.Equal(t, "test-name", fxFirst.Name, "fxamacker Name")
+			assert.Equal(t, 42, fxFirst.Value, "fxamacker Value")
+
+			assert.Equal(t, fxFirst, ourFirst, "our implementation should match fxamacker")
+		})
+
+		// Test embedded as middle field
+		t.Run("embedded middle", func(t *testing.T) {
+			encoded, err := marshaler.Marshal(testData)
+			require.NoError(t, err)
+
+			var fxMiddle EmbeddedMiddle
+			err = unmarshaler.Unmarshal(encoded, &fxMiddle)
+			require.NoError(t, err)
+
+			var ourMiddle EmbeddedMiddle
+			err = Unmarshal(encoded, &ourMiddle)
+			require.NoError(t, err)
+
+			// Verify both implementations handle embedded fields correctly
+			assert.Equal(t, "test-name", fxMiddle.Name, "fxamacker Name")
+			assert.Equal(t, "test-id", fxMiddle.ID, "fxamacker embedded ID")
+			assert.Equal(t, "test-type", fxMiddle.Type, "fxamacker embedded Type")
+			assert.Equal(t, "test-status", fxMiddle.Status, "fxamacker embedded Status")
+			assert.Equal(t, 42, fxMiddle.Value, "fxamacker Value")
+
+			assert.Equal(t, fxMiddle, ourMiddle, "our implementation should match fxamacker")
+		})
+
+		// Test embedded as last field
+		t.Run("embedded last", func(t *testing.T) {
+			encoded, err := marshaler.Marshal(testData)
+			require.NoError(t, err)
+
+			var fxLast EmbeddedLast
+			err = unmarshaler.Unmarshal(encoded, &fxLast)
+			require.NoError(t, err)
+
+			var ourLast EmbeddedLast
+			err = Unmarshal(encoded, &ourLast)
+			require.NoError(t, err)
+
+			// Verify both implementations handle embedded fields correctly
+			assert.Equal(t, "test-name", fxLast.Name, "fxamacker Name")
+			assert.Equal(t, 42, fxLast.Value, "fxamacker Value")
+			assert.Equal(t, "test-id", fxLast.ID, "fxamacker embedded ID")
+			assert.Equal(t, "test-type", fxLast.Type, "fxamacker embedded Type")
+			assert.Equal(t, "test-status", fxLast.Status, "fxamacker embedded Status")
+
+			assert.Equal(t, fxLast, ourLast, "our implementation should match fxamacker")
+		})
+
+		// Test multiple embedded structs
+		t.Run("multiple embedded", func(t *testing.T) {
+			encoded, err := marshaler.Marshal(testData)
+			require.NoError(t, err)
+
+			var fxMultiple MultipleEmbedded
+			err = unmarshaler.Unmarshal(encoded, &fxMultiple)
+			require.NoError(t, err)
+
+			var ourMultiple MultipleEmbedded
+			err = Unmarshal(encoded, &ourMultiple)
+			require.NoError(t, err)
+
+			// Verify both implementations handle multiple embedded fields correctly
+			assert.Equal(t, "test-name", fxMultiple.Name, "fxamacker Name")
+			assert.Equal(t, "test-id", fxMultiple.ID, "fxamacker first embedded ID")
+			assert.Equal(t, "test-type", fxMultiple.Type, "fxamacker first embedded Type")
+			assert.Equal(t, "test-status", fxMultiple.Status, "fxamacker first embedded Status")
+			assert.Equal(t, 42, fxMultiple.Value, "fxamacker Value")
+			assert.Equal(t, "test-code", fxMultiple.Code, "fxamacker second embedded Code")
+			assert.Equal(t, 99, fxMultiple.Count, "fxamacker second embedded Count")
+			assert.Equal(t, "test-extra", fxMultiple.Extra, "fxamacker Extra")
+
+			assert.Equal(t, fxMultiple, ourMultiple, "our implementation should match fxamacker")
+		})
+
+		// Test field shadowing - when parent and embedded have same field names
+		t.Run("field shadowing", func(t *testing.T) {
+			type ShadowEmbedded struct {
+				Name string `json:"shadow_name"`
+				ID   string
+			}
+
+			type ShadowParent struct {
+				Name string `json:"name"` // Different tag from embedded
+				ShadowEmbedded
+				Value int
+			}
+
+			shadowData := map[string]any{
+				"name":        "parent-name",
+				"shadow_name": "embedded-name",
+				"ID":          "test-id",
+				"Value":       100,
+			}
+
+			encoded, err := marshaler.Marshal(shadowData)
+			require.NoError(t, err)
+
+			var fxShadow ShadowParent
+			err = unmarshaler.Unmarshal(encoded, &fxShadow)
+			require.NoError(t, err)
+
+			var ourShadow ShadowParent
+			err = Unmarshal(encoded, &ourShadow)
+			require.NoError(t, err)
+
+			// Parent field should shadow embedded field
+			assert.Equal(t, "parent-name", fxShadow.Name, "fxamacker parent Name")
+			assert.Equal(t, "embedded-name", fxShadow.ShadowEmbedded.Name, "fxamacker embedded Name")
+			assert.Equal(t, "test-id", fxShadow.ID, "fxamacker embedded ID")
+			assert.Equal(t, 100, fxShadow.Value, "fxamacker Value")
+
+			assert.Equal(t, fxShadow, ourShadow, "our implementation should match fxamacker")
+		})
+	})
 }

--- a/surrealcbor/decode_bench_test.go
+++ b/surrealcbor/decode_bench_test.go
@@ -1,0 +1,475 @@
+package surrealcbor
+
+import (
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Benchmark Results Summary (approximate):
+//
+// BenchmarkDecoder:
+//   - fxamacker: ~3600 ns/op, 440 B/op, 17 allocs/op
+//   - surrealcbor: ~4000 ns/op, 728 B/op, 44 allocs/op
+//   - Performance: fxamacker is ~11% faster
+//
+// BenchmarkDecoderNested:
+//   - fxamacker: ~2060 ns/op, 192 B/op, 7 allocs/op
+//   - surrealcbor: ~2330 ns/op, 352 B/op, 24 allocs/op
+//   - Performance: fxamacker is ~13% faster
+//
+// BenchmarkDecoderEmbedded:
+//   - fxamacker: ~1380 ns/op, 176 B/op, 6 allocs/op
+//   - surrealcbor: ~1510 ns/op, 272 B/op, 15 allocs/op
+//   - Performance: fxamacker is ~9% faster
+//
+// BenchmarkDecoderLargeSlice:
+//   - fxamacker: ~63000 ns/op, 6600 B/op, 205 allocs/op
+//   - surrealcbor: ~83000 ns/op, 12232 B/op, 808 allocs/op
+//   - Performance: fxamacker is ~31% faster
+//
+// BenchmarkDecoderMixedTypes:
+//   - fxamacker: ~4470 ns/op, 584 B/op, 14 allocs/op
+//   - surrealcbor: ~5180 ns/op, 920 B/op, 36 allocs/op
+//   - Performance: fxamacker is ~16% faster
+//
+// BenchmarkDecoderCaseInsensitive:
+//   - fxamacker: ~1200 ns/op, 128 B/op, 8 allocs/op
+//   - surrealcbor: ~1530 ns/op, 192 B/op, 13 allocs/op
+//   - Performance: fxamacker is ~27% faster
+//
+// BenchmarkDecoderWithNone:
+//   - surrealcbor only: ~3190 ns/op, 576 B/op, 29 allocs/op
+//   - fxamacker cannot handle None -> nil conversion
+//
+// Overall: fxamacker/cbor is generally faster and more memory-efficient,
+// but surrealcbor provides critical SurrealDB-specific features like
+// proper None handling that fxamacker cannot support.
+
+// BenchmarkDecoder compares the performance of pkg/models.CborUnmarshaler vs surrealcbor unmarshaler
+func BenchmarkDecoder(b *testing.B) {
+	// Complex struct types similar to field_resolver_bench_test.go
+	type Address struct {
+		Street  string `json:"street"`
+		City    string `json:"city"`
+		ZipCode string `json:"zip_code"`
+		Country string `json:"country"`
+	}
+
+	type Person struct {
+		ID        string   `json:"id"`
+		FirstName string   `json:"first_name"`
+		LastName  string   `json:"last_name"`
+		Email     string   `json:"email"`
+		Phone     string   `json:"phone"`
+		Age       int      `json:"age"`
+		Address   Address  `json:"address"`
+		Tags      []string `json:"tags"`
+		Active    bool     `json:"active"`
+		Score     float64  `json:"score"`
+	}
+
+	// Sample data with various field name cases
+	data := map[string]any{
+		"id":         "person-123",
+		"first_name": "John",
+		"last_name":  "Doe",
+		"email":      "john@example.com",
+		"phone":      "+1234567890",
+		"age":        30,
+		"address": map[string]any{
+			"street":   "123 Main St",
+			"city":     "Springfield",
+			"zip_code": "12345",
+			"country":  "USA",
+		},
+		"tags":   []string{"developer", "golang", "backend", "microservices"},
+		"active": true,
+		"score":  95.5,
+	}
+
+	// Use surrealcbor's marshaler to generate CBOR data
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
+		unmarshaler := &models.CborUnmarshaler{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var p Person
+			err := unmarshaler.Unmarshal(encoded, &p)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("surrealcbor_unmarshaler", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var p Person
+			err := Unmarshal(encoded, &p)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDecoderNested tests performance with deeply nested structures
+func BenchmarkDecoderNested(b *testing.B) {
+	type Level3 struct {
+		Value string `json:"value"`
+		Count int    `json:"count"`
+	}
+
+	type Level2 struct {
+		Name  string `json:"name"`
+		Items Level3 `json:"items"`
+	}
+
+	type Level1 struct {
+		ID     string `json:"id"`
+		Nested Level2 `json:"nested"`
+	}
+
+	type Root struct {
+		Root  string `json:"root"`
+		Data  Level1 `json:"data"`
+		Extra string `json:"extra"`
+	}
+
+	// Sample nested data
+	data := map[string]any{
+		"root": "root-value",
+		"data": map[string]any{
+			"id": "level1-id",
+			"nested": map[string]any{
+				"name": "level2-name",
+				"items": map[string]any{
+					"value": "level3-value",
+					"count": 42,
+				},
+			},
+		},
+		"extra": "extra-value",
+	}
+
+	// Use surrealcbor's marshaler to generate CBOR data
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
+		unmarshaler := &models.CborUnmarshaler{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var r Root
+			err := unmarshaler.Unmarshal(encoded, &r)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("surrealcbor_unmarshaler", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var r Root
+			err := Unmarshal(encoded, &r)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDecoderEmbedded tests performance with embedded structs
+func BenchmarkDecoderEmbedded(b *testing.B) {
+	type Base struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	}
+
+	type Extended struct {
+		Base
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Value       int    `json:"value"`
+	}
+
+	// Sample data with embedded struct fields
+	data := map[string]any{
+		"id":          "base-123",
+		"type":        "extended",
+		"name":        "Test Item",
+		"description": "This is a test item with embedded base",
+		"value":       100,
+	}
+
+	// Use surrealcbor's marshaler to generate CBOR data
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
+		unmarshaler := &models.CborUnmarshaler{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var e Extended
+			err := unmarshaler.Unmarshal(encoded, &e)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("surrealcbor_unmarshaler", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var e Extended
+			err := Unmarshal(encoded, &e)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDecoderLargeSlice tests performance with large slices
+func BenchmarkDecoderLargeSlice(b *testing.B) {
+	type Item struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	type Container struct {
+		Title string `json:"title"`
+		Items []Item `json:"items"`
+	}
+
+	// Generate large slice data
+	items := make([]map[string]any, 100)
+	for i := 0; i < 100; i++ {
+		items[i] = map[string]any{
+			"id":    "item-" + string(rune(i)),
+			"name":  "Item Name " + string(rune(i)),
+			"value": i * 10,
+		}
+	}
+
+	data := map[string]any{
+		"title": "Large Container",
+		"items": items,
+	}
+
+	// Use surrealcbor's marshaler to generate CBOR data
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
+		unmarshaler := &models.CborUnmarshaler{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var c Container
+			err := unmarshaler.Unmarshal(encoded, &c)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("surrealcbor_unmarshaler", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var c Container
+			err := Unmarshal(encoded, &c)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDecoderMixedTypes tests performance with various data types
+func BenchmarkDecoderMixedTypes(b *testing.B) {
+	type MixedData struct {
+		StringField  string         `json:"string_field"`
+		IntField     int            `json:"int_field"`
+		FloatField   float64        `json:"float_field"`
+		BoolField    bool           `json:"bool_field"`
+		SliceField   []string       `json:"slice_field"`
+		MapField     map[string]int `json:"map_field"`
+		NestedStruct struct {
+			Inner string `json:"inner"`
+		} `json:"nested_struct"`
+		BytesField []byte  `json:"bytes_field"`
+		NilField   *string `json:"nil_field"`
+	}
+
+	// Sample data with mixed types
+	data := map[string]any{
+		"string_field": "test string",
+		"int_field":    42,
+		"float_field":  3.14159,
+		"bool_field":   true,
+		"slice_field":  []string{"a", "b", "c", "d", "e"},
+		"map_field": map[string]int{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		},
+		"nested_struct": map[string]any{
+			"inner": "nested value",
+		},
+		"bytes_field": []byte("hello world"),
+		"nil_field":   nil,
+	}
+
+	// Use surrealcbor's marshaler to generate CBOR data
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
+		unmarshaler := &models.CborUnmarshaler{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var m MixedData
+			err := unmarshaler.Unmarshal(encoded, &m)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("surrealcbor_unmarshaler", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var m MixedData
+			err := Unmarshal(encoded, &m)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDecoderCaseInsensitive tests performance with case-insensitive field matching
+func BenchmarkDecoderCaseInsensitive(b *testing.B) {
+	type CaseSensitive struct {
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		UserName  string // No tag, relies on field name matching
+		UserID    int    // No tag, relies on field name matching
+	}
+
+	// Data with mixed case field names
+	data := map[string]any{
+		"first_name": "John",    // Exact match
+		"LAST_NAME":  "Doe",     // Case mismatch
+		"username":   "johndoe", // Case-insensitive field name
+		"userid":     12345,     // Case-insensitive field name
+	}
+
+	// Use surrealcbor's marshaler to generate CBOR data
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
+		unmarshaler := &models.CborUnmarshaler{}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var c CaseSensitive
+			err := unmarshaler.Unmarshal(encoded, &c)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("surrealcbor_unmarshaler", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var c CaseSensitive
+			err := Unmarshal(encoded, &c)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDecoderWithNone tests performance with SurrealDB None values
+// This showcases the main feature difference - surrealcbor can handle None as nil
+func BenchmarkDecoderWithNone(b *testing.B) {
+	type DataWithOptionals struct {
+		ID       string             `json:"id"`
+		Name     *string            `json:"name"`
+		Age      *int               `json:"age"`
+		Email    *string            `json:"email"`
+		Metadata map[string]*string `json:"metadata"`
+	}
+
+	// Create data with None values (which our marshaler handles)
+	name := "John"
+	data := map[string]any{
+		"id":    "user-123",
+		"name":  &name,
+		"age":   models.CustomNil{}, // SurrealDB None
+		"email": models.CustomNil{}, // SurrealDB None
+		"metadata": map[string]any{
+			"field1": "value1",
+			"field2": models.CustomNil{}, // SurrealDB None
+			"field3": "value3",
+		},
+	}
+
+	// Use models marshaler since it knows how to encode CustomNil as Tag 6
+	marshaler := &models.CborMarshaler{}
+	encoded, err := marshaler.Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("surrealcbor_unmarshaler_with_none", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var d DataWithOptionals
+			err := Unmarshal(encoded, &d)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Our implementation should unmarshal None to nil
+			if d.Age != nil || d.Email != nil {
+				b.Fatal("Expected None values to be unmarshaled as nil")
+			}
+		}
+	})
+
+	// Note: We don't benchmark fxamacker here because it can't handle None -> nil conversion
+	// It would unmarshal None to a non-nil CustomNil{} struct
+}

--- a/surrealcbor/decode_map.go
+++ b/surrealcbor/decode_map.go
@@ -199,13 +199,13 @@ func (d *decoder) decodeMapIntoMap(v reflect.Value, length int) error {
 
 func (d *decoder) decodeMapIntoStruct(v reflect.Value, length int) error {
 	for i := 0; i < length; i++ {
-		var key string
-		if err := d.decodeValue(reflect.ValueOf(&key).Elem()); err != nil {
+		keyStr, err := d.decodeStringDirect()
+		if err != nil {
 			return err
 		}
 
 		// Find field using field resolver
-		field := d.getFieldResolver().FindField(v, key)
+		field := d.getFieldResolver().FindField(v, keyStr)
 		if field.IsValid() && field.CanSet() {
 			if err := d.decodeValue(field); err != nil {
 				return err

--- a/surrealcbor/decode_map.go
+++ b/surrealcbor/decode_map.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"math"
 	"reflect"
-	"strings"
 )
 
 // decodeMap decodes a CBOR map (Major Type 5) into the given reflect.Value.
@@ -107,8 +106,8 @@ func (d *decoder) decodeIndefiniteMapIntoStruct(v reflect.Value) error {
 			return err
 		}
 
-		// Find the struct field
-		field := d.findStructField(v, fieldName)
+		// Find the struct field using field resolver
+		field := d.getFieldResolver().FindField(v, fieldName)
 		if field.IsValid() && field.CanSet() {
 			if err := d.decodeValue(field); err != nil {
 				return err
@@ -125,110 +124,12 @@ func (d *decoder) decodeIndefiniteMapIntoStruct(v reflect.Value) error {
 	return nil
 }
 
-// findStructField returns the struct field with the given name, if it exists.
-// It searches for the field by the following order of precedence:
-// 1. Exact match on CBOR/JSON tags
-// 2. Exact match on field names
-// 3. Case-insensitive match on field names
-//
-// It does a depth-first search for embedded structs.
-func (d *decoder) findStructField(v reflect.Value, name string) reflect.Value {
-	if field := d.findFieldByTag(v, name); field.IsValid() {
-		return field
+// getFieldResolver returns the field resolver, creating a default one if needed
+func (d *decoder) getFieldResolver() FieldResolver {
+	if d.fieldResolver == nil {
+		d.fieldResolver = NewCachedFieldResolver()
 	}
-
-	if field := d.findFieldByName(v, name); field.IsValid() {
-		return field
-	}
-
-	return d.findFieldByNameCaseInsensitive(v, name)
-}
-
-// findFieldByTag returns the struct field with the given CBOR or JSON tag name, if it exists.
-func (d *decoder) findFieldByTag(v reflect.Value, name string) reflect.Value {
-	t := v.Type()
-
-	for i := 0; i < v.NumField(); i++ {
-		field := t.Field(i)
-
-		// Handle embedded structs
-		if field.Anonymous && field.Type.Kind() == reflect.Struct {
-			if embeddedField := d.findFieldByTag(v.Field(i), name); embeddedField.IsValid() {
-				return embeddedField
-			}
-		}
-
-		// Check for matching tag
-		if tagName := d.getFieldTagName(&field); tagName == name {
-			return v.Field(i)
-		}
-	}
-
-	return reflect.Value{}
-}
-
-func (d *decoder) findFieldByName(v reflect.Value, name string) reflect.Value {
-	t := v.Type()
-
-	for i := 0; i < v.NumField(); i++ {
-		field := t.Field(i)
-
-		// Handle embedded structs
-		if field.Anonymous && field.Type.Kind() == reflect.Struct {
-			if embeddedField := d.findFieldByName(v.Field(i), name); embeddedField.IsValid() {
-				return embeddedField
-			}
-		}
-
-		if field.Name == name {
-			return v.Field(i)
-		}
-	}
-
-	return reflect.Value{}
-}
-
-// getFieldTagName returns the CBOR or JSON tag name for a struct field.
-func (d *decoder) getFieldTagName(field *reflect.StructField) string {
-	if tag := field.Tag.Get("cbor"); tag != "" {
-		// Parse tag to handle comma-separated options like "name,omitempty"
-		if idx := strings.Index(tag, ","); idx != -1 {
-			tag = tag[:idx]
-		}
-		return tag
-	}
-
-	if tag := field.Tag.Get("json"); tag != "" {
-		// Parse tag to handle comma-separated options
-		if idx := strings.Index(tag, ","); idx != -1 {
-			tag = tag[:idx]
-		}
-		return tag
-	}
-
-	return ""
-}
-
-// findFieldByNameCaseInsensitive returns the struct field with a case-insensitive match on field name
-func (d *decoder) findFieldByNameCaseInsensitive(v reflect.Value, name string) reflect.Value {
-	t := v.Type()
-
-	for i := 0; i < v.NumField(); i++ {
-		field := t.Field(i)
-
-		// Handle embedded structs
-		if field.Anonymous && field.Type.Kind() == reflect.Struct {
-			if embeddedField := d.findFieldByNameCaseInsensitive(v.Field(i), name); embeddedField.IsValid() {
-				return embeddedField
-			}
-		}
-
-		if strings.EqualFold(field.Name, name) {
-			return v.Field(i)
-		}
-	}
-
-	return reflect.Value{}
+	return d.fieldResolver
 }
 
 func (d *decoder) decodeIndefiniteMapIntoInterface(v reflect.Value) error {
@@ -303,8 +204,8 @@ func (d *decoder) decodeMapIntoStruct(v reflect.Value, length int) error {
 			return err
 		}
 
-		// Find field by json tag or name
-		field := d.findStructField(v, key)
+		// Find field using field resolver
+		field := d.getFieldResolver().FindField(v, key)
 		if field.IsValid() && field.CanSet() {
 			if err := d.decodeValue(field); err != nil {
 				return err

--- a/surrealcbor/decode_string.go
+++ b/surrealcbor/decode_string.go
@@ -6,6 +6,67 @@ import (
 	"reflect"
 )
 
+// Maximum allowed string length when decoding CBOR strings
+// This prevents excessive memory allocation
+var MaxCBORStringLength uint64 = 10000000 // 10MB
+
+// readStringLength reads the length of a string and returns it as an int
+// with appropriate bounds checking
+func (d *decoder) readStringLength(dst *int) error {
+	length, err := d.readUint()
+	if err != nil {
+		return err
+	}
+	if length > MaxCBORStringLength {
+		return fmt.Errorf("CBOR string length %d exceeds maximum allowed (%d)", length, MaxCBORStringLength)
+	}
+	if length > uint64(int(^uint(0)>>1)) { // check for int overflow
+		return fmt.Errorf("CBOR string length %d overflows int", length)
+	}
+
+	*dst = int(length) // #nosec G115 - length checked above
+	return nil
+}
+
+// decodeStringDirect decodes a CBOR text string directly without using reflect.Value
+// This avoids allocations when we just need the string value itself.
+//
+// That said, this is a better alternative to:
+//
+//	decodeValue(reflect.ValueOf(&key).Elem())
+func (d *decoder) decodeStringDirect() (string, error) {
+	// Check major type
+	if d.pos >= len(d.data) {
+		return "", io.EOF
+	}
+
+	majorType := d.data[d.pos] >> 5
+	if majorType != 3 { // Text string
+		return "", fmt.Errorf("expected text string (major type 3), got major type %d", majorType)
+	}
+
+	// Check for indefinite length
+	if d.data[d.pos]&0x1f == 31 {
+		d.pos++ // Skip the indefinite length marker
+		return d.decodeIndefiniteStringDirect()
+	}
+
+	var strLen int
+	err := d.readStringLength(&strLen)
+	if err != nil {
+		return "", err
+	}
+
+	remaining := len(d.data) - d.pos
+	if remaining < strLen {
+		return "", io.ErrUnexpectedEOF
+	}
+	str := string(d.data[d.pos : d.pos+strLen])
+	d.pos += strLen
+
+	return str, nil
+}
+
 // decodeString decodes a CBOR text string (Major Type 3) into the given reflect.Value.
 // https://www.rfc-editor.org/rfc/rfc8949.html#section-3.1-2.8
 func (d *decoder) decodeString(v reflect.Value) error {
@@ -18,21 +79,16 @@ func (d *decoder) decodeString(v reflect.Value) error {
 		return d.decodeIndefiniteString(v)
 	}
 
-	length, err := d.readUint()
+	var strLen int
+	err := d.readStringLength(&strLen)
 	if err != nil {
 		return err
 	}
 
 	remaining := len(d.data) - d.pos
-	if remaining < 0 {
-		return fmt.Errorf("not enough data to decode string, expected %d bytes, got %d", length, remaining)
-	}
-
-	if length > uint64(remaining) {
+	if remaining < strLen {
 		return io.ErrUnexpectedEOF
 	}
-
-	strLen := int(length) // #nosec G115 - length checked above
 	str := string(d.data[d.pos : d.pos+strLen])
 	d.pos += strLen
 
@@ -45,6 +101,56 @@ func (d *decoder) decodeString(v reflect.Value) error {
 		return fmt.Errorf("cannot decode string into %v", v.Type())
 	}
 	return nil
+}
+
+// decodeIndefiniteStringDirect decodes an indefinite-length string directly
+func (d *decoder) decodeIndefiniteStringDirect() (string, error) {
+	var chunks []string
+
+	for {
+		// Check for break marker (0xFF)
+		if d.pos >= len(d.data) {
+			return "", io.ErrUnexpectedEOF
+		}
+		if d.data[d.pos] == 0xFF {
+			d.pos++ // Skip break marker
+			break
+		}
+
+		// Each chunk must be a definite-length string
+		if d.data[d.pos]>>5 != 3 {
+			return "", fmt.Errorf("indefinite string chunk must be a text string")
+		}
+
+		// Check that chunk is not indefinite (avoid recursion)
+		if d.data[d.pos]&0x1f == 31 {
+			return "", fmt.Errorf("indefinite string chunks cannot be indefinite")
+		}
+
+		// Decode definite-length chunk
+		var strLen int
+		err := d.readStringLength(&strLen)
+		if err != nil {
+			return "", err
+		}
+
+		remaining := len(d.data) - d.pos
+		if remaining < strLen {
+			return "", io.ErrUnexpectedEOF
+		}
+
+		chunk := string(d.data[d.pos : d.pos+strLen])
+		d.pos += strLen
+		chunks = append(chunks, chunk)
+	}
+
+	// Concatenate all chunks
+	result := ""
+	for _, chunk := range chunks {
+		result += chunk
+	}
+
+	return result, nil
 }
 
 func (d *decoder) decodeIndefiniteString(v reflect.Value) error {

--- a/surrealcbor/field_resolver.go
+++ b/surrealcbor/field_resolver.go
@@ -1,0 +1,293 @@
+package surrealcbor
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// FieldResolver is an interface for resolving struct fields by name
+type FieldResolver interface {
+	// FindField finds a struct field by name, following the precedence:
+	// 1. Exact match on CBOR/JSON tags
+	// 2. Exact match on field names
+	// 3. Case-insensitive match on field names
+	FindField(v reflect.Value, name string) reflect.Value
+}
+
+// BasicFieldResolver is the original implementation without caching
+type BasicFieldResolver struct{}
+
+// NewBasicFieldResolver creates a new basic field resolver
+func NewBasicFieldResolver() FieldResolver {
+	return &BasicFieldResolver{}
+}
+
+func (r *BasicFieldResolver) FindField(v reflect.Value, name string) reflect.Value {
+	// Try exact tag match
+	if field := r.findFieldByTag(v, name); field.IsValid() {
+		return field
+	}
+
+	// Try exact field name match (only for fields without tags)
+	if field := r.findFieldByNameNoTag(v, name); field.IsValid() {
+		return field
+	}
+
+	// Fallback to case-insensitive field name match (only for fields without tags)
+	return r.findFieldByNameCaseInsensitiveNoTag(v, name)
+}
+
+func (r *BasicFieldResolver) findFieldByTag(v reflect.Value, name string) reflect.Value {
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Handle embedded structs
+		if field.Anonymous && field.Type.Kind() == reflect.Struct {
+			if embeddedField := r.findFieldByTag(v.Field(i), name); embeddedField.IsValid() {
+				return embeddedField
+			}
+		}
+
+		// Check for matching tag (only if tag name is not empty)
+		// fxamacker/cbor does case-insensitive tag matching
+		if tagName := getFieldTagName(&field); tagName != "" && strings.EqualFold(tagName, name) {
+			return v.Field(i)
+		}
+	}
+
+	return reflect.Value{}
+}
+
+// findFieldByNameNoTag finds a field by exact name match, but only if the field has no tags
+func (r *BasicFieldResolver) findFieldByNameNoTag(v reflect.Value, name string) reflect.Value {
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Skip fields that have tags
+		if getFieldTagName(&field) != "" {
+			continue
+		}
+
+		// Handle embedded structs
+		if field.Anonymous && field.Type.Kind() == reflect.Struct {
+			if embeddedField := r.findFieldByNameNoTag(v.Field(i), name); embeddedField.IsValid() {
+				return embeddedField
+			}
+		}
+
+		if field.Name == name {
+			return v.Field(i)
+		}
+	}
+
+	return reflect.Value{}
+}
+
+// findFieldByNameCaseInsensitiveNoTag finds a field by case-insensitive name match, but only if the field has no tags
+func (r *BasicFieldResolver) findFieldByNameCaseInsensitiveNoTag(v reflect.Value, name string) reflect.Value {
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Skip fields that have tags
+		if getFieldTagName(&field) != "" {
+			continue
+		}
+
+		// Handle embedded structs
+		if field.Anonymous && field.Type.Kind() == reflect.Struct {
+			if embeddedField := r.findFieldByNameCaseInsensitiveNoTag(v.Field(i), name); embeddedField.IsValid() {
+				return embeddedField
+			}
+		}
+
+		if strings.EqualFold(field.Name, name) {
+			return v.Field(i)
+		}
+	}
+
+	return reflect.Value{}
+}
+
+// getFieldTagName returns the CBOR or JSON tag name for a struct field
+func getFieldTagName(field *reflect.StructField) string {
+	if tag := field.Tag.Get("cbor"); tag != "" {
+		// Parse tag to handle comma-separated options like "name,omitempty"
+		if idx := strings.Index(tag, ","); idx != -1 {
+			tag = tag[:idx]
+		}
+		// Don't use empty tag or "-" as a name
+		if tag == "" || tag == "-" {
+			return ""
+		}
+		return tag
+	}
+
+	if tag := field.Tag.Get("json"); tag != "" {
+		// Parse tag to handle comma-separated options
+		if idx := strings.Index(tag, ","); idx != -1 {
+			tag = tag[:idx]
+		}
+		// Don't use empty tag or "-" as a name
+		if tag == "" || tag == "-" {
+			return ""
+		}
+		return tag
+	}
+
+	return ""
+}
+
+// fieldInfo contains cached information about a struct field
+type fieldInfo struct {
+	index      []int  // Field index path (for embedded structs)
+	tagName    string // CBOR or JSON tag name
+	fieldName  string // Actual field name
+	isEmbedded bool   // Whether this is an embedded field
+}
+
+// structFieldsCache caches field information for struct types
+type structFieldsCache struct {
+	// Map from reflect.Type to field information
+	// The inner map is keyed by: tag names, field names, and lowercase field names
+	cache map[reflect.Type]map[string]*fieldInfo
+	mu    sync.RWMutex
+}
+
+// CachedFieldResolver resolves struct fields with caching
+type CachedFieldResolver struct {
+	cache *structFieldsCache
+}
+
+// NewCachedFieldResolver creates a new cached field resolver
+func NewCachedFieldResolver() FieldResolver {
+	return &CachedFieldResolver{
+		cache: &structFieldsCache{
+			cache: make(map[reflect.Type]map[string]*fieldInfo),
+		},
+	}
+}
+
+func (r *CachedFieldResolver) FindField(v reflect.Value, name string) reflect.Value {
+	t := v.Type()
+
+	// Get or build the field map for this type
+	fieldMap := r.cache.getOrBuildFieldMap(t)
+
+	// Try exact match (tags and field names)
+	if info, ok := fieldMap[name]; ok {
+		return fieldByIndex(v, info.index)
+	}
+
+	// Try case-insensitive field name match
+	nameLower := strings.ToLower(name)
+	if info, ok := fieldMap["~"+nameLower]; ok { // Using ~ prefix for case-insensitive keys
+		return fieldByIndex(v, info.index)
+	}
+
+	return reflect.Value{}
+}
+
+// fieldByIndex returns the field value at the given index path
+func fieldByIndex(v reflect.Value, index []int) reflect.Value {
+	for _, i := range index {
+		v = v.Field(i)
+	}
+	return v
+}
+
+func (c *structFieldsCache) getOrBuildFieldMap(t reflect.Type) map[string]*fieldInfo {
+	c.mu.RLock()
+	fieldMap, ok := c.cache[t]
+	c.mu.RUnlock()
+
+	if ok {
+		return fieldMap
+	}
+
+	// Build the field map
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check in case another goroutine built it
+	if fm, ok := c.cache[t]; ok {
+		return fm
+	}
+
+	fieldMap = c.buildFieldMap(t, nil)
+	c.cache[t] = fieldMap
+	return fieldMap
+}
+
+func (c *structFieldsCache) buildFieldMap(t reflect.Type, parentIndex []int) map[string]*fieldInfo {
+	fieldMap := make(map[string]*fieldInfo)
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		index := append(append([]int(nil), parentIndex...), i)
+
+		// Handle embedded structs
+		if field.Anonymous && field.Type.Kind() == reflect.Struct {
+			// Recursively add embedded struct fields
+			embeddedMap := c.buildFieldMap(field.Type, index)
+			for key, info := range embeddedMap {
+				// Only add if not already present (outer fields take precedence)
+				if _, exists := fieldMap[key]; !exists {
+					fieldMap[key] = info
+				}
+			}
+		}
+
+		info := &fieldInfo{
+			index:      index,
+			fieldName:  field.Name,
+			isEmbedded: field.Anonymous,
+		}
+
+		// Add tag-based entries (getFieldTagName already filters out empty and "-" tags)
+		if tagName := getFieldTagName(&field); tagName != "" {
+			info.tagName = tagName
+			fieldMap[tagName] = info
+			// Also add case-insensitive tag entry (fxamacker behavior)
+			// Using ~ prefix to distinguish from exact matches
+			fieldMap["~"+strings.ToLower(tagName)] = info
+		} else {
+			// Only add field name entries if there's no tag
+			// Add field name entry (exact match)
+			fieldMap[field.Name] = info
+
+			// Add lowercase field name entry for case-insensitive matching
+			// Using ~ prefix to distinguish from actual field/tag names
+			fieldMap["~"+strings.ToLower(field.Name)] = info
+		}
+	}
+
+	return fieldMap
+}

--- a/surrealcbor/field_resolver_bench_test.go
+++ b/surrealcbor/field_resolver_bench_test.go
@@ -1,0 +1,222 @@
+package surrealcbor
+
+import (
+	"testing"
+)
+
+// BenchmarkFieldResolver compares the performance of basic vs cached field resolver
+func BenchmarkFieldResolver(b *testing.B) {
+	// Complex struct for benchmarking
+	type Address struct {
+		Street  string `json:"street"`
+		City    string `json:"city"`
+		ZipCode string `json:"zip_code"`
+		Country string `json:"country"`
+	}
+
+	type Person struct {
+		ID        string   `json:"id"`
+		FirstName string   `json:"first_name"`
+		LastName  string   `json:"last_name"`
+		Email     string   `json:"email"`
+		Phone     string   `json:"phone"`
+		Age       int      `json:"age"`
+		Address   Address  `json:"address"`
+		Tags      []string `json:"tags"`
+		Active    bool     `json:"active"`
+		Score     float64  `json:"score"`
+	}
+
+	// Sample data with various field name cases
+	data := map[string]any{
+		"id":         "person-123",
+		"first_name": "John",
+		"last_name":  "Doe",
+		"email":      "john@example.com",
+		"phone":      "+1234567890",
+		"age":        30,
+		"address": map[string]any{
+			"street":   "123 Main St",
+			"city":     "Springfield",
+			"zip_code": "12345",
+			"country":  "USA",
+		},
+		"tags":   []string{"developer", "golang"},
+		"active": true,
+		"score":  95.5,
+	}
+
+	// Encode the data once
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("BasicFieldResolver", func(b *testing.B) {
+		basicResolver := NewBasicFieldResolver()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var p Person
+			d := &decoder{
+				data:          encoded,
+				pos:           0,
+				fieldResolver: basicResolver,
+			}
+			if decodeErr := d.decode(&p); decodeErr != nil {
+				b.Fatal(decodeErr)
+			}
+		}
+	})
+
+	b.Run("CachedFieldResolver", func(b *testing.B) {
+		cachedResolver := NewCachedFieldResolver()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var p Person
+			d := &decoder{
+				data:          encoded,
+				pos:           0,
+				fieldResolver: cachedResolver,
+			}
+			if decodeErr := d.decode(&p); decodeErr != nil {
+				b.Fatal(decodeErr)
+			}
+		}
+	})
+
+	// Test with case-insensitive field names
+	dataCaseInsensitive := map[string]any{
+		"ID":         "person-456",
+		"FIRST_NAME": "Jane",
+		"LAST_NAME":  "Smith",
+		"EMAIL":      "jane@example.com",
+		"PHONE":      "+0987654321",
+		"AGE":        25,
+		"ADDRESS": map[string]any{
+			"STREET":   "456 Oak Ave",
+			"CITY":     "Metropolis",
+			"ZIP_CODE": "67890",
+			"COUNTRY":  "Canada",
+		},
+		"TAGS":   []string{"manager", "python"},
+		"ACTIVE": false,
+		"SCORE":  88.0,
+	}
+
+	encodedCaseInsensitive, err := Marshal(dataCaseInsensitive)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("BasicFieldResolver_CaseInsensitive", func(b *testing.B) {
+		basicResolver := NewBasicFieldResolver()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var p Person
+			d := &decoder{
+				data:          encodedCaseInsensitive,
+				pos:           0,
+				fieldResolver: basicResolver,
+			}
+			if decodeErr := d.decode(&p); decodeErr != nil {
+				b.Fatal(decodeErr)
+			}
+		}
+	})
+
+	b.Run("CachedFieldResolver_CaseInsensitive", func(b *testing.B) {
+		cachedResolver := NewCachedFieldResolver()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var p Person
+			d := &decoder{
+				data:          encodedCaseInsensitive,
+				pos:           0,
+				fieldResolver: cachedResolver,
+			}
+			if decodeErr := d.decode(&p); decodeErr != nil {
+				b.Fatal(decodeErr)
+			}
+		}
+	})
+}
+
+// BenchmarkFieldResolverDeepStruct tests performance with deeply nested structs
+func BenchmarkFieldResolverDeepStruct(b *testing.B) {
+	type Level3 struct {
+		Value string `json:"value"`
+		Count int    `json:"count"`
+	}
+
+	type Level2 struct {
+		Name  string `json:"name"`
+		Items Level3 `json:"items"`
+	}
+
+	type Level1 struct {
+		ID     string `json:"id"`
+		Nested Level2 `json:"nested"`
+	}
+
+	type RootStruct struct {
+		Root   string `json:"root"`
+		Level1 Level1 `json:"level1"`
+	}
+
+	data := map[string]any{
+		"root": "root-value",
+		"level1": map[string]any{
+			"id": "level1-id",
+			"nested": map[string]any{
+				"name": "level2-name",
+				"items": map[string]any{
+					"value": "level3-value",
+					"count": 42,
+				},
+			},
+		},
+	}
+
+	encoded, err := Marshal(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("BasicFieldResolver", func(b *testing.B) {
+		basicResolver := NewBasicFieldResolver()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var r RootStruct
+			d := &decoder{
+				data:          encoded,
+				pos:           0,
+				fieldResolver: basicResolver,
+			}
+			if decodeErr := d.decode(&r); decodeErr != nil {
+				b.Fatal(decodeErr)
+			}
+		}
+	})
+
+	b.Run("CachedFieldResolver", func(b *testing.B) {
+		cachedResolver := NewCachedFieldResolver()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			var r RootStruct
+			d := &decoder{
+				data:          encoded,
+				pos:           0,
+				fieldResolver: cachedResolver,
+			}
+			if decodeErr := d.decode(&r); decodeErr != nil {
+				b.Fatal(decodeErr)
+			}
+		}
+	})
+}

--- a/surrealcbor/field_resolver_test.go
+++ b/surrealcbor/field_resolver_test.go
@@ -1,0 +1,493 @@
+package surrealcbor
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFieldResolverConsistency verifies that BasicFieldResolver and CachedFieldResolver
+// produce identical results for all field resolution scenarios
+//
+//nolint:gocyclo
+func TestFieldResolverConsistency(t *testing.T) {
+	basicResolver := NewBasicFieldResolver()
+	cachedResolver := NewCachedFieldResolver()
+
+	t.Run("simple struct", func(t *testing.T) {
+		type Simple struct {
+			Name  string `json:"name"`
+			Value int    `cbor:"val"`
+			Count int
+		}
+
+		s := Simple{}
+		v := reflect.ValueOf(&s).Elem()
+
+		testCases := []struct {
+			fieldName string
+			expected  string // expected field name or empty if not found
+		}{
+			{"name", "Name"},   // JSON tag match
+			{"Name", "Name"},   // Case-insensitive tag match (fxamacker behavior)
+			{"val", "Value"},   // CBOR tag match
+			{"Val", "Value"},   // Case-insensitive tag match (fxamacker behavior)
+			{"VAL", "Value"},   // Case-insensitive tag match (fxamacker behavior)
+			{"Value", ""},      // Field name not matched when tag exists
+			{"value", ""},      // Field name not matched when tag exists (case-insensitive)
+			{"Count", "Count"}, // Exact field name match
+			{"count", "Count"}, // Case-insensitive field name match
+			{"COUNT", "Count"}, // Case-insensitive field name match
+			{"unknown", ""},    // Non-existent field
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.fieldName, func(t *testing.T) {
+				basicField := basicResolver.FindField(v, tc.fieldName)
+				cachedField := cachedResolver.FindField(v, tc.fieldName)
+
+				if tc.expected == "" {
+					assert.False(t, basicField.IsValid(), "basic resolver should not find field")
+					assert.False(t, cachedField.IsValid(), "cached resolver should not find field")
+				} else {
+					require.True(t, basicField.IsValid(), "basic resolver should find field")
+					require.True(t, cachedField.IsValid(), "cached resolver should find field")
+
+					// Verify they found the same field by checking they point to the same struct field
+					// We'll modify through one and check the other sees the change
+					switch tc.expected {
+					case "Name":
+						basicField.SetString("test_value")
+						assert.Equal(t, "test_value", s.Name, "basic resolver should set correct field")
+						// Reset and test cached resolver
+						s.Name = ""
+						cachedField.SetString("test_value")
+						assert.Equal(t, "test_value", s.Name, "cached resolver should set correct field")
+					case "Value":
+						basicField.SetInt(100)
+						assert.Equal(t, 100, s.Value, "basic resolver should set correct field")
+						// Reset and test cached resolver
+						s.Value = 0
+						cachedField.SetInt(100)
+						assert.Equal(t, 100, s.Value, "cached resolver should set correct field")
+					case "Count":
+						basicField.SetInt(100)
+						assert.Equal(t, 100, s.Count, "basic resolver should set correct field")
+						// Reset and test cached resolver
+						s.Count = 0
+						cachedField.SetInt(100)
+						assert.Equal(t, 100, s.Count, "cached resolver should set correct field")
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("embedded struct", func(t *testing.T) {
+		type Embedded struct {
+			ID   string `json:"id"`
+			Type string
+		}
+
+		type Container struct {
+			Embedded
+			Name  string `json:"name"`
+			Value int
+		}
+
+		c := Container{}
+		v := reflect.ValueOf(&c).Elem()
+
+		testCases := []struct {
+			fieldName  string
+			expected   string // expected field name
+			isEmbedded bool
+		}{
+			{"id", "ID", true},        // Embedded field via tag
+			{"ID", "ID", true},        // Case-insensitive tag match (fxamacker behavior)
+			{"Type", "Type", true},    // Embedded field direct (no tag)
+			{"type", "Type", true},    // Embedded field case-insensitive (no tag)
+			{"name", "Name", false},   // Container field via tag
+			{"Name", "Name", false},   // Case-insensitive tag match (fxamacker behavior)
+			{"Value", "Value", false}, // Container field direct (no tag)
+			{"value", "Value", false}, // Container field case-insensitive (no tag)
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.fieldName, func(t *testing.T) {
+				basicField := basicResolver.FindField(v, tc.fieldName)
+				cachedField := cachedResolver.FindField(v, tc.fieldName)
+
+				if tc.expected == "" {
+					assert.False(t, basicField.IsValid(), "basic resolver should not find field")
+					assert.False(t, cachedField.IsValid(), "cached resolver should not find field")
+					return
+				}
+
+				require.True(t, basicField.IsValid(), "basic resolver should find field")
+				require.True(t, cachedField.IsValid(), "cached resolver should find field")
+
+				// Verify they point to the same field by modifying and checking
+				switch tc.expected {
+				case "ID":
+					basicField.SetString("test_value")
+					assert.Equal(t, "test_value", c.ID)
+					c.ID = ""
+					cachedField.SetString("test_value")
+					assert.Equal(t, "test_value", c.ID)
+				case "Type":
+					basicField.SetString("test_value")
+					assert.Equal(t, "test_value", c.Type)
+					c.Type = ""
+					cachedField.SetString("test_value")
+					assert.Equal(t, "test_value", c.Type)
+				case "Name":
+					basicField.SetString("test_value")
+					assert.Equal(t, "test_value", c.Name)
+					c.Name = ""
+					cachedField.SetString("test_value")
+					assert.Equal(t, "test_value", c.Name)
+				case "Value":
+					basicField.SetInt(100)
+					assert.Equal(t, 100, c.Value)
+					c.Value = 0
+					cachedField.SetInt(100)
+					assert.Equal(t, 100, c.Value)
+				}
+			})
+		}
+	})
+
+	t.Run("deeply nested struct", func(t *testing.T) {
+		type Level3 struct {
+			Value string `json:"value"`
+			Count int    `json:"count"`
+			Name  string // Field with same name as Level2
+		}
+
+		type Level2 struct {
+			Name  string `json:"name2"` // Different tag to avoid conflict
+			Items Level3 `json:"items"`
+			Count int    // Field with same name as Level3
+		}
+
+		type Level1 struct {
+			ID     string `json:"id"`
+			Nested Level2 `json:"nested"`
+			Name   string // Field with same name as Level2 and Level3
+		}
+
+		type Root struct {
+			Level1
+			Root  string `json:"root"`
+			Value string // Field with same name as Level3
+		}
+
+		r := Root{}
+		v := reflect.ValueOf(&r).Elem()
+
+		testCases := []struct {
+			fieldName string
+			desc      string
+		}{
+			{"root", "Root field via tag"},
+			{"Root", "Root field direct"},
+			{"id", "Level1 embedded field via tag"},
+			{"ID", "Level1 embedded field direct"},
+			{"Name", "Level1 embedded field (conflicts resolved by outer precedence)"},
+			{"name", "Level1 embedded field case-insensitive"},
+			{"Value", "Root field (takes precedence over deeper nested)"},
+			{"value", "Root field case-insensitive"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.fieldName, func(t *testing.T) {
+				basicField := basicResolver.FindField(v, tc.fieldName)
+				cachedField := cachedResolver.FindField(v, tc.fieldName)
+
+				// Both should find the same field or both should not find it
+				assert.Equal(t, basicField.IsValid(), cachedField.IsValid(),
+					"both resolvers should agree on field validity for %s", tc.fieldName)
+
+				if basicField.IsValid() && cachedField.IsValid() {
+					// Verify they found the same field by checking types
+					assert.Equal(t, basicField.Type(), cachedField.Type(),
+						"both resolvers should find the same field type for %s", tc.fieldName)
+				}
+			})
+		}
+	})
+
+	t.Run("multiple embedded structs with conflicts", func(t *testing.T) {
+		type Base1 struct {
+			ID   string `json:"id"`
+			Name string `json:"name1"`
+			Type string
+		}
+
+		type Base2 struct {
+			Code string `json:"code"`
+			Name string `json:"name2"`
+			Type string
+		}
+
+		type Container struct {
+			Base1
+			Base2
+			Name string `json:"name"` // Shadows embedded Name fields
+		}
+
+		c := Container{}
+		v := reflect.ValueOf(&c).Elem()
+
+		testCases := []struct {
+			fieldName string
+			desc      string
+		}{
+			{"id", "Base1.ID via tag"},
+			{"code", "Base2.Code via tag"},
+			{"name", "Container.Name via tag (shadows embedded)"},
+			{"name1", "Base1.Name via its specific tag"},
+			{"name2", "Base2.Name via its specific tag"},
+			{"Name", "Container.Name (shadows embedded)"},
+			{"Type", "Ambiguous embedded field"},
+			{"type", "Ambiguous embedded field case-insensitive"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.fieldName, func(t *testing.T) {
+				basicField := basicResolver.FindField(v, tc.fieldName)
+				cachedField := cachedResolver.FindField(v, tc.fieldName)
+
+				// For ambiguous fields like "Type", both might find Base1.Type
+				// The important thing is they both behave the same way
+				assert.Equal(t, basicField.IsValid(), cachedField.IsValid(),
+					"both resolvers should agree on field validity for %s", tc.fieldName)
+
+				if basicField.IsValid() && cachedField.IsValid() {
+					// They should find fields of the same type
+					assert.Equal(t, basicField.Type(), cachedField.Type(),
+						"both resolvers should find the same field type for %s", tc.fieldName)
+				}
+			})
+		}
+	})
+
+	t.Run("tag precedence over field names", func(t *testing.T) {
+		type TagTest struct {
+			FieldA string `json:"b" cbor:"c"` // CBOR tag takes precedence
+			FieldB string `json:"d"`          // JSON tag
+			FieldC string // No tag
+		}
+
+		tt := TagTest{}
+		v := reflect.ValueOf(&tt).Elem()
+
+		testCases := []struct {
+			fieldName  string
+			shouldFind bool
+			fieldSet   string // which field should be set
+		}{
+			{"c", true, "FieldA"},      // CBOR tag
+			{"C", true, "FieldA"},      // Case-insensitive tag match
+			{"b", false, ""},           // JSON tag is overridden by CBOR
+			{"B", false, ""},           // JSON tag is overridden by CBOR (case-insensitive)
+			{"d", true, "FieldB"},      // JSON tag
+			{"D", true, "FieldB"},      // Case-insensitive tag match
+			{"FieldA", false, ""},      // Field name not matched when tags exist
+			{"FieldB", false, ""},      // Field name not matched when tags exist
+			{"FieldC", true, "FieldC"}, // Exact field name (no tag)
+			{"fielda", false, ""},      // Field name not matched when tags exist
+			{"fieldb", false, ""},      // Field name not matched when tags exist
+			{"fieldc", true, "FieldC"}, // Case-insensitive field name (no tag)
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.fieldName, func(t *testing.T) {
+				basicField := basicResolver.FindField(v, tc.fieldName)
+				cachedField := cachedResolver.FindField(v, tc.fieldName)
+
+				assert.Equal(t, tc.shouldFind, basicField.IsValid(),
+					"basic resolver field validity for %s", tc.fieldName)
+				assert.Equal(t, tc.shouldFind, cachedField.IsValid(),
+					"cached resolver field validity for %s", tc.fieldName)
+
+				if tc.shouldFind {
+					// Verify they found the same field
+					switch tc.fieldSet {
+					case "FieldA":
+						basicField.SetString("test_value")
+						assert.Equal(t, "test_value", tt.FieldA)
+						tt.FieldA = ""
+						cachedField.SetString("test_value")
+						assert.Equal(t, "test_value", tt.FieldA)
+					case "FieldB":
+						basicField.SetString("test_value")
+						assert.Equal(t, "test_value", tt.FieldB)
+						tt.FieldB = ""
+						cachedField.SetString("test_value")
+						assert.Equal(t, "test_value", tt.FieldB)
+					case "FieldC":
+						basicField.SetString("test_value")
+						assert.Equal(t, "test_value", tt.FieldC)
+						tt.FieldC = ""
+						cachedField.SetString("test_value")
+						assert.Equal(t, "test_value", tt.FieldC)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("unexported fields", func(t *testing.T) {
+		type Private struct {
+			Public  string `json:"public"`
+			private string //nolint:unused // intentionally unused for testing unexported fields
+		}
+
+		p := Private{}
+		v := reflect.ValueOf(&p).Elem()
+
+		testCases := []struct {
+			fieldName  string
+			shouldFind bool
+		}{
+			{"public", true},   // Public field via tag
+			{"Public", true},   // Case-insensitive tag match (fxamacker behavior)
+			{"private", false}, // Should not be found (unexported)
+			{"Private", false}, // Should not be found (unexported)
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.fieldName, func(t *testing.T) {
+				basicField := basicResolver.FindField(v, tc.fieldName)
+				cachedField := cachedResolver.FindField(v, tc.fieldName)
+
+				assert.Equal(t, tc.shouldFind, basicField.IsValid(),
+					"basic resolver should%s find %s", map[bool]string{true: "", false: " not"}[tc.shouldFind], tc.fieldName)
+				assert.Equal(t, tc.shouldFind, cachedField.IsValid(),
+					"cached resolver should%s find %s", map[bool]string{true: "", false: " not"}[tc.shouldFind], tc.fieldName)
+				assert.Equal(t, basicField.IsValid(), cachedField.IsValid(),
+					"both resolvers should agree on field validity for %s", tc.fieldName)
+			})
+		}
+	})
+
+	t.Run("empty tags", func(t *testing.T) {
+		type EmptyTags struct {
+			Field1 string `json:""`           // Empty tag
+			Field2 string `json:"-"`          // Ignored field
+			Field3 string `json:",omitempty"` // Only options
+		}
+
+		et := EmptyTags{}
+		v := reflect.ValueOf(&et).Elem()
+
+		testCases := []struct {
+			fieldName  string
+			shouldFind bool
+		}{
+			{"Field1", true}, // Found by field name
+			{"field1", true}, // Case-insensitive
+			{"Field2", true}, // Found by field name (- means skip in encoding, not in field lookup)
+			{"field2", true}, // Case-insensitive
+			{"Field3", true}, // Found by field name
+			{"field3", true}, // Case-insensitive
+			{"", false},      // Empty string shouldn't match empty tag
+			{"-", false},     // Dash shouldn't match as tag
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.fieldName, func(t *testing.T) {
+				basicField := basicResolver.FindField(v, tc.fieldName)
+				cachedField := cachedResolver.FindField(v, tc.fieldName)
+
+				assert.Equal(t, tc.shouldFind, basicField.IsValid(),
+					"basic resolver field validity for %s", tc.fieldName)
+				assert.Equal(t, tc.shouldFind, cachedField.IsValid(),
+					"cached resolver field validity for %s", tc.fieldName)
+			})
+		}
+	})
+}
+
+// TestCachedFieldResolverCaching verifies that the cached resolver actually caches
+func TestCachedFieldResolverCaching(t *testing.T) {
+	type TestStruct struct {
+		Field1 string `json:"f1"`
+		Field2 int    `cbor:"f2"`
+		Field3 bool
+	}
+
+	cachedResolver := NewCachedFieldResolver().(*CachedFieldResolver)
+
+	// First access - should build cache
+	s1 := TestStruct{}
+	v1 := reflect.ValueOf(&s1).Elem()
+
+	field1 := cachedResolver.FindField(v1, "f1")
+	assert.True(t, field1.IsValid())
+
+	// Check that cache has been populated
+	cachedResolver.cache.mu.RLock()
+	_, exists := cachedResolver.cache.cache[v1.Type()]
+	cachedResolver.cache.mu.RUnlock()
+	assert.True(t, exists, "cache should be populated after first access")
+
+	// Second access with same type - should use cache
+	s2 := TestStruct{}
+	v2 := reflect.ValueOf(&s2).Elem()
+
+	field2 := cachedResolver.FindField(v2, "f2")
+	assert.True(t, field2.IsValid())
+
+	// Multiple fields from same struct
+	field3 := cachedResolver.FindField(v2, "Field3")
+	assert.True(t, field3.IsValid())
+
+	field4 := cachedResolver.FindField(v2, "field3") // case-insensitive
+	assert.True(t, field4.IsValid())
+}
+
+// TestFieldResolverThreadSafety verifies that CachedFieldResolver is thread-safe
+func TestFieldResolverThreadSafety(t *testing.T) {
+	type TestStruct struct {
+		Field1 string `json:"f1"`
+		Field2 int    `cbor:"f2"`
+		Field3 bool
+	}
+
+	cachedResolver := NewCachedFieldResolver()
+	basicResolver := NewBasicFieldResolver()
+
+	// Run concurrent field resolutions
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			s := TestStruct{}
+			v := reflect.ValueOf(&s).Elem()
+
+			// Try various field names
+			fieldNames := []string{"f1", "f2", "Field3", "field3", "Field1", "field2"}
+
+			for _, name := range fieldNames {
+				cachedField := cachedResolver.FindField(v, name)
+				basicField := basicResolver.FindField(v, name)
+
+				// They should always agree
+				if cachedField.IsValid() != basicField.IsValid() {
+					t.Errorf("goroutine %d: resolvers disagree on field %s", id, name)
+				}
+			}
+
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}


### PR DESCRIPTION
This pull request is a follow-up to #304 with the following changes:

- Refactors how struct fields are resolved during CBOR decoding
- Introduce a more efficient field resolution system with caching, which is enabled by default
- Optimize map key decoding for better performance
- More compatibility with fxamacker/cbor-based implementation: surrealcbor no longer falls back to field name matching when json/cbor field tag is present. Also, json/cbor field tag can be used for case-insensitive matching now.

Overall, surrealcbor now performs slightly better than the existing fxamacker/cbor-based implementation for our specific use-case, as far as I can see from the benchmark results.
