### PR TITLE
Fix test flakiness

### DIFF
--- a/contrib/surrealql/example_create_test.go
+++ b/contrib/surrealql/example_create_test.go
@@ -80,7 +80,7 @@ func ExampleCreate_integration_thing_recordID() {
 	// Assume we have a *surrealdb.DB instance
 	var db *surrealdb.DB
 
-	db, err := testenv.New("surrealql", "test", "users")
+	db, err := testenv.New("surrealqlexamples", "test", "users")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func ExampleCreate_integration_thing_recordID() {
 func ExampleCreate_integration_table() {
 	var db *surrealdb.DB
 
-	db, err := testenv.New("surrealql", "test", "users")
+	db, err := testenv.New("surrealqlexamples", "test", "users")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/surrealql/example_select_test.go
+++ b/contrib/surrealql/example_select_test.go
@@ -322,7 +322,7 @@ func ExampleSelect_integration() {
 	// Assume we have a *surrealdb.DB instance
 	var db *surrealdb.DB
 
-	db, err := testenv.New("surrealql", "test", "users")
+	db, err := testenv.New("surrealqlexamples", "test", "users")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/surrealql/integration_define_test.go
+++ b/contrib/surrealql/integration_define_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIntegrationDefineTable(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "events")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "events")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_insert_test.go
+++ b/contrib/surrealql/integration_insert_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIntegrationInsert(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "products", "categories", "product_categories")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "products", "categories", "product_categories")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_item_crud_test.go
+++ b/contrib/surrealql/integration_item_crud_test.go
@@ -23,7 +23,7 @@ type Item struct {
 }
 
 func TestIntegrationCreateThenUpdate(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "items")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "items")
 	ctx := context.Background()
 
 	t.Run("Create", func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestIntegrationCreateThenUpdate(t *testing.T) {
 }
 
 func TestIntegrationCreateThenDelete(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "items_delete")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "items_delete")
 	ctx := context.Background()
 
 	// Setup: Create items with different active states

--- a/contrib/surrealql/integration_product_count_test.go
+++ b/contrib/surrealql/integration_product_count_test.go
@@ -39,7 +39,7 @@ func setupProductData(t *testing.T, ctx context.Context, db *surrealdb.DB, table
 }
 
 func TestIntegrationCount_All(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "products_all")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "products_all")
 	ctx := context.Background()
 
 	// Setup test data
@@ -92,7 +92,7 @@ func TestIntegrationCount_All(t *testing.T) {
 }
 
 func TestIntegrationCount_WithWhere(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "products_where")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "products_where")
 	ctx := context.Background()
 
 	// Setup test data
@@ -121,7 +121,7 @@ func TestIntegrationCount_WithWhere(t *testing.T) {
 }
 
 func TestIntegrationCount_GroupBy(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "products_group")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "products_group")
 	ctx := context.Background()
 
 	// Setup test data

--- a/contrib/surrealql/integration_relate_test.go
+++ b/contrib/surrealql/integration_relate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIntegrationRelate(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "users", "posts", "likes")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "users", "posts", "likes")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_sales_aggregate_test.go
+++ b/contrib/surrealql/integration_sales_aggregate_test.go
@@ -46,7 +46,7 @@ func setupSalesData(t *testing.T, ctx context.Context, db *surrealdb.DB, table s
 }
 
 func TestIntegrationAggregate_Sum(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "sales_sum")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "sales_sum")
 	ctx := context.Background()
 
 	// Setup test data
@@ -92,7 +92,7 @@ func TestIntegrationAggregate_Sum(t *testing.T) {
 }
 
 func TestIntegrationAggregate_Average(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "sales_avg")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "sales_avg")
 	ctx := context.Background()
 
 	// Setup test data
@@ -124,7 +124,7 @@ func TestIntegrationAggregate_Average(t *testing.T) {
 }
 
 func TestIntegrationAggregate_MinMax(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "sales_minmax")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "sales_minmax")
 	ctx := context.Background()
 
 	// Setup test data

--- a/contrib/surrealql/integration_select_from_record_id_test.go
+++ b/contrib/surrealql/integration_select_from_record_id_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationSelect_fromRecordID(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "select_from_record_id_test")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "select_from_record_id_test")
 	ctx := context.Background()
 
 	tableName := "record_test_data"

--- a/contrib/surrealql/integration_select_from_table_test.go
+++ b/contrib/surrealql/integration_select_from_table_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationSelect_fromTable(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "select_from_table_test")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "select_from_table_test")
 	ctx := context.Background()
 
 	// Create test data in a table with special characters

--- a/contrib/surrealql/integration_transaction_test.go
+++ b/contrib/surrealql/integration_transaction_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIntegrationTransaction(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "accounts")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "accounts")
 
 	ctx := context.Background()
 

--- a/contrib/surrealql/integration_update_return_test.go
+++ b/contrib/surrealql/integration_update_return_test.go
@@ -17,7 +17,7 @@ func TestIntegrationUpdateReturnNone(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	db := testenv.MustNewDeprecated("surrealql_test", "update_table")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "update_table")
 	ctx := context.Background()
 
 	// Setup: Create test records

--- a/contrib/surrealql/integration_upsert_test.go
+++ b/contrib/surrealql/integration_upsert_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIntegration_UpsertSet(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_set", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_set", "product")
 	ctx := context.Background()
 
 	t.Run("creates new record", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestIntegration_UpsertSet(t *testing.T) {
 }
 
 func TestIntegration_UpsertContent(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_content", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_content", "product")
 	ctx := context.Background()
 
 	// UPSERT with CONTENT
@@ -86,7 +86,7 @@ func TestIntegration_UpsertContent(t *testing.T) {
 }
 
 func TestIntegration_UpsertMerge(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_merge", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_merge", "product")
 	ctx := context.Background()
 
 	// First, create a record with initial data
@@ -115,7 +115,7 @@ func TestIntegration_UpsertMerge(t *testing.T) {
 }
 
 func TestIntegration_UpsertWhere(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_where", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_where", "product")
 	ctx := context.Background()
 
 	// Create a record
@@ -159,7 +159,7 @@ func TestIntegration_UpsertWhere(t *testing.T) {
 }
 
 func TestIntegration_UpsertOnly(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_only", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_only", "product")
 	ctx := context.Background()
 
 	// UPSERT ONLY
@@ -179,7 +179,7 @@ func TestIntegration_UpsertOnly(t *testing.T) {
 }
 
 func TestIntegration_UpsertReturnNone(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_return_none", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_return_none", "product")
 	ctx := context.Background()
 
 	// UPSERT with RETURN NONE
@@ -199,7 +199,7 @@ func TestIntegration_UpsertReturnNone(t *testing.T) {
 }
 
 func TestIntegration_UpsertReturnDiff(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_return_diff", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_return_diff", "product")
 	ctx := context.Background()
 
 	// First create a record
@@ -223,7 +223,7 @@ func TestIntegration_UpsertReturnDiff(t *testing.T) {
 }
 
 func TestIntegration_UpsertSetRaw(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_setraw", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_setraw", "product")
 	ctx := context.Background()
 
 	// First create a record with initial values
@@ -259,7 +259,7 @@ func TestIntegration_UpsertSetRaw(t *testing.T) {
 }
 
 func TestIntegration_UpsertUnifiedSet(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_unified", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_unified", "product")
 	ctx := context.Background()
 
 	// First create a record with initial values
@@ -290,7 +290,7 @@ func TestIntegration_UpsertUnifiedSet(t *testing.T) {
 }
 
 func TestIntegration_UpsertSetArrayOperations(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_arrays", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_arrays", "product")
 	ctx := context.Background()
 
 	// First create a record with initial array values
@@ -327,7 +327,7 @@ func TestIntegration_UpsertSetArrayOperations(t *testing.T) {
 }
 
 func TestIntegration_UpsertReturnValue(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "upsert_return_value", "product")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "upsert_return_value", "product")
 	ctx := context.Background()
 
 	// First create a record with initial value

--- a/contrib/surrealql/integration_user_select_test.go
+++ b/contrib/surrealql/integration_user_select_test.go
@@ -37,7 +37,7 @@ func setupUserData(t *testing.T, ctx context.Context, db *surrealdb.DB, table st
 }
 
 func TestIntegrationSelect_All(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "users_all")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "users_all")
 	ctx := context.Background()
 
 	// Setup test data
@@ -66,7 +66,7 @@ func TestIntegrationSelect_All(t *testing.T) {
 }
 
 func TestIntegrationSelect_WhereEq(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "users_whereeq")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "users_whereeq")
 	ctx := context.Background()
 
 	// Setup test data
@@ -95,7 +95,7 @@ func TestIntegrationSelect_WhereEq(t *testing.T) {
 }
 
 func TestIntegrationSelect_WhereWithParams(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "users_params")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "users_params")
 	ctx := context.Background()
 
 	// Setup test data
@@ -123,7 +123,7 @@ func TestIntegrationSelect_WhereWithParams(t *testing.T) {
 }
 
 func TestIntegrationSelect_WithPagination(t *testing.T) {
-	db := testenv.MustNewDeprecated("surrealql_test", "users_page")
+	db := testenv.MustNew("surrealqlexamples", "surrealql_test", "users_page")
 	ctx := context.Background()
 
 	// Setup test data

--- a/contrib/testenv/connection.go
+++ b/contrib/testenv/connection.go
@@ -76,14 +76,6 @@ func GetSurrealDBWSURL() string {
 	return strings.ReplaceAll(currentURL, "http", "ws")
 }
 
-func MustNewDeprecated(database string, tables ...string) *surrealdb.DB {
-	db, err := New("examples", database, tables...)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create SurrealDB connection: %v", err))
-	}
-	return db
-}
-
 type Config struct {
 	// Endpoint is the SurrealDB endpoint URL.
 	Endpoint string

--- a/example/example_create_test.go
+++ b/example/example_create_test.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:funlen
 func ExampleCreate() {
-	db := testenv.MustNewDeprecated("example_create", "persons")
+	db := testenv.MustNew("surrealdbexamples", "example_create", "persons")
 
 	type Person struct {
 		Name string `json:"name"`
@@ -119,7 +119,7 @@ func ExampleCreate() {
 }
 
 func ExampleCreate_server_unmarshal_error() {
-	db := testenv.MustNewDeprecated("query", "person")
+	db := testenv.MustNew("surrealdbexamples", "query", "person")
 
 	type Person struct {
 		ID   models.RecordID `json:"id,omitempty"`

--- a/example/example_db_record_user_test.go
+++ b/example/example_db_record_user_test.go
@@ -10,7 +10,8 @@ import (
 
 //nolint:funlen
 func ExampleDB_record_user_auth_struct() {
-	db := testenv.MustNewDeprecated("record_auth_demo", "user")
+	ns := "surrealdbexamples"
+	db := testenv.MustNew(ns, "record_auth_demo", "user")
 
 	setupQuery := `
 		-- Define the user table with schema
@@ -49,7 +50,7 @@ func ExampleDB_record_user_auth_struct() {
 	// Refer to the next example, `ExampleDB_record_user_custom_struct`,
 	// when you need to use fields other than `user` and `pass` in the query specified for SIGNUP.
 	_, err := db.SignUp(context.Background(), &surrealdb.Auth{
-		Namespace: "examples",
+		Namespace: ns,
 		Database:  "record_auth_demo",
 		Access:    "user",
 		Username:  "yusuke",
@@ -66,7 +67,7 @@ func ExampleDB_record_user_auth_struct() {
 	// For example, you might want to use `email` and `password` instead of `user` and `pass`.
 	// In that case, you need to something that encodes to a cbor map containing those keys.
 	_, err = db.SignIn(context.Background(), &surrealdb.Auth{
-		Namespace: "examples",
+		Namespace: ns,
 		Database:  "record_auth_demo",
 		Access:    "user",
 		Username:  "yusuke",
@@ -91,7 +92,8 @@ func ExampleDB_record_user_auth_struct() {
 }
 
 func ExampleDB_record_user_custom_struct() {
-	db := testenv.MustNewDeprecated("record_user_custom", "user")
+	ns := "surrealdbexamples"
+	db := testenv.MustNew(ns, "record_user_custom", "user")
 
 	setupQuery := `
 		-- Define the user table with schema
@@ -148,7 +150,7 @@ func ExampleDB_record_user_custom_struct() {
 
 	_, err := db.SignUp(context.Background(), &User{
 		// Corresponds to the SurrealDB namespace
-		Namespace: "examples",
+		Namespace: ns,
 		// Corresponds to the SurrealDB database
 		Database: "record_user_custom",
 		// Corresponds to `user` in `DEFINE ACCESS USER ON ...`
@@ -166,7 +168,7 @@ func ExampleDB_record_user_custom_struct() {
 	fmt.Println("User signed up successfully")
 
 	_, err = db.SignIn(context.Background(), &LoginRequest{
-		Namespace: "examples",
+		Namespace: ns,
 		Database:  "record_user_custom",
 		Access:    "user",
 		// Corresponds to the $email in the SIGNIN query and `email` in `DEFINE FIELD email ON user`

--- a/example/example_db_send_select_test.go
+++ b/example/example_db_send_select_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleDB_send_select() {
-	db := testenv.MustNewDeprecated("update", "person")
+	db := testenv.MustNew("surrealdbexamples", "update", "person")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_insert_relation_test.go
+++ b/example/example_insert_relation_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ExampleInsertRelation() {
-	db := testenv.MustNewDeprecated("query", "person", "follow")
+	db := testenv.MustNew("surrealdbexamples", "query", "person", "follow")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_insert_test.go
+++ b/example/example_insert_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleInsert_table() {
-	db := testenv.MustNewDeprecated("query", "persons")
+	db := testenv.MustNew("surrealdbexamples", "query", "persons")
 
 	type Person struct {
 		Name string `json:"name"`
@@ -110,7 +110,7 @@ func ExampleInsert_table() {
 }
 
 func ExampleInsert_bulk_isnert_record() {
-	db := testenv.MustNewDeprecated("query", "person")
+	db := testenv.MustNew("surrealdbexamples", "query", "person")
 
 	type Person struct {
 		ID models.RecordID `json:"id"`
@@ -154,7 +154,7 @@ func ExampleInsert_bulk_isnert_record() {
 }
 
 func ExampleInsert_bulk_insert_relation_workaround_for_rpcv1() {
-	db := testenv.MustNewDeprecated("query", "person", "follow")
+	db := testenv.MustNew("surrealdbexamples", "query", "person", "follow")
 
 	type Person struct {
 		ID models.RecordID `json:"id"`

--- a/example/example_issue_192_test.go
+++ b/example/example_issue_192_test.go
@@ -11,7 +11,7 @@ import (
 
 // See https://github.com/surrealdb/surrealdb.go/issues/292
 func ExampleQuery_issue192() {
-	db := testenv.MustNew("example", "query_issue192", "t")
+	db := testenv.MustNew("surrealdbexamples", "query_issue192", "t")
 
 	_, err := surrealdb.Query[any](
 		context.Background(),

--- a/example/example_query_bulk_insert_upsert_test.go
+++ b/example/example_query_bulk_insert_upsert_test.go
@@ -15,7 +15,7 @@ import (
 //
 //nolint:funlen
 func ExampleQuery_bluk_insert_upsert() {
-	db := testenv.MustNewDeprecated("query", "persons")
+	db := testenv.MustNew("surrealdbexamples", "query", "persons")
 
 	/// You can make it a schemaful table by defining fields like this:
 	//

--- a/example/example_query_count_test.go
+++ b/example/example_query_count_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleQuery_count_groupAll() {
-	db := testenv.MustNewDeprecated("querytest", "product")
+	db := testenv.MustNew("surrealdbexamples", "querytest", "product")
 
 	type Product struct {
 		ID       models.RecordID `json:"id,omitempty"`
@@ -73,7 +73,7 @@ func ExampleQuery_count_groupAll() {
 }
 
 func ExampleQuery_count_groupBy() {
-	db := testenv.MustNewDeprecated("querytest", "product")
+	db := testenv.MustNew("surrealdbexamples", "querytest", "product")
 
 	type Product struct {
 		ID       models.RecordID `json:"id,omitempty"`

--- a/example/example_query_embedded_struct_test.go
+++ b/example/example_query_embedded_struct_test.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:funlen
 func ExampleQuery_embedded_struct() {
-	db := testenv.MustNewDeprecated("query", "persons")
+	db := testenv.MustNew("surrealdbexamples", "query", "persons")
 
 	type Base struct {
 		ID *models.RecordID `json:"id,omitempty"`

--- a/example/example_query_none_null_test.go
+++ b/example/example_query_none_null_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 func ExampleQuery_none_and_null_handling_allExistingFields() {
-	db := testenv.MustNewDeprecated("query", "t")
+	db := testenv.MustNew("surrealdbexamples", "query", "t")
 
 	_, err := surrealdb.Query[[]any](
 		context.Background(),

--- a/example/example_query_return_test.go
+++ b/example/example_query_return_test.go
@@ -15,7 +15,7 @@ import (
 //
 //nolint:funlen
 func ExampleQuery_return() {
-	db := testenv.MustNewDeprecated("query", "persons")
+	db := testenv.MustNew("surrealdbexamples", "query", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/example_query_test.go
+++ b/example/example_query_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleQuery() {
-	db := testenv.MustNewDeprecated("query", "persons")
+	db := testenv.MustNew("surrealdbexamples", "query", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/example_query_transaction_let_return_test.go
+++ b/example/example_query_transaction_let_return_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleQuery_transaction_let_return() {
-	db := testenv.MustNewDeprecated("query", "t")
+	db := testenv.MustNew("surrealdbexamples", "query", "t")
 
 	createQueryResults, err := surrealdb.Query[[]any](
 		context.Background(),

--- a/example/example_query_transaction_test.go
+++ b/example/example_query_transaction_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleQuery_transaction_return() {
-	db := testenv.MustNewDeprecated("query", "person")
+	db := testenv.MustNew("surrealdbexamples", "query", "person")
 
 	var err error
 
@@ -34,7 +34,7 @@ func ExampleQuery_transaction_return() {
 }
 
 func ExampleQuery_transaction_throw() {
-	db := testenv.MustNewDeprecated("query", "person")
+	db := testenv.MustNew("surrealdbexamples", "query", "person")
 
 	var (
 		queryResults *[]surrealdb.QueryResult[*int]
@@ -106,7 +106,7 @@ func ExampleQuery_transaction_throw() {
 
 // See https://github.com/surrealdb/surrealdb.go/issues/177
 func ExampleQuery_transaction_issue_177_return_before_commit() {
-	db := testenv.MustNewDeprecated("query", "t")
+	db := testenv.MustNew("surrealdbexamples", "query", "t")
 
 	var err error
 
@@ -150,7 +150,7 @@ func ExampleQuery_transaction_issue_177_return_before_commit() {
 
 // See https://github.com/surrealdb/surrealdb.go/issues/177
 func ExampleQuery_transaction_issue_177_commit() {
-	db := testenv.MustNewDeprecated("query", "t")
+	db := testenv.MustNew("surrealdbexamples", "query", "t")
 
 	var err error
 

--- a/example/example_relate_test.go
+++ b/example/example_relate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ExampleRelate() {
-	db := testenv.MustNewDeprecated("query", "person", "follow")
+	db := testenv.MustNew("surrealdbexamples", "query", "person", "follow")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_select_test.go
+++ b/example/example_select_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleSelect() {
-	db := testenv.MustNewDeprecated("update", "person")
+	db := testenv.MustNew("surrealdbexamples", "update", "person")
 
 	type Person struct {
 		ID models.RecordID `json:"id,omitempty"`

--- a/example/example_update_test.go
+++ b/example/example_update_test.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:funlen // ExampleUpdate demonstrates how to update records in SurrealDB.
 func ExampleUpdate() {
-	db := testenv.MustNewDeprecated("update", "persons")
+	db := testenv.MustNew("surrealdbexamples", "update", "persons")
 
 	type NestedStruct struct {
 		City string `json:"city"`

--- a/example/example_upsert_test.go
+++ b/example/example_upsert_test.go
@@ -13,7 +13,7 @@ import (
 
 //nolint:funlen
 func ExampleUpsert() {
-	db := testenv.MustNewDeprecated("query", "persons")
+	db := testenv.MustNew("surrealdbexamples", "query", "persons")
 
 	type Person struct {
 		ID   *models.RecordID `json:"id,omitempty"`
@@ -185,7 +185,7 @@ func ExampleUpsert_unmarshal_error_surrealcbor() {
 }
 
 func ExampleUpsert_rpc_error() {
-	db := testenv.MustNewDeprecated("query", "person")
+	db := testenv.MustNew("surrealdbexamples", "query", "person")
 
 	type Person struct {
 		Name string `json:"name"`

--- a/example/example_version_test.go
+++ b/example/example_version_test.go
@@ -9,14 +9,14 @@ import (
 
 //nolint:lll,govet
 func ExampleDB_Version() {
-	ws := testenv.MustNewDeprecated("version")
+	ws := testenv.MustNew("surrealdbexamples", "version")
 	v, err := ws.Version(context.Background())
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("VersionData (WebSocket): %+v\n", v)
 
-	http := testenv.MustNewDeprecated("version")
+	http := testenv.MustNew("surrealdbexamples", "version")
 	v, err = http.Version(context.Background())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This pull request updates all the testenvs used in testable examples in `./example` to use only `surrealdbexampls` and ones in `./contrib/surrealql` to use only `surrealqlexamples` namespaces.

Our CI sometimes failed like this:

```
=== RUN   TestIntegrationDefineTable/DefineTableWithChangefeed
    integration_define_test.go:25: DEFINE TABLE SurrealQL: DEFINE TABLE events SCHEMAFULL CHANGEFEED 1h
    integration_define_test.go:29: DEFINE TABLE failed: The query was not executed due to a failed transaction. Failed to commit transaction due to a read or write conflict. This transaction can be retried
--- FAIL: TestIntegrationDefineTable (0.03s)
    --- FAIL: TestIntegrationDefineTable/DefineTableWithChangefeed (0.00s)
```

I believe this is due to that concurrent table creations within the same namespace can fail.
Go-test can run tests in different packages in parallel, even when `t.Parallel()` is not called, so using the same namespace across packages could cause conflicts.