### PR TITLE
SurrealDB backup tool for demonstrating SDK usage

### DIFF
--- a/contrib/surrealdump/.gitignore
+++ b/contrib/surrealdump/.gitignore
@@ -1,0 +1,2 @@
+*.cbor
+/surrealdump

--- a/contrib/surrealdump/README.md
+++ b/contrib/surrealdump/README.md
@@ -1,0 +1,138 @@
+# surrealdump
+
+A Go-based tool for dumping SurrealDB databases to CBOR format, demonstrating the SurrealDB Go SDK capabilities with surrealcbor and gws.
+
+> This tool demonstrates SDK capabilities and is not intended for production use.
+>
+> For production backups, use the official `surreal export` command.
+
+## Features
+
+- Consistent full dump combining inconsistent dump with Change Feed
+- Incremental dumps using Change Feed
+- CBOR-based binary format for efficient storage
+- Metadata tracking (timestamps, versionstamps)
+- Point-in-time recovery support
+- SHA256 integrity verification
+
+## Prerequisites for Incremental Dumps
+
+Incremental dumps require Change Feeds to be enabled on the database **before** any data is created. Change Feeds must be configured using:
+
+```sql
+DEFINE DATABASE OVERWRITE <database_name> CHANGEFEED <retention_period>
+```
+
+For example:
+```sql
+DEFINE DATABASE OVERWRITE mydb CHANGEFEED 1h
+```
+
+Without Change Feeds enabled, full dumps will be inconsistent and incremental dumps will not capture any changes.
+
+## Installation
+
+```bash
+go install github.com/surrealdb/surrealdb.go/contrib/surrealdump/cmd/surrealdump@latest
+```
+
+## Usage
+
+`surrealdump` creates manifest files that track dump metadata and relationships, enabling safe point-in-time recovery and preventing incompatible incremental dumps from being applied.
+
+```bash
+# Create initial full backup
+surrealdump -endpoint ws://localhost:8000 -namespace myapp -database prod -dir backups -output full-$(date +%Y%m%d).cbor
+
+# Create daily incremental backups (auto-detects base from directory)
+surrealdump -incremental -namespace myapp -database prod -dir backups -output inc-$(date +%Y%m%d-%H%M%S).cbor
+
+# View backup chain
+surrealrestore -dir backups/ -info
+
+# Restore to specific versionstamp
+surrealrestore -dir backups/ -point-in-time 655360 -endpoint ws://localhost:8001
+
+# Restore to latest available state
+surrealrestore -dir backups/ -endpoint ws://localhost:8001
+
+# To start incremental backups on the restored database:
+# First, take a new full dump
+surrealdump -endpoint ws://localhost:8001 -namespace myapp -database prod -dir backups_new -output restored-full.cbor
+# Now you can take incremental dumps based on the restored database
+surrealdump -incremental -endpoint ws://localhost:8001 -namespace myapp -database prod -dir backups_new -output restored-inc1.cbor
+```
+
+Please refer to the following sections for more details on each feature:
+
+- [Full Dump](#full-dump)
+- [Incremental Dump](#incremental-dump)
+- [Options](#options)
+- [Restore with surrealrestore](#restore-with-surrealrestore)
+- [Format](#format)
+- [Notes](#notes)
+
+### Full Dump
+
+Full dumps include both an inconsistent full dump of records and change feed data to ensure consistency despite SurrealDB's isolation limitations. This approach guarantees no changes are missed when applying subsequent incremental dumps.
+
+To take a full dump, run `surrealdump` without `-incremental`:
+
+```bash
+surrealdump -endpoint ws://localhost:8000 -namespace myapp -database production -username root -password root -output dump.cbor
+```
+
+### Incremental Dump
+
+```bash
+# Manual versionstamp specification
+surrealdump -incremental -since 1000 -endpoint ws://localhost:8000 -namespace myapp -database production -username root -password root -output increment.cbor
+
+# Auto-detect start versionstamp from directory
+surrealdump -incremental -endpoint ws://localhost:8000 -namespace myapp -database production -username root -password root -dir backups/ -output increment.cbor
+```
+
+### Options
+
+- `-endpoint`: SurrealDB server endpoint (default: ws://localhost:8000)
+- `-username`: Authentication username (default: root)
+- `-password`: Authentication password (default: root)
+- `-namespace`: Namespace to dump (required)
+- `-database`: Database to dump (required)
+- `-output`: Output file path (required)
+- `-incremental`: Perform incremental dump
+- `-since`: Versionstamp to start incremental dump from (default: auto-detect from directory)
+- `-verbose`: Enable verbose logging
+- `-manifest`: Create manifest file for dump chain tracking (default: true)
+- `-dir`: Base directory for dumps (prefixes the output path when used with -output)
+
+### Restore with surrealrestore
+
+To restore a dump created by surrealdump:
+
+```bash
+# Full restore (requires clean database)
+surrealrestore -endpoint ws://localhost:8000 -username root -password root -input dump.cbor
+
+# Apply incremental changes
+surrealrestore -incremental -endpoint ws://localhost:8000 -username root -password root -input increment.cbor
+```
+
+See [surrealrestore documentation](../surrealrestore/) for more information.
+
+### Format
+
+Dumps use CBOR encoding with:
+- Magic header: "SURDUMP01" (full) or "SURINC01" (incremental)
+- Record entries containing table info and data
+- Manifest files (`.manifest.json`) for metadata tracking and chain building
+
+### Notes
+
+- **Versionstamps are unique to each database instance**: When you restore a database from a dump, the restored database will have completely different versionstamps than the original database.
+- **Incremental dumps from the original database can be applied to restored databases**: You can apply incremental dumps created from the original database onto a restored database as part of the restoration process.
+- **Cannot continue incremental chains after restoration**: After restoring a database, you cannot continue taking incremental dumps based on the original database's versionstamps. To start a new incremental backup chain on a restored database:
+  1. Take a new full dump of the restored database
+  2. Use this new full dump as the base for future incremental dumps
+
+For detailed design documentation including consistency guarantees and safety mechanisms, see [docs/design.md](docs/design.md).

--- a/contrib/surrealdump/chain.go
+++ b/contrib/surrealdump/chain.go
@@ -1,0 +1,140 @@
+package surrealdump
+
+import "fmt"
+
+// Chain represents a valid sequence of dumps for restoration
+type Chain struct {
+	FullDump         *Manifest
+	IncrementalDumps []*Manifest
+	// TotalSize tracks the total bytes of all dumps in the chain.
+	// This is intended to be used for reporting.
+	TotalSize int64
+	// LatestVersionstamp is the end versionstamp of the last dump,
+	// which is the max possible restoration point.
+	LatestVersionstamp uint64
+}
+
+// buildChains builds valid dump chains from a set of manifests.
+// This is a private function - callers should use ScanChains instead.
+//
+// This function assumes manifests are already loaded and does not validate chains.
+// Chain validation is performed separately to allow for better error reporting.
+func buildChains(manifests []*Manifest) []*Chain {
+	var chains []*Chain
+
+	// Group by namespace and database
+	groups := make(map[string][]*Manifest)
+	for _, m := range manifests {
+		key := fmt.Sprintf("%s/%s", m.Namespace, m.Database)
+		groups[key] = append(groups[key], m)
+	}
+
+	// Build chains for each group
+	for _, group := range groups {
+		// Find full dumps
+		for _, manifest := range group {
+			if manifest.Type != ManifestTypeFull {
+				continue
+			}
+			chain := &Chain{
+				FullDump:           manifest,
+				IncrementalDumps:   []*Manifest{},
+				TotalSize:          manifest.Size,
+				LatestVersionstamp: manifest.EndVersionstamp,
+			}
+
+			// Find compatible incremental dumps
+			currentVs := manifest.EndVersionstamp
+			usedIncrementals := make(map[*Manifest]bool)
+
+			for {
+				found := false
+				for _, inc := range group {
+					// Skip if already used in this chain
+					if usedIncrementals[inc] {
+						continue
+					}
+
+					// Use CanApplyIncremental to check if this incremental can be applied
+					if CanApplyIncremental(currentVs, inc) == nil {
+						chain.IncrementalDumps = append(chain.IncrementalDumps, inc)
+						chain.TotalSize += inc.Size
+						chain.LatestVersionstamp = inc.EndVersionstamp
+						currentVs = inc.EndVersionstamp
+						usedIncrementals[inc] = true
+						found = true
+						break
+					}
+				}
+				if !found {
+					break
+				}
+			}
+
+			chains = append(chains, chain)
+		}
+	}
+
+	return chains
+}
+
+// Validate validates that the dump chain is consistent
+func (c *Chain) Validate() error {
+	if c.FullDump == nil {
+		return fmt.Errorf("chain missing full dump")
+	}
+
+	expectedVs := c.FullDump.EndVersionstamp
+
+	for i, inc := range c.IncrementalDumps {
+		if inc.StartVersionstamp != expectedVs {
+			return fmt.Errorf("incremental dump %d has mismatched start versionstamp: expected %d, got %d",
+				i, expectedVs, inc.StartVersionstamp)
+		}
+
+		// StartVersionstamp should be less than EndVersionstamp for incremental dumps
+		if inc.StartVersionstamp >= inc.EndVersionstamp {
+			return fmt.Errorf("incremental dump %d has invalid versionstamp range: base %d >= max %d",
+				i, inc.StartVersionstamp, inc.EndVersionstamp)
+		}
+
+		expectedVs = inc.EndVersionstamp
+	}
+
+	return nil
+}
+
+// GetRestorationPoints returns end versionstamps associated to available restoration points from a chain
+func (c *Chain) GetRestorationPoints() []uint64 {
+	var points []uint64
+
+	// Add the full dump point
+	points = append(points, c.FullDump.EndVersionstamp)
+
+	// Add each incremental point
+	for _, inc := range c.IncrementalDumps {
+		points = append(points, inc.EndVersionstamp)
+	}
+
+	return points
+}
+
+// GetManifestsForVersionstamp returns the dump manifests needed to restore to a specific versionstamp
+func (c *Chain) GetManifestsForVersionstamp(targetVs uint64) ([]*Manifest, error) {
+	if targetVs < c.FullDump.EndVersionstamp {
+		return nil, fmt.Errorf("target versionstamp %d is before the full dump at %d",
+			targetVs, c.FullDump.EndVersionstamp)
+	}
+
+	dumps := []*Manifest{c.FullDump}
+
+	for _, inc := range c.IncrementalDumps {
+		if inc.EndVersionstamp <= targetVs {
+			dumps = append(dumps, inc)
+		} else {
+			break
+		}
+	}
+
+	return dumps, nil
+}

--- a/contrib/surrealdump/chain_test.go
+++ b/contrib/surrealdump/chain_test.go
@@ -1,0 +1,156 @@
+package surrealdump_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+)
+
+func TestChain(t *testing.T) {
+	// Create test manifests
+	fullDump := &surrealdump.Manifest{
+		Filename:          "dump-001.cbor",
+		Type:              surrealdump.ManifestTypeFull,
+		CreatedAt:         time.Now(),
+		Size:              1000,
+		Namespace:         "test",
+		Database:          "db",
+		EndVersionstamp:   200,
+		StartVersionstamp: 0, // Full dumps start from 0
+	}
+
+	// Valid incremental that continues from full dump
+	validIncremental1 := &surrealdump.Manifest{
+		Filename:          "dump-002.cbor",
+		Type:              surrealdump.ManifestTypeIncremental,
+		CreatedAt:         time.Now(),
+		Size:              500,
+		Namespace:         "test",
+		Database:          "db",
+		EndVersionstamp:   300,
+		StartVersionstamp: 200, // Matches full dump's max
+	}
+
+	// Valid incremental that continues from first incremental
+	validIncremental2 := &surrealdump.Manifest{
+		Filename:          "dump-003.cbor",
+		Type:              surrealdump.ManifestTypeIncremental,
+		CreatedAt:         time.Now(),
+		Size:              300,
+		Namespace:         "test",
+		Database:          "db",
+		EndVersionstamp:   400,
+		StartVersionstamp: 300, // Matches incremental1's max
+	}
+
+	// Invalid incremental with gap
+	invalidIncremental := &surrealdump.Manifest{
+		Filename:          "dump-004.cbor",
+		Type:              surrealdump.ManifestTypeIncremental,
+		CreatedAt:         time.Now(),
+		Size:              200,
+		Namespace:         "test",
+		Database:          "db",
+		EndVersionstamp:   600,
+		StartVersionstamp: 500, // Gap - doesn't match any previous max
+	}
+
+	t.Run("ValidChain", func(t *testing.T) {
+		chain := &surrealdump.Chain{
+			FullDump:           fullDump,
+			IncrementalDumps:   []*surrealdump.Manifest{validIncremental1, validIncremental2},
+			TotalSize:          1800,
+			LatestVersionstamp: 400,
+		}
+
+		err := chain.Validate()
+		assert.NoError(t, err, "Valid chain should pass validation")
+	})
+
+	t.Run("ChainWithGap", func(t *testing.T) {
+		chain := &surrealdump.Chain{
+			FullDump:           fullDump,
+			IncrementalDumps:   []*surrealdump.Manifest{invalidIncremental},
+			TotalSize:          1200,
+			LatestVersionstamp: 600,
+		}
+
+		err := chain.Validate()
+		assert.Error(t, err, "Chain with gap should fail validation")
+		assert.Contains(t, err.Error(), "mismatched start versionstamp")
+	})
+
+	t.Run("EmptyChain", func(t *testing.T) {
+		chain := &surrealdump.Chain{
+			FullDump:         nil,
+			IncrementalDumps: []*surrealdump.Manifest{},
+		}
+
+		err := chain.Validate()
+		assert.Error(t, err, "Empty chain should fail validation")
+		assert.Contains(t, err.Error(), "missing full dump")
+	})
+
+	t.Run("CanApplyIncremental", func(t *testing.T) {
+		// Valid case
+		err := surrealdump.CanApplyIncremental(200, validIncremental1)
+		assert.NoError(t, err, "Should be able to apply incremental at correct versionstamp")
+
+		// Invalid case - wrong base
+		err = surrealdump.CanApplyIncremental(100, validIncremental1)
+		assert.Error(t, err, "Should not be able to apply incremental at wrong versionstamp")
+		assert.Contains(t, err.Error(), "expects start versionstamp 200, but current is 100")
+
+		// Invalid case - not incremental
+		err = surrealdump.CanApplyIncremental(200, fullDump)
+		assert.Error(t, err, "Should not be able to apply full dump as incremental")
+		assert.Contains(t, err.Error(), "not an incremental dump")
+	})
+
+	t.Run("GetPointInTimeOptions", func(t *testing.T) {
+		chain := &surrealdump.Chain{
+			FullDump:           fullDump,
+			IncrementalDumps:   []*surrealdump.Manifest{validIncremental1, validIncremental2},
+			TotalSize:          1800,
+			LatestVersionstamp: 400,
+		}
+
+		options := chain.GetRestorationPoints()
+		assert.Equal(t, []uint64{200, 300, 400}, options, "Should return all restoration points")
+	})
+
+	t.Run("GetDumpsForVersionstamp", func(t *testing.T) {
+		chain := &surrealdump.Chain{
+			FullDump:           fullDump,
+			IncrementalDumps:   []*surrealdump.Manifest{validIncremental1, validIncremental2},
+			TotalSize:          1800,
+			LatestVersionstamp: 400,
+		}
+
+		// Restore to full dump point
+		dumps, err := chain.GetManifestsForVersionstamp(200)
+		require.NoError(t, err)
+		assert.Len(t, dumps, 1, "Should only need full dump")
+		assert.Equal(t, fullDump, dumps[0])
+
+		// Restore to first incremental
+		dumps, err = chain.GetManifestsForVersionstamp(300)
+		require.NoError(t, err)
+		assert.Len(t, dumps, 2, "Should need full dump and first incremental")
+		assert.Equal(t, fullDump, dumps[0])
+		assert.Equal(t, validIncremental1, dumps[1])
+
+		// Restore to latest
+		dumps, err = chain.GetManifestsForVersionstamp(400)
+		require.NoError(t, err)
+		assert.Len(t, dumps, 3, "Should need all dumps")
+
+		// Restore to point before full dump
+		_, err = chain.GetManifestsForVersionstamp(50)
+		assert.Error(t, err, "Should fail for versionstamp before full dump")
+		assert.Contains(t, err.Error(), "before the full dump")
+	})
+}

--- a/contrib/surrealdump/cmd/surrealdump/main.go
+++ b/contrib/surrealdump/cmd/surrealdump/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+)
+
+func main() {
+	// Create config with defaults
+	config := surrealdump.NewConfig()
+
+	// Parse command-line flags into config
+	flag.StringVar(&config.Endpoint, "endpoint", config.Endpoint, "SurrealDB server endpoint")
+	flag.StringVar(&config.Username, "username", config.Username, "Authentication username")
+	flag.StringVar(&config.Password, "password", config.Password, "Authentication password")
+	flag.StringVar(&config.Namespace, "namespace", "", "Namespace to dump (required)")
+	flag.StringVar(&config.Database, "database", "", "Database to dump (required)")
+	flag.StringVar(&config.Output, "output", "", "Output file path (required)")
+	flag.BoolVar(&config.Incremental, "incremental", false, "Perform incremental dump")
+	flag.Uint64Var(&config.SinceVersionstamp, "since", 0, "Versionstamp to start incremental dump from")
+	flag.BoolVar(&config.Verbose, "verbose", false, "Enable verbose logging")
+	flag.StringVar(&config.Dir, "dir", "", "Base directory for dumps (prefixes output path)")
+
+	// Tables flag - comma-separated list of tables to dump
+	var tablesFlag string
+	flag.StringVar(&tablesFlag, "tables", "", "Comma-separated list of tables to dump (empty means all tables)")
+
+	flag.Parse()
+
+	// Parse tables flag
+	if tablesFlag != "" {
+		config.Tables = strings.Split(tablesFlag, ",")
+		// Trim spaces from table names
+		for i, table := range config.Tables {
+			config.Tables[i] = strings.TrimSpace(table)
+		}
+	}
+
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Execute the dump
+	ctx := context.Background()
+	if err := surrealdump.Do(ctx, config); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/contrib/surrealdump/config.go
+++ b/contrib/surrealdump/config.go
@@ -1,0 +1,84 @@
+package surrealdump
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Config holds all configuration options for dump operations
+type Config struct {
+	// SurrealDB server endpoint (e.g., "ws://localhost:8000")
+	Endpoint string
+	// Authentication username
+	Username string
+	// Authentication password
+	Password string
+
+	// Namespace to dump
+	Namespace string
+	// Database to dump
+	Database string
+
+	// Output file path
+	Output string
+	// Perform incremental dump instead of full
+	Incremental bool
+	// Versionstamp to start incremental dump from (for incremental dumps)
+	SinceVersionstamp uint64
+	// Specific tables to dump
+	// If empty, all tables in the specified ns/db will be dumped
+	Tables []string
+
+	// Base directory for dumps (prefixes output path)
+	Dir string
+
+	// Enable verbose logging
+	Verbose bool
+}
+
+// NewConfig creates a new Config with default values
+func NewConfig() *Config {
+	return &Config{
+		Endpoint: "ws://localhost:8000",
+		Username: "root",
+		Password: "root",
+	}
+}
+
+// Validate checks if the configuration is valid
+func (c *Config) Validate() error {
+	if c.Namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if c.Database == "" {
+		return fmt.Errorf("database is required")
+	}
+	if c.Output == "" {
+		return fmt.Errorf("output path is required")
+	}
+	// Note: c.Incremental with c.SinceVersionstamp == 0 is OK - it can be auto-detected
+	return nil
+}
+
+// GetOutputPath returns the full output path, applying Dir prefix if set
+func (c *Config) GetOutputPath() string {
+	if c.Dir != "" && c.Output != "" {
+		return filepath.Join(c.Dir, c.Output)
+	}
+	return c.Output
+}
+
+// findLatestVersionstamp searches for the latest versionstamp from previous dumps
+// in the search directory for the configured namespace and database.
+// It uses c.Dir if set, otherwise the directory of c.Output.
+func (c *Config) findLatestVersionstamp() (uint64, error) {
+	searchDir := c.Dir
+	if searchDir == "" && c.Output != "" {
+		searchDir = filepath.Dir(c.GetOutputPath())
+	}
+	if searchDir == "" {
+		searchDir = "."
+	}
+
+	return findLatestVersionstamp(searchDir, c.Namespace, c.Database)
+}

--- a/contrib/surrealdump/config_test.go
+++ b/contrib/surrealdump/config_test.go
@@ -1,0 +1,323 @@
+package surrealdump_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+)
+
+func TestNewConfig(t *testing.T) {
+	config := surrealdump.NewConfig()
+	assert.NotNil(t, config, "NewConfig should return non-nil config")
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("ValidConfig", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Database:  "test_db",
+			Output:    "dump.cbor",
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Valid config should not return error")
+	})
+
+	t.Run("MissingNamespace", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Database: "test_db",
+			Output:   "dump.cbor",
+		}
+
+		err := config.Validate()
+		assert.Error(t, err, "Should error when namespace is missing")
+		assert.Contains(t, err.Error(), "namespace is required")
+	})
+
+	t.Run("MissingDatabase", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Output:    "dump.cbor",
+		}
+
+		err := config.Validate()
+		assert.Error(t, err, "Should error when database is missing")
+		assert.Contains(t, err.Error(), "database is required")
+	})
+
+	t.Run("MissingOutput", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Database:  "test_db",
+		}
+
+		err := config.Validate()
+		assert.Error(t, err, "Should error when output is missing")
+		assert.Contains(t, err.Error(), "output path is required")
+	})
+
+	t.Run("IncrementalWithZeroVersionstampIsValid", func(t *testing.T) {
+		// As per the comment in Validate(), incremental with zero versionstamp is OK
+		// because it can be auto-detected
+		config := &surrealdump.Config{
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			Output:            "dump.cbor",
+			Incremental:       true,
+			SinceVersionstamp: 0, // Zero is OK, will be auto-detected
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Incremental with zero versionstamp should be valid")
+	})
+
+	t.Run("IncrementalWithNonZeroVersionstamp", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			Output:            "dump.cbor",
+			Incremental:       true,
+			SinceVersionstamp: 12345,
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Incremental with non-zero versionstamp should be valid")
+	})
+
+	t.Run("CompleteConfigWithAllFields", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Endpoint:          "ws://remote:8000",
+			Username:          "admin",
+			Password:          "secret",
+			Namespace:         "production",
+			Database:          "main",
+			Output:            "backup.cbor",
+			Incremental:       true,
+			SinceVersionstamp: 999999,
+			Tables:            []string{"users", "products", "orders"},
+			Dir:               "/backups",
+			Verbose:           true,
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Complete config with all fields should be valid")
+	})
+
+	t.Run("OptionalFieldsCanBeEmpty", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Database:  "test_db",
+			Output:    "dump.cbor",
+			// All optional fields left as zero values
+			Endpoint: "",
+			Username: "",
+			Password: "",
+			Tables:   nil,
+			Dir:      "",
+			Verbose:  false,
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Config with only required fields should be valid")
+	})
+}
+
+func TestConfig_GetOutputPath(t *testing.T) {
+	t.Run("OutputOnlyNoDir", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Output: "dump.cbor",
+			Dir:    "",
+		}
+
+		result := config.GetOutputPath()
+		assert.Equal(t, "dump.cbor", result, "Should return Output when Dir is empty")
+	})
+
+	t.Run("OutputWithDir", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Output: "dump.cbor",
+			Dir:    "backups",
+		}
+
+		result := config.GetOutputPath()
+		expected := filepath.Join("backups", "dump.cbor")
+		assert.Equal(t, expected, result, "Should join Dir and Output")
+	})
+
+	t.Run("OutputWithRelativeDir", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Output: "dump.cbor",
+			Dir:    "backups",
+		}
+
+		result := config.GetOutputPath()
+		expected := filepath.Join("backups", "dump.cbor")
+		assert.Equal(t, expected, result, "Should join relative Dir and Output")
+	})
+
+	t.Run("OutputWithNestedDir", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Output: "daily/dump.cbor",
+			Dir:    "backups",
+		}
+
+		result := config.GetOutputPath()
+		expected := filepath.Join("backups", "daily", "dump.cbor")
+		assert.Equal(t, expected, result, "Should handle nested paths correctly")
+	})
+
+	t.Run("EmptyOutputReturnsEmpty", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Output: "",
+			Dir:    "backups",
+		}
+
+		result := config.GetOutputPath()
+		assert.Empty(t, result, "Should return empty when Output is empty")
+	})
+
+	t.Run("EmptyDirAndOutput", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Output: "",
+			Dir:    "",
+		}
+
+		result := config.GetOutputPath()
+		assert.Empty(t, result, "Should return empty when both Dir and Output are empty")
+	})
+
+	t.Run("TrailingSlashInDir", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Output: "dump.cbor",
+			Dir:    "backups",
+		}
+
+		result := config.GetOutputPath()
+		// filepath.Join should handle trailing slashes correctly
+		expected := filepath.Join("backups", "dump.cbor")
+		assert.Equal(t, expected, result, "Should handle trailing slash in Dir")
+	})
+}
+
+func TestConfig_Integration(t *testing.T) {
+	t.Run("NewConfigValidateAndGetPath", func(t *testing.T) {
+		// Create a new config with defaults
+		config := surrealdump.NewConfig()
+
+		// Set required fields
+		config.Namespace = "test"
+		config.Database = "mydb"
+		config.Output = "backup.cbor"
+		config.Dir = "backups"
+
+		// Validate
+		err := config.Validate()
+		require.NoError(t, err, "Config should be valid")
+
+		// Get output path
+		outputPath := config.GetOutputPath()
+		expected := filepath.Join("backups", "backup.cbor")
+		assert.Equal(t, expected, outputPath, "Output path should be correctly joined")
+	})
+
+	t.Run("IncrementalDumpConfig", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Endpoint:          "ws://db.example.com:8000",
+			Username:          "backup_user",
+			Password:          "backup_pass",
+			Namespace:         "production",
+			Database:          "main",
+			Output:            "incremental-001.cbor",
+			Incremental:       true,
+			SinceVersionstamp: 0, // Will be auto-detected
+			Tables:            []string{"users", "sessions"},
+			Dir:               "backups",
+			Verbose:           true,
+		}
+
+		// Validate
+		err := config.Validate()
+		require.NoError(t, err, "Incremental config should be valid")
+
+		// Get output path
+		outputPath := config.GetOutputPath()
+		expected := filepath.Join("backups", "incremental-001.cbor")
+		assert.Equal(t, expected, outputPath, "Incremental dump path should be correct")
+	})
+
+	t.Run("MinimalConfig", func(t *testing.T) {
+		// Test with absolute minimum required fields
+		config := &surrealdump.Config{
+			Namespace: "ns",
+			Database:  "db",
+			Output:    "dump.cbor",
+		}
+
+		err := config.Validate()
+		require.NoError(t, err, "Minimal config should be valid")
+
+		outputPath := config.GetOutputPath()
+		assert.Equal(t, "dump.cbor", outputPath, "Minimal config should return Output as-is")
+	})
+}
+
+func TestConfig_TableSelection(t *testing.T) {
+	t.Run("NoTablesSpecified", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Database:  "test_db",
+			Output:    "dump.cbor",
+			Tables:    nil,
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Config with no tables specified should be valid (dumps all tables)")
+		assert.Empty(t, config.Tables, "Tables should be empty")
+	})
+
+	t.Run("EmptyTablesSlice", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Database:  "test_db",
+			Output:    "dump.cbor",
+			Tables:    []string{},
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Config with empty tables slice should be valid (dumps all tables)")
+		assert.Empty(t, config.Tables, "Tables should be empty")
+	})
+
+	t.Run("SpecificTablesSelected", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Database:  "test_db",
+			Output:    "dump.cbor",
+			Tables:    []string{"users", "products", "orders"},
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Config with specific tables should be valid")
+		assert.Len(t, config.Tables, 3, "Should have 3 tables")
+		assert.Contains(t, config.Tables, "users", "Should contain users table")
+		assert.Contains(t, config.Tables, "products", "Should contain products table")
+		assert.Contains(t, config.Tables, "orders", "Should contain orders table")
+	})
+
+	t.Run("SingleTable", func(t *testing.T) {
+		config := &surrealdump.Config{
+			Namespace: "test_ns",
+			Database:  "test_db",
+			Output:    "dump.cbor",
+			Tables:    []string{"users"},
+		}
+
+		err := config.Validate()
+		assert.NoError(t, err, "Config with single table should be valid")
+		assert.Len(t, config.Tables, 1, "Should have 1 table")
+		assert.Equal(t, "users", config.Tables[0], "Should be users table")
+	})
+}

--- a/contrib/surrealdump/current_versionstamp.go
+++ b/contrib/surrealdump/current_versionstamp.go
@@ -1,0 +1,150 @@
+package surrealdump
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+// GetCurrentVersionstamp gets the current versionstamp by writing to a temp table.
+//
+// This function is designed to handle the requirements for you,
+// which prevents you from falling into the common mistakes,
+// both explained in the below.
+//
+// Requirements:
+//  1. The database connection MUST have a namespace and database selected via db.Use()
+//     before creating the Dumper instance.
+//  2. This function creates a temporary table with change feed enabled and IMMEDIATELY
+//     writes a record to it. The change feed ONLY generates versionstamps AFTER it is
+//     enabled AND when changes are made to the table.
+//  3. Without the actual write operation (CREATE record), no versionstamp will be available.
+//
+// Common mistakes:
+//   - Do NOT assume versionstamps exist just because change feeds are enabled
+//   - Do NOT assume versionstamps are generated without writing data to the table
+//   - ALWAYS ensure db.Use() was called before using the dumper
+//   - Be aware that specific databases (namespace.database combinations) can become
+//     corrupted after heavy use in test environments, where DEFINE TABLE CHANGEFEED
+//     succeeds but doesn't actually enable change feeds. Use unique database names
+//     in tests to avoid this SurrealDB issue.
+//
+// This technique works because versionstamps are monotonic and unique within a database.
+//
+//nolint:gocyclo,funlen // Complex versionstamp detection logic with multiple fallback paths
+func (d *Dumper) GetCurrentVersionstamp(ctx context.Context) (uint64, error) {
+	// First, verify we're in the right namespace/database by trying to query INFO
+	// This helps catch issues where db.Use() wasn't called
+	if _, err := surrealdb.Query[any](ctx, d.db, "INFO FOR DB", nil); err != nil {
+		return 0, fmt.Errorf("cannot query database info - ensure db.Use() was called with namespace '%s' and database '%s': %w",
+			d.namespace, d.database, err)
+	}
+
+	tempTable := fmt.Sprintf("_dump_temp_%d_%d", time.Now().UnixNano(), time.Now().Unix())
+
+	// Create temp table with change feed enabled
+	//
+	// Note that just enabling change feed does NOT generate a versionstamp yet.
+	//
+	// We must check the Error field in the result to catch DEFINE TABLE errors.
+	defineTableQuery, defineVars := surrealql.DefineTable(tempTable).Changefeed("1h").Build()
+	defineTableResult, err := surrealdb.Query[[]map[string]any](ctx, d.db, defineTableQuery, defineVars)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create temp table with change feed (check db.Use was called): %w", err)
+	}
+	// Check if the query returned an error in the result
+	if len(*defineTableResult) > 0 && (*defineTableResult)[0].Error != nil {
+		return 0, fmt.Errorf("failed to create temp table with change feed: %s", (*defineTableResult)[0].Error.Error())
+	}
+	// Verify we got a successful result
+	if len(*defineTableResult) == 0 {
+		return 0, fmt.Errorf("DEFINE TABLE returned empty result")
+	}
+
+	// Clean up temp table when done
+	defer func() {
+		deleteQuery := fmt.Sprintf("REMOVE TABLE %s", tempTable)
+		_, _ = surrealdb.Query[any](ctx, d.db, deleteQuery, nil)
+	}()
+
+	// Insert a record to generate a versionstamp
+	//
+	// Note that change feeds ONLY generate versionstamps when changes are made to the table.
+	// Without this insert, there will be NO versionstamp available.
+	createQuery, createVars := surrealql.Create(surrealql.Thing(tempTable, "marker")).Set("timestamp = time::now()").Build()
+	createResult, err := surrealdb.Query[[]map[string]any](ctx, d.db, createQuery, createVars)
+	if err != nil {
+		return 0, fmt.Errorf("failed to insert marker record (this is required to generate versionstamp): %w", err)
+	}
+	// Verify the insert succeeded
+	if len(*createResult) == 0 || len((*createResult)[0].Result) == 0 {
+		// Check if there's an error in the result
+		if len(*createResult) > 0 && (*createResult)[0].Error != nil {
+			return 0, fmt.Errorf("failed to insert marker record: %s", (*createResult)[0].Error.Error())
+		}
+		return 0, fmt.Errorf("insert succeeded but returned no result - database might not be properly initialized")
+	}
+
+	// Check if we can query the table to verify the record exists
+	selectQuery, selectVars := surrealql.Select(tempTable).Build()
+	selectResult, _ := surrealdb.Query[[]map[string]any](ctx, d.db, selectQuery, selectVars)
+	if selectResult != nil && len(*selectResult) > 0 {
+		recordCount := len((*selectResult)[0].Result)
+		if recordCount == 0 {
+			return 0, fmt.Errorf("table %s exists but has no records after insert", tempTable)
+		}
+	}
+
+	// Query the change feed to get the versionstamp
+	//
+	// SurrealDB generates versionstamps immediately when a change is made to a table with change feed enabled.
+	// However, it does not return the versionstamp as a part of the query result.
+	// That's why we need to query the change feed separately for obtaining the versionstamp here.
+	//
+	// We retry a few times only to handle potential network/query timing issues, not because versionstamps are delayed.
+	// Versionstamps are generated immediately and never delayed.
+	var lastErr error
+	for i := 0; i < 10; i++ {
+		if i > 0 {
+			// Only sleep on retries, not on first attempt
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		changesQuery, changesVars := surrealql.ShowChangesForTable(tempTable).SinceVersionstamp(0).Build()
+
+		// The result from SHOW CHANGES is an array of change entries
+		result, err := surrealdb.Query[[]map[string]any](ctx, d.db, changesQuery, changesVars)
+		if err != nil {
+			lastErr = fmt.Errorf("SHOW CHANGES query error for table %s: %w", tempTable, err)
+			continue
+		}
+
+		if len(*result) > 0 && len((*result)[0].Result) > 0 {
+			change := (*result)[0].Result[0]
+			if vs, ok := change["versionstamp"].(uint64); ok {
+				return vs, nil
+			}
+			// If versionstamp field exists but has unexpected type, debug it.
+			// This is purely for debugging purpose, because this should never happen.
+			// If happened, it indicates a bug in the SDK, the dumper or SurrealDB.
+			if _, hasVs := change["versionstamp"]; hasVs {
+				lastErr = fmt.Errorf("versionstamp has unexpected type: %T", change["versionstamp"])
+			}
+		} else {
+			// This shouldn't happen and indicates a bug in the SDK, the dumper or SurrealDB.
+			if len(*result) > 0 {
+				lastErr = fmt.Errorf("got result but no changes (len=%d)", len((*result)[0].Result))
+			} else {
+				lastErr = fmt.Errorf("got empty result array")
+			}
+		}
+	}
+
+	if lastErr != nil {
+		return 0, fmt.Errorf("no versionstamp found after retries (last error: %w)", lastErr)
+	}
+	return 0, fmt.Errorf("no versionstamp found after retries")
+}

--- a/contrib/surrealdump/current_versionstamp_test.go
+++ b/contrib/surrealdump/current_versionstamp_test.go
@@ -1,0 +1,183 @@
+package surrealdump_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// TestGetCurrentVersionstamp_integration verifies that GetCurrentVersionstamp works correctly
+// with a real SurrealDB instance, tracking versionstamp advancement as changes are made
+//
+//nolint:gocyclo // Test requires complex setup and verification steps
+func TestGetCurrentVersionstamp_integration(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup connection
+	conf := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
+	codec := surrealcbor.New()
+	conf.Marshaler = codec
+	conf.Unmarshaler = codec
+	conf.Logger = nil
+
+	conn := gws.New(conf)
+	db, err := surrealdb.FromConnection(ctx, conn)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer db.Close(ctx)
+
+	ns := "test_changefeed"
+	testdb := fmt.Sprintf("cf_db_%d", time.Now().UnixNano())
+
+	// Initialize database
+	if _, initErr := testenv.Init(db, ns, testdb); initErr != nil {
+		t.Fatalf("Failed to init test environment: %v", initErr)
+	}
+
+	// Step 1: Enable change feed on products table
+	t.Log("Step 1: Enabling change feed on products table")
+	if _, feedErr := surrealdb.Query[any](ctx, db, `
+		DEFINE TABLE products CHANGEFEED 1h;
+	`, nil); feedErr != nil {
+		t.Fatalf("Failed to enable change feed: %v", feedErr)
+	}
+
+	// NOTE: We cannot get a versionstamp here yet because:
+	// 1. Just enabling change feed does NOT generate a versionstamp
+	// 2. GetCurrentVersionstamp works by creating a temp table and writing to it
+	// 3. We'll get the first versionstamp after making changes to the products table
+
+	dumper := surrealdump.New(db, ns, testdb)
+
+	// Step 2: Create initial data to generate first versionstamp
+	t.Log("Step 2: Creating initial data")
+	if _, createErr := surrealdb.Query[any](ctx, db, `
+		CREATE products:laptop SET name = "Laptop", price = 999.99, stock = 10;
+		CREATE products:phone SET name = "Phone", price = 599.99, stock = 20;
+	`, nil); createErr != nil {
+		t.Fatalf("Failed to create initial data: %v", createErr)
+	}
+
+	// Wait a bit to ensure versionstamp advances
+	time.Sleep(100 * time.Millisecond)
+
+	// Get first versionstamp (vs0) - this is our baseline
+	vs0, err := dumper.GetCurrentVersionstamp(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get versionstamp after first insert: %v", err)
+	}
+	t.Logf("Versionstamp after first insert (baseline): %d", vs0)
+
+	// Step 3: Make changes
+	t.Log("Step 3: Making changes to data")
+	if _, changeErr := surrealdb.Query[any](ctx, db, `
+		UPDATE products:laptop SET stock = 5, last_sold = time::now();
+		CREATE products:tablet SET name = "Tablet", price = 799.99, stock = 15;
+		DELETE products:phone;
+	`, nil); changeErr != nil {
+		t.Fatalf("Failed to make changes: %v", changeErr)
+	}
+
+	// Wait a bit to ensure versionstamp advances
+	time.Sleep(100 * time.Millisecond)
+
+	vs1, err := dumper.GetCurrentVersionstamp(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get versionstamp after changes: %v", err)
+	}
+	t.Logf("Versionstamp after changes: %d", vs1)
+
+	if vs1 <= vs0 {
+		t.Errorf("Versionstamp did not advance after changes: %d <= %d", vs1, vs0)
+	}
+
+	// Step 4: Query change feed to verify changes are captured
+	t.Log("Step 4: Querying change feed")
+
+	// Note: Querying change feed directly is complex, so we'll skip this check
+	// The important thing is that versionstamps are advancing
+	t.Log("Skipping direct change feed query (complex format)")
+
+	// Step 5: Test incremental dump to see if it captures changes
+	t.Log("Step 5: Testing incremental dump")
+
+	// Create a full dump first
+	tempDir := t.TempDir()
+	fullPath := tempDir + "/full.cbor"
+	if fullErr := dumper.Full(ctx, fullPath); fullErr != nil {
+		t.Fatalf("Failed to create full dump: %v", fullErr)
+	}
+
+	fullManifest, err := surrealdump.ReadManifest(fullPath)
+	if err != nil {
+		t.Fatalf("Failed to read full manifest: %v", err)
+	}
+	t.Logf("Full dump versionstamp: base=%d, max=%d",
+		fullManifest.StartVersionstamp, fullManifest.EndVersionstamp)
+
+	// Make another change
+	t.Log("Step 6: Making another change for incremental dump")
+	if _, watchErr := surrealdb.Query[any](ctx, db, `
+		CREATE products:watch SET name = "Smart Watch", price = 299.99, stock = 30;
+	`, nil); watchErr != nil {
+		t.Fatalf("Failed to create watch: %v", watchErr)
+	}
+
+	// Wait to ensure versionstamp advances
+	time.Sleep(100 * time.Millisecond)
+
+	vs2, err := dumper.GetCurrentVersionstamp(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get versionstamp after watch creation: %v", err)
+	}
+	t.Logf("Versionstamp after watch creation: %d", vs2)
+
+	if vs2 <= fullManifest.EndVersionstamp {
+		t.Errorf("Versionstamp did not advance after watch creation: %d <= %d",
+			vs2, fullManifest.EndVersionstamp)
+	}
+
+	// Create incremental dump
+	incPath := tempDir + "/inc.cbor"
+	if incrErr := dumper.Incremental(ctx, incPath, fullManifest.EndVersionstamp); incrErr != nil {
+		t.Fatalf("Failed to create incremental dump: %v", incrErr)
+	}
+
+	incManifest, err := surrealdump.ReadManifest(incPath)
+	if err != nil {
+		t.Fatalf("Failed to read incremental manifest: %v", err)
+	}
+
+	t.Logf("Incremental dump versionstamp: base=%d, max=%d",
+		incManifest.StartVersionstamp, incManifest.EndVersionstamp)
+
+	// When incremental dump captures no actual changes from change feed,
+	// MinVersionstamp and EndVersionstamp may be the same
+	// This is expected if changes weren't captured in the change feed
+	if incManifest.EndVersionstamp < incManifest.StartVersionstamp {
+		t.Errorf("Incremental dump EndVersionstamp (%d) should be >= StartVersionstamp (%d)",
+			incManifest.EndVersionstamp, incManifest.StartVersionstamp)
+	}
+
+	// The key insight: even though we made changes and versionstamps advanced,
+	// the change feed might not have captured them yet or they might not be
+	// available via SHOW CHANGES query
+	t.Logf("Note: Incremental dump may show same min/max if no changes were captured from change feed")
+
+	t.Log("\n=== Summary ===")
+	t.Logf("Versionstamp progression:")
+	t.Logf("  After first insert (baseline): %d", vs0)
+	t.Logf("  After changes: %d (delta: %d)", vs1, vs1-vs0)
+	t.Logf("  After watch creation: %d (delta: %d)", vs2, vs2-vs1)
+	t.Logf("Full dump captured: base=%d, max=%d", fullManifest.StartVersionstamp, fullManifest.EndVersionstamp)
+	t.Logf("Incremental dump captured: base=%d, max=%d", incManifest.StartVersionstamp, incManifest.EndVersionstamp)
+}

--- a/contrib/surrealdump/do.go
+++ b/contrib/surrealdump/do.go
@@ -1,0 +1,155 @@
+package surrealdump
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// newDumper creates a new dumper from the configuration
+func newDumper(ctx context.Context, config *Config) (*Dumper, func(), error) {
+	u, err := url.ParseRequestURI(config.Endpoint)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse server endpoint: %w", err)
+	}
+
+	conf := connection.NewConfig(u)
+	codec := surrealcbor.New()
+	conf.Marshaler = codec
+	conf.Unmarshaler = codec
+
+	if !config.Verbose {
+		conf.Logger = nil
+	}
+
+	conn := gws.New(conf)
+
+	db, err := surrealdb.FromConnection(ctx, conn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to SurrealDB: %w", err)
+	}
+
+	cleanup := func() {
+		if closeErr := db.Close(ctx); closeErr != nil {
+			log.Printf("Warning: failed to close database connection: %v", closeErr)
+		}
+	}
+
+	_, err = db.SignIn(ctx, surrealdb.Auth{
+		Username: config.Username,
+		Password: config.Password,
+	})
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	if err := db.Use(ctx, config.Namespace, config.Database); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to use namespace/database: %w", err)
+	}
+
+	dumper := New(db, config.Namespace, config.Database, config.Tables...)
+
+	return dumper, cleanup, nil
+}
+
+// Do executes a dump operation based on the provided configuration.
+// It handles connection setup, authentication, and performs either a full or incremental dump.
+// The configuration should be validated before calling this function.
+func Do(ctx context.Context, config *Config) error {
+	outputPath := config.GetOutputPath()
+
+	dumper, cleanup, err := newDumper(ctx, config)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	startTime := time.Now()
+
+	if config.Incremental {
+		// Auto-detect start versionstamp if not provided
+		if config.SinceVersionstamp == 0 {
+			if vs, err := config.findLatestVersionstamp(); err == nil && vs > 0 {
+				config.SinceVersionstamp = vs
+				log.Printf("Auto-detected start versionstamp: %d", vs)
+			}
+		}
+
+		if config.SinceVersionstamp == 0 {
+			return fmt.Errorf("no start versionstamp specified and no previous dumps found")
+		}
+
+		log.Printf("Starting incremental dump from versionstamp %d...", config.SinceVersionstamp)
+		if err := dumper.Incremental(ctx, outputPath, config.SinceVersionstamp); err != nil {
+			return fmt.Errorf("incremental dump failed: %w", err)
+		}
+		log.Printf("Incremental dump completed successfully")
+	} else {
+		log.Println("Starting full database dump...")
+		if err := dumper.Full(ctx, outputPath); err != nil {
+			return fmt.Errorf("full dump failed: %w", err)
+		}
+		log.Printf("Full dump completed successfully")
+	}
+
+	elapsed := time.Since(startTime)
+	fileInfo, _ := os.Stat(outputPath)
+	log.Printf("Dump completed in %v, output size: %s", elapsed, formatBytes(fileInfo.Size()))
+
+	if !config.Incremental {
+		if manifest, err := ReadManifest(outputPath); err == nil {
+			displayDumpManifest(manifest)
+		}
+	}
+
+	if config.Verbose {
+		if manifest, err := ReadManifest(outputPath); err == nil {
+			log.Printf("Manifest created: %s.manifest.json (SHA256: %s)", outputPath, manifest.SHA256)
+		}
+	}
+
+	return nil
+}
+
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func displayDumpManifest(manifest *Manifest) {
+	fmt.Println("\nDump Information:")
+	fmt.Println(strings.Repeat("-", 50))
+	fmt.Printf("Type:              %s\n", manifest.Type)
+	fmt.Printf("Created At:        %s\n", manifest.CreatedAt.Format(time.RFC3339))
+	fmt.Printf("Namespace:         %s\n", manifest.Namespace)
+	fmt.Printf("Database:          %s\n", manifest.Database)
+	if manifest.Type == ManifestTypeFull {
+		fmt.Printf("Versionstamp:      %d (full dump from 0)\n", manifest.EndVersionstamp)
+	} else {
+		fmt.Printf("Versionstamp Range: %d - %d\n", manifest.StartVersionstamp, manifest.EndVersionstamp)
+	}
+	if manifest.Type == ManifestTypeIncremental {
+		fmt.Printf("Start Versionstamp:  %d\n", manifest.StartVersionstamp)
+	}
+	fmt.Printf("Size:              %s\n", formatBytes(manifest.Size))
+	fmt.Printf("SHA256:            %s\n", manifest.SHA256)
+}

--- a/contrib/surrealdump/docs/design.md
+++ b/contrib/surrealdump/docs/design.md
@@ -1,0 +1,122 @@
+# Surrealdump Design
+
+`surrealdump` tries its best to provide consistent full and incremental dumps of the database
+in a way so that it works on any SurrealDB backend.
+
+Some SurrealDB backend's isolation model and SurrealDB's lack of versionstamp visibility in transactions make traditional point-in-time dumps not straight-forward.
+
+> Note that SurrealDB's "versionstamp" is a concept related to "commit version" or "transaction ID" in other databases. A versionstamp is used by SurrealDB's "change feed" feature to serialize all the transactions to the database and tables on which the change feed is enabled.
+
+`surrealdump` combines an inconsistent full dump with change feed data to guarantee consistency at a specific versionstamp.
+
+More concretely, `surrealdump` create a consistent full dump that can be reliably followed by incremental dumps without missing any changes. And it does so by capturing an inconsistent full dump of all records alongside the complete change history from before the dump started, then replay changes over the inconsistent dump during restore.
+
+## The Problem
+
+Without serializable isolation and the commit version exposed to the transaction client, a full dump taken between time T1 and T2 may contain:
+- Some records as they existed at T1
+- Other records as they existed at T2
+- Records modified during the dump in various intermediate states
+
+If an incremental dump starts at T2, changes between T1 and T2 for the "T1 records" would be missed in the resulting database.
+
+How can we avoid that?
+
+## The Solution
+
+We solve this consistency problem by capturing a complete change history alongside the inconsistent dump. During restore, we first apply the inconsistent dump, then replay the changes to bring all records to a consistent state at a specific versionstamp (vs_2). This ensures no data is lost between dumps.
+
+### Full Dump Structure
+
+The dump contains two parts:
+1. **Inconsistent Full Dump** - All records dumped between versionstamp vs_1 and vs_2 (inherently inconsistent)
+2. **Change History** - All changes from vs_0 (before dump) through vs_2 (after dump)
+
+### Versionstamp Tracking
+
+Since SurrealDB transactions don't return versionstamps, we use a temp table to capture:
+- **vs_0**: Before starting the dump (baseline, for simplicity we cann this StartVersionstamp in code)
+- **vs_1**: Before dumping records (inconsistent dump start, does not appear in code)
+- **vs_2**: After dumping records (inconsistent dump end, we call this EndVersionstamp in code)
+
+### Restore Process
+
+1. Apply all records from the inconsistent full dump using UPSERT
+2. Apply all changes from the incremental dumps in ascending order of versionstamps, up to vs_2
+3. Result: Database state consistent at vs_2
+
+## Why This Works
+
+The inconsistent full dump might have record A at vs_1 and record B at vs_2, but the included changes from vs_0 to vs_2 ensure:
+- Record A gets updated from its vs_1 state to vs_2
+- Record B already at vs_2 remains unchanged (idempotent UPSERT)
+- Any records created or deleted between vs_1 and vs_2 are handled by the changes
+
+Subsequent incremental dumps starting at vs_2 will capture all future changes without gaps.
+
+## Technical Considerations
+
+- **Change feeds** must be enabled on all tables (automatically attempted by the dumper)
+- **Backend isolation** varies (e.g., TiKV provides snapshot isolation), and further more SurrealDB transactions do not include versionstamps in the transaction result as of today
+- **UPSERT operations** handle records appearing in both the inconsistent dump and changes without creating duplicates
+
+## Dump Chains
+
+To ensure data integrity and prevent corruption from incorrect dump application, surrealdump implements a dump chain system based on manifest files that track dump metadata and relationships among full and incremental dumps.
+
+### Manifest Structure
+
+Each dump automatically generates a `.manifest.json` file containing:
+- **Dump type** (full or incremental)
+- **Versionstamp ranges** (start and end versionstamps)
+- **Start versionstamp** for incremental dumps (equals to the end versionstamp of the previous dump)
+- **Namespace and database** information
+- **SHA256 hash** for integrity verification
+- **Timestamp and size** metadata
+
+### Chain Building
+
+The dump chain system provides several key features:
+
+1. **ValidateChain**: Ensures incremental dumps connect properly without gaps in versionstamps
+2. **CanApplyIncremental**: Verifies an incremental dump can be applied to the current database state
+3. **BuildChains**: Automatically discovers and constructs valid dump chains from a directory
+4. **ScanDirectory**: Finds all dumps and their manifests in a directory
+5. **GetManifestsForVersionstamp**: Determines which dumps are needed to restore to a specific point
+
+See the `ScanChains` function for more details.
+
+### Safety Guards
+
+The system prevents several types of errors that could lead to data corruption:
+
+1. **Gap Prevention**: Refuses to apply incremental dumps when there's a gap in versionstamps
+   - For example, you cannot apply an incremental dump expecting start versionstamp 300 to a database at versionstamp 200
+
+2. **Wrong Start Detection**: Validates that incremental dumps are applied to the correct start state
+   - Each incremental dump records its expected start versionstamp
+   - Restoration fails if the current state doesn't match the expected start
+
+3. **Namespace/Database Consistency**: Ensures dumps from different namespaces or databases aren't mixed
+   - Manifest files track the source namespace and database
+   - Chain building groups dumps by namespace/database combination
+
+4. **Order Enforcement**: Guarantees dumps are applied in the correct sequence
+   - Full dump must be applied first
+   - Incremental dumps must be applied in versionstamp order
+   - Point-in-time restore automatically determines the correct sequence
+
+5. **Integrity Verification**: SHA256 hashes verify dump files haven't been corrupted
+   - Each manifest includes the hash of its corresponding dump file
+   - Restoration can verify file integrity before application
+
+### Point-in-Time Recovery
+
+The chain validation system enables point-in-time recovery by:
+1. Scanning a directory for all available dumps
+2. Building valid chains from full dumps and their incremental continuations
+3. Validating chain consistency
+4. Determining the minimum set of dumps needed for a target versionstamp
+5. Applying dumps in the correct order to reach the desired state
+
+This design ensures that even with distributed systems and eventual consistency, administrators can reliably backup and restore their SurrealDB databases without risk of data corruption or loss.

--- a/contrib/surrealdump/dump.go
+++ b/contrib/surrealdump/dump.go
@@ -1,0 +1,483 @@
+package surrealdump
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// Alias types from surrealcbor for convenience
+type (
+	Encoder = surrealcbor.Encoder
+	Decoder = surrealcbor.Decoder
+)
+
+// Helper functions to create encoder/decoder
+var (
+	NewEncoder = surrealcbor.NewEncoder
+	NewDecoder = surrealcbor.NewDecoder
+)
+
+// DumpFormat represents the format version of the dump
+const DumpFormat = "SURDUMP01"
+
+// Record represents a single database record
+type Record struct {
+	Table string         `cbor:"table"`
+	ID    string         `cbor:"id"`
+	Data  map[string]any `cbor:"data"`
+}
+
+// ChangeEntry represents a change feed entry
+type ChangeEntry struct {
+	Table        string   `cbor:"table"`
+	Versionstamp uint64   `cbor:"versionstamp"`
+	Changes      []Change `cbor:"changes"`
+}
+
+// Change represents a single change in the database
+type Change struct {
+	DefineTable *ChangeDefineTable `cbor:"define_table,omitempty"`
+	Update      map[string]any     `cbor:"update,omitempty"`
+	Delete      map[string]any     `cbor:"delete,omitempty"`
+}
+
+// ChangeDefineTable represents the definition of a new table
+type ChangeDefineTable struct {
+	Name string `cbor:"name"`
+}
+
+// Dumper handles the database dump process.
+// It dumps the currently selected namespace and database that was set via db.Use().
+// To dump a specific namespace/database, call db.Use(ctx, namespace, database) before creating the dumper.
+type Dumper struct {
+	db        *surrealdb.DB
+	codec     *surrealcbor.Codec
+	namespace string
+	database  string
+	tables    []string // Tables to dump, if empty will dump all tables
+}
+
+// New creates a new Dumper instance.
+//
+// The provided db connection MUST have the namespace and database already selected
+// via db.Use(ctx, namespace, database) BEFORE creating the Dumper. The namespace and database
+// parameters passed here are for metadata purposes only - they do NOT change the connection's
+// current namespace/database context.
+//
+// The namespace and database parameters are required because SurrealDB doesn't provide an API
+// to query the current context, so we need them for writing metadata.
+//
+// Example:
+//
+//	db.Use(ctx, "myapp", "production")  // Set namespace/database first
+//	dumper := surrealdump.New(db, "myapp", "production")  // Pass same values for metadata
+func New(db *surrealdb.DB, namespace, database string, tables ...string) *Dumper {
+	return &Dumper{
+		db:        db,
+		codec:     surrealcbor.New(),
+		namespace: namespace,
+		database:  database,
+		tables:    tables,
+	}
+}
+
+// full performs a consistent full database dump to a writer.
+// This is a private method - external callers should use Full() which writes to a file
+// and creates the mandatory manifest.
+//
+//nolint:gocyclo // Complex logic required for consistent dump algorithm
+func (d *Dumper) full(ctx context.Context, w io.Writer) (*uint64, error) {
+	if _, err := w.Write([]byte(DumpFormat)); err != nil {
+		return nil, fmt.Errorf("failed to write magic header: %w", err)
+	}
+
+	// Use configured tables or detect all tables if not set
+	tables := d.tables
+	if len(tables) == 0 {
+		detectedTables, err := detectTables(ctx, d.db)
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect tables in current database: %w", err)
+		}
+		tables = detectedTables
+	}
+
+	// Change feeds are MANDATORY for consistent dumps
+	for _, table := range tables {
+		if feedErr := d.ensureChangeFeed(ctx, table); feedErr != nil {
+			return nil, fmt.Errorf("failed to ensure change feed on table %s: %w", table, feedErr)
+		}
+	}
+
+	// Get vs_0: the versionstamp BEFORE we start the dump
+	// This ensures we capture all changes, even those made during the dump
+	vs0, err := d.GetCurrentVersionstamp(ctx)
+	if err != nil {
+		// Log the error for debugging
+		return nil, fmt.Errorf("failed to get initial versionstamp: %w", err)
+	}
+
+	encoder := NewEncoder(w)
+
+	// PART 1: Dump all table records (inconsistent full dump between vs_1 and vs_2)
+	for _, table := range tables {
+		// Dump table - namespace/database are in metadata
+		if dumpErr := d.dumpTable(ctx, encoder, table); dumpErr != nil {
+			return nil, fmt.Errorf("failed to dump table %s: %w", table, dumpErr)
+		}
+	}
+
+	// Get vs_2: versionstamp after dumping all tables
+	vs2, err := d.GetCurrentVersionstamp(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get end versionstamp: %w", err)
+	}
+
+	// PART 2: Capture ALL changes from vs_0 to vs_2
+	// This ensures consistency by replaying any changes that occurred
+	// before or during the dump
+	for _, table := range tables {
+		maxVs, err := d.getAndEncodeTableChanges(ctx, encoder, table, vs0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to capture changes for table %s: %w", table, err)
+		}
+
+		// Track the actual end versionstamp we captured
+		if maxVs > vs2 {
+			vs2 = maxVs
+		}
+	}
+
+	return &vs2, nil
+}
+
+func (d *Dumper) getAndEncodeTableChanges(
+	ctx context.Context,
+	encoder *surrealcbor.Encoder,
+	table string,
+	sinceVersionstamp uint64,
+) (uint64, error) {
+	changes, maxVs, err := d.getTableChanges(ctx, table, sinceVersionstamp)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, changeSet := range changes {
+		entry := ChangeEntry{
+			Table:        table,
+			Versionstamp: changeSet.Versionstamp,
+			Changes:      changeSet.Changes,
+		}
+		if err := encoder.Encode(entry); err != nil {
+			return maxVs, fmt.Errorf("failed to encode change entry: %w", err)
+		}
+	}
+
+	return maxVs, nil
+}
+
+// incremental performs an incremental dump of changes to a writer.
+// External callers should use Incremental() which writes to a file
+// and creates the mandatory manifest.
+func (d *Dumper) incremental(ctx context.Context, w io.Writer, sinceVersionstamp uint64) (*uint64, error) {
+	if _, err := w.Write([]byte("SURINC01")); err != nil {
+		return nil, fmt.Errorf("failed to write magic header: %w", err)
+	}
+
+	encoder := NewEncoder(w)
+
+	var lastVersionstamp = sinceVersionstamp
+
+	// Use configured tables or detect all tables if not set
+	tables := d.tables
+	if len(tables) == 0 {
+		detectedTables, err := detectTables(ctx, d.db)
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect tables: %w", err)
+		}
+		tables = detectedTables
+	}
+
+	// Collect changes from all tables in the current database
+	for _, table := range tables {
+		maxVs, err := d.getAndEncodeTableChanges(ctx, encoder, table, sinceVersionstamp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to capture changes for table %s: %w", table, err)
+		}
+
+		if maxVs > lastVersionstamp {
+			lastVersionstamp = maxVs
+		}
+	}
+
+	// If no changes were found, return an error
+	// An incremental dump without changes is meaningless
+	if lastVersionstamp == sinceVersionstamp {
+		return nil, fmt.Errorf("no changes captured since versionstamp %d - incremental dump would be empty", sinceVersionstamp)
+	}
+
+	return &lastVersionstamp, nil
+}
+
+// ensureChangeFeed ensures a table has change feed enabled
+func (d *Dumper) ensureChangeFeed(ctx context.Context, table string) error {
+	// OVERWRITE will update existing table or create new one
+	query := fmt.Sprintf("DEFINE TABLE OVERWRITE %s CHANGEFEED 1h", table)
+	_, err := surrealdb.Query[any](ctx, d.db, query, nil)
+	return err
+}
+
+// detectTables detects all tables in the current database
+func detectTables(ctx context.Context, db *surrealdb.DB) ([]string, error) {
+	query := "INFO FOR DB"
+	result, err := surrealdb.Query[map[string]any](ctx, db, query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tables []string
+	if len(*result) > 0 {
+		if info, ok := (*result)[0].Result["tables"].(map[string]any); ok {
+			for table := range info {
+				tables = append(tables, table)
+			}
+		}
+	}
+	return tables, nil
+}
+
+func (d *Dumper) dumpTable(ctx context.Context, encoder *Encoder, table string) error {
+	// TODO: Enhancement for large tables - parallel/chunked SELECT
+	//
+	// For very large tables, we could potentially split the SELECT into parallel chunks
+	// by ID ranges to improve dump performance:
+	//
+	// 1. Get min ID: SELECT VALUE id FROM table ORDER BY id ASC LIMIT 1
+	// 2. Get max ID: SELECT VALUE id FROM table ORDER BY id DESC LIMIT 1
+	// 3. Split ID range into N chunks
+	// 4. Parallel SELECT for each chunk: SELECT * FROM table WHERE id >= $start AND id < $end
+	//
+	// However, this approach is currently blocked because:
+	// - Not all SurrealDB datastores support reverse scans (ORDER BY id DESC)
+	// - Without max ID, we can't determine the range to split
+	// - Example error: "The underlying datastore does not support reversed scans"
+	//
+	// Alternative approaches that might work:
+	// 1. Sequential pagination using last seen ID (memory efficient, works today):
+	//    - Get first batch: SELECT * FROM table ORDER BY id ASC LIMIT 1000
+	//    - Remember last ID from batch
+	//    - Get next batch: SELECT * FROM table WHERE id > $lastSeenId ORDER BY id ASC LIMIT 1000
+	//    - Repeat until no more records
+	//    - Benefits: Low memory usage on client/server, works on all backends
+	//    - Drawback: Sequential only, can't parallelize
+	//
+	// 2. Use COUNT() to estimate chunks (but still need max ID for ranges)
+	// 3. Stream records with pagination using LIMIT/START (sequential, not parallel)
+	// 4. Wait for SurrealDB to add reverse scan support to all datastores
+	//
+	// For now, we use a simple full table SELECT which works reliably on all backends.
+
+	// Use surrealql to build the SELECT query
+	q := surrealql.Select(table)
+	query, _ := q.Build()
+
+	result, err := surrealdb.Query[[]map[string]any](ctx, d.db, query, nil)
+	if err != nil {
+		return err
+	}
+
+	if len(*result) > 0 {
+		for _, data := range (*result)[0].Result {
+			record := Record{
+				Table: table,
+				Data:  data,
+			}
+			if id, ok := data["id"]; ok {
+				record.ID = fmt.Sprintf("%v", id)
+			}
+			if err := encoder.Encode(record); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *Dumper) getTableChanges(ctx context.Context, table string, sinceVersionstamp uint64) (allChanges []struct {
+	Versionstamp uint64
+	Changes      []Change
+}, maxVs uint64, err error) {
+	// SurrealDB versionstamps include extra bytes for FoundationDB ordering
+	// When using SINCE, we need to shift right by 16 bits to get the logical version
+	// See: https://surrealdb.com/docs/surrealql/statements/show
+	adjustedVs := sinceVersionstamp >> 16
+	q := surrealql.ShowChangesForTable(table).SinceVersionstamp(adjustedVs)
+	query, _ := q.Build()
+
+	type ChangeSet struct {
+		Versionstamp uint64   `json:"versionstamp"`
+		Changes      []Change `json:"changes"`
+	}
+
+	result, err := surrealdb.Query[[]ChangeSet](ctx, d.db, query, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var maxVersionstamp = sinceVersionstamp
+
+	if len(*result) > 0 {
+		for _, changeSet := range (*result)[0].Result {
+			allChanges = append(allChanges, struct {
+				Versionstamp uint64
+				Changes      []Change
+			}{
+				Versionstamp: changeSet.Versionstamp,
+				Changes:      changeSet.Changes,
+			})
+			if changeSet.Versionstamp > maxVersionstamp {
+				maxVersionstamp = changeSet.Versionstamp
+			}
+		}
+	}
+
+	return allChanges, maxVersionstamp, nil
+}
+
+// WriteUint64 writes a uint64 to the writer in big-endian format
+func WriteUint64(w io.Writer, v uint64) error {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, v)
+	_, err := w.Write(buf)
+	return err
+}
+
+// ReadUint64 reads a uint64 from the reader in big-endian format
+func ReadUint64(r io.Reader) (uint64, error) {
+	buf := make([]byte, 8)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(buf), nil
+}
+
+// Full performs a consistent full database dump to a file with mandatory manifest.
+//
+// The dump consists of two parts to ensure consistency:
+// 1. An inconsistent full dump of all records (captured between vs_1 and vs_2)
+// 2. All changes from vs_0 (before the dump started) to vs_2 (after the dump ended)
+//
+// By including the complete change history, we ensure that even if the inconsistent
+// dump captured records at different points between vs_1 and vs_2, we can replay all
+// changes up to vs_2 to get a consistent state. This approach guarantees that incremental
+// dumps starting at vs_2 won't miss any changes.
+//
+// Example usage:
+//
+//	db.Use(ctx, "myapp", "production")
+//	dumper := surrealdump.New(db, "myapp", "production")
+//	dumper.Full(ctx, "/path/to/dump.cbor")
+func (d *Dumper) Full(ctx context.Context, filePath string) error {
+	startTime := time.Now()
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create dump file: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	writer := io.MultiWriter(file, hash)
+
+	// Perform the dump
+	maxVs, dumpErr := d.full(ctx, writer)
+	if dumpErr != nil {
+		return fmt.Errorf("dump failed: %w", dumpErr)
+	}
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	manifest := &Manifest{
+		Filename:          filepath.Base(filePath),
+		Type:              ManifestTypeFull,
+		CreatedAt:         startTime,
+		Size:              fileInfo.Size(),
+		Namespace:         d.namespace,
+		Database:          d.database,
+		EndVersionstamp:   *maxVs,
+		StartVersionstamp: 0, // Full dumps start from 0
+		SHA256:            fmt.Sprintf("%x", hash.Sum(nil)),
+	}
+
+	if err := WriteManifest(filePath, manifest); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	return nil
+}
+
+// Incremental performs an incremental dump of changes since the specified versionstamp
+// to a file with mandatory manifest.
+//
+// Returns an error if no changes have been captured since the given versionstamp,
+// as empty incremental dumps are not valid.
+//
+// Example usage:
+//
+//	db.Use(ctx, "myapp", "production")
+//	dumper := surrealdump.New(db, "myapp", "production")
+//	dumper.Incremental(ctx, "/path/to/incremental.cbor", sinceVersionstamp)
+func (d *Dumper) Incremental(ctx context.Context, filePath string, sinceVersionstamp uint64) error {
+	startTime := time.Now()
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create dump file: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	writer := io.MultiWriter(file, hash)
+
+	// Perform the dump
+	maxVs, dumpErr := d.incremental(ctx, writer, sinceVersionstamp)
+	if dumpErr != nil {
+		return fmt.Errorf("dump failed: %w", dumpErr)
+	}
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	manifest := &Manifest{
+		Filename:          filepath.Base(filePath),
+		Type:              ManifestTypeIncremental,
+		CreatedAt:         startTime,
+		Size:              fileInfo.Size(),
+		Namespace:         d.namespace,
+		Database:          d.database,
+		EndVersionstamp:   *maxVs,
+		StartVersionstamp: sinceVersionstamp,
+		SHA256:            fmt.Sprintf("%x", hash.Sum(nil)),
+	}
+
+	if err := WriteManifest(filePath, manifest); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	return nil
+}

--- a/contrib/surrealdump/integration_test.go
+++ b/contrib/surrealdump/integration_test.go
@@ -1,0 +1,497 @@
+package surrealdump_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// TestComprehensiveSurrealdumpAPIs tests all surrealdump APIs comprehensively:
+// 1. New() - Creates dumper instance (for GetCurrentVersionstamp)
+// 2. Do() - Creates full dump with manifest using the external API
+// 3. Do() - Creates incremental dumps with manifests using the external API
+// 4. ReadManifest() - Reads and validates manifest files
+// 5. ReadManifest() - Reads and validates manifests
+// 6. ScanChains() - Scans directory and builds valid chains
+// 7. Chain.Validate() - Validates chain consistency
+// 8. Chain.GetPointInTimeOptions() - Lists available restore points
+// 9. Chain.GetDumpsForVersionstamp() - Gets dumps needed for specific point
+// 10. GetCurrentVersionstamp() - Gets current datastart versionstamp
+// 11. CanApplyIncremental() - Validates incremental dump applicability
+// 12. Verifies dumps without manifests are ignored
+//
+//nolint:gocyclo // Comprehensive integration test requires complex workflow validation
+func TestComprehensiveSurrealdumpAPIs(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup connection
+	conf := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
+	codec := surrealcbor.New()
+	conf.Marshaler = codec
+	conf.Unmarshaler = codec
+	conf.Logger = nil
+
+	conn := gws.New(conf)
+	db, err := surrealdb.FromConnection(ctx, conn)
+	require.NoError(t, err, "Failed to connect")
+	defer db.Close(ctx)
+
+	// We observed that SurrealDB running locally with in-memory datastore stops
+	// serving change feed sometimes.
+	// More concretely, after repeated table creation and removal in the same database, we found that:
+	// - DEFINE TABLE ... CHANGEFEED succeeds but doesn't create working change feeds
+	// - SHOW CHANGES FOR TABLE always returns 0 changes, even after inserts
+	// - The behavior persists even after REMOVE TABLE and recreating tables
+	// - The behavior appears to be at the database level and persists until SurrealDB is restarted
+	// To avoid this issue in tests, we use unique database names for each test run.
+	ns := "test_comprehensive"
+	testdb := fmt.Sprintf("comprehensive_db_%d", time.Now().UnixNano())
+
+	// Initialize database
+	_, initErr := testenv.Init(db, ns, testdb)
+	require.NoError(t, initErr, "Failed to init test environment")
+
+	// Create temporary directory for dumps
+	tempDir := t.TempDir()
+
+	// Shared state across sub-tests
+	var dumper *surrealdump.Dumper
+	var fullDumpPath string
+	var fullManifest *surrealdump.Manifest
+	var inc1DumpPath string
+	var inc1Manifest *surrealdump.Manifest
+	var inc2DumpPath string
+	var inc2Manifest *surrealdump.Manifest
+	var chains []*surrealdump.Chain
+
+	t.Run("New_Creates_Dumper_Instance", func(t *testing.T) {
+		dumper = surrealdump.New(db, ns, testdb, "products", "users", "orders")
+		require.NotNil(t, dumper, "New() returned nil dumper")
+	})
+
+	t.Run("Setup_Enable_Change_Feeds", func(t *testing.T) {
+		_, feedErr := surrealdb.Query[any](ctx, db, `
+			DEFINE TABLE products CHANGEFEED 1h;
+			DEFINE TABLE users CHANGEFEED 1h;
+			DEFINE TABLE orders CHANGEFEED 1h;
+		`, nil)
+		require.NoError(t, feedErr, "Failed to enable change feeds")
+	})
+
+	t.Run("Setup_Create_Initial_Data", func(t *testing.T) {
+		// Define Product struct for API insertion
+		type Product struct {
+			ID    string  `json:"id,omitempty"`
+			Name  string  `json:"name"`
+			Price float64 `json:"price"`
+			Stock int     `json:"stock"`
+		}
+
+		// Insert using API
+		products := []Product{
+			{Name: "Laptop", Price: 999.99, Stock: 10},
+			{Name: "Mouse", Price: 29.99, Stock: 50},
+			{Name: "Keyboard", Price: 79.99, Stock: 30},
+		}
+
+		for _, p := range products {
+			_, insertErr := surrealdb.Insert[Product](ctx, db, "products", p)
+			require.NoError(t, insertErr, "Failed to insert product")
+		}
+
+		// Insert using raw queries with specific IDs
+		_, createErr := surrealdb.Query[any](ctx, db, `
+			CREATE products:phone SET name = "Phone", price = 599.99, stock = 20;
+			CREATE users:alice SET name = "Alice", role = "admin", age = 30;
+			CREATE users:bob SET name = "Bob", role = "user", age = 25;
+			CREATE orders:order1 SET user = users:alice, product = products:laptop, quantity = 1;
+		`, nil)
+		require.NoError(t, createErr, "Failed to create initial data")
+	})
+
+	t.Run("Do_Incremental_With_Auto_Detect_Fails_Before_Full_Dump", func(t *testing.T) {
+		// Try to create an incremental dump with auto-detection before any full dump exists
+		// This should fail because there are no previous dumps to detect from
+		failedIncPath := filepath.Join(tempDir, "dump-000-inc-fail.cbor")
+
+		config := &surrealdump.Config{
+			Endpoint:          testenv.MustParseSurrealDBWSURL().String(),
+			Username:          "root",
+			Password:          "root",
+			Namespace:         ns,
+			Database:          testdb,
+			Output:            failedIncPath,
+			Incremental:       true, // Incremental dump
+			SinceVersionstamp: 0,    // Zero triggers auto-detection, but should fail
+			Tables:            []string{"products", "users", "orders"},
+			Verbose:           false,
+		}
+
+		err := surrealdump.Do(ctx, config)
+		assert.Error(t, err, "Should fail to create incremental dump when no previous dumps exist")
+		assert.Contains(t, err.Error(), "no start versionstamp specified and no previous dumps found",
+			"Error should indicate that no previous dumps were found for auto-detection")
+
+		// Verify the failed dump file was not created
+		_, statErr := os.Stat(failedIncPath)
+		assert.True(t, os.IsNotExist(statErr), "Failed incremental dump file should not exist")
+
+		t.Logf("Auto-detection correctly failed before any dumps exist")
+	})
+
+	t.Run("Do_Creates_Full_Dump_With_Manifest", func(t *testing.T) {
+		fullDumpPath = filepath.Join(tempDir, "dump-001-full.cbor")
+
+		// Use Do function with Config for full dump
+		config := &surrealdump.Config{
+			Endpoint:    testenv.MustParseSurrealDBWSURL().String(),
+			Username:    "root",
+			Password:    "root",
+			Namespace:   ns,
+			Database:    testdb,
+			Output:      fullDumpPath,
+			Incremental: false, // Full dump
+			Tables:      []string{"products", "users", "orders"},
+			Verbose:     false, // Suppress verbose logging in tests
+		}
+
+		fullErr := surrealdump.Do(ctx, config)
+		require.NoError(t, fullErr, "Failed to create full dump using Do")
+
+		// Verify dump file exists and has content
+		fullDumpData, err := os.ReadFile(fullDumpPath)
+		require.NoError(t, err, "Failed to read full dump file")
+		assert.NotEmpty(t, fullDumpData, "Full dump file is empty")
+	})
+
+	t.Run("Manifest_Contains_Expected_Information", func(t *testing.T) {
+		manifest, err := surrealdump.ReadManifest(fullDumpPath)
+		require.NoError(t, err, "Failed to read manifest")
+		assert.Equal(t, surrealdump.ManifestTypeFull, manifest.Type, "Expected full dump type")
+		assert.Equal(t, ns, manifest.Namespace, "Expected namespace")
+		assert.Equal(t, testdb, manifest.Database, "Expected database")
+		assert.NotZero(t, manifest.EndVersionstamp, "EndVersionstamp should not be zero")
+		assert.NotEmpty(t, manifest.SHA256, "SHA256 should not be empty")
+	})
+
+	t.Run("ReadManifest_Reads_And_Validates_Full_Manifest", func(t *testing.T) {
+		var err error
+		fullManifest, err = surrealdump.ReadManifest(fullDumpPath)
+		require.NoError(t, err, "Failed to read full dump manifest")
+
+		// Comprehensive manifest validation
+		assert.Equal(t, filepath.Base(fullDumpPath), fullManifest.Filename, "Expected filename")
+		assert.Equal(t, surrealdump.ManifestTypeFull, fullManifest.Type, "Expected type")
+		assert.Equal(t, ns, fullManifest.Namespace, "Expected namespace")
+		assert.Equal(t, testdb, fullManifest.Database, "Expected database")
+		assert.Zero(t, fullManifest.StartVersionstamp, "Full dump should have zero StartVersionstamp")
+		assert.NotEmpty(t, fullManifest.SHA256, "Manifest missing SHA256 hash")
+		assert.NotZero(t, fullManifest.Size, "Manifest has zero size")
+		assert.False(t, fullManifest.CreatedAt.IsZero(), "Manifest has zero CreatedAt time")
+		assert.NotZero(t, fullManifest.EndVersionstamp, "Manifest has zero EndVersionstamp")
+
+		t.Logf("Full dump created: %s (vs: 0-%d, size: %d bytes, SHA256: %s)",
+			fullManifest.Filename, fullManifest.EndVersionstamp, fullManifest.Size, fullManifest.SHA256)
+	})
+
+	t.Run("Do_Creates_First_Incremental_Dump", func(t *testing.T) {
+		_, changeErr := surrealdb.Query[any](ctx, db, `
+			UPDATE products:laptop SET stock = 5, last_sold = time::now();
+			CREATE products:tablet SET name = "Tablet", price = 799.99, stock = 15;
+			DELETE users:bob;
+			UPDATE products SET on_sale = true WHERE price > 900;
+		`, nil)
+		require.NoError(t, changeErr, "Failed to make first changes")
+
+		inc1DumpPath = filepath.Join(tempDir, "dump-002-inc.cbor")
+
+		// Use Do function with Config for incremental dump
+		config := &surrealdump.Config{
+			Endpoint:          testenv.MustParseSurrealDBWSURL().String(),
+			Username:          "root",
+			Password:          "root",
+			Namespace:         ns,
+			Database:          testdb,
+			Output:            inc1DumpPath,
+			Incremental:       true, // Incremental dump
+			SinceVersionstamp: fullManifest.EndVersionstamp,
+			Tables:            []string{"products", "users", "orders"},
+			Verbose:           false, // Suppress verbose logging in tests
+		}
+
+		inc1Err := surrealdump.Do(ctx, config)
+		require.NoError(t, inc1Err, "Failed to create first incremental dump using Do")
+
+		// Verify incremental dump file
+		inc1Data, err := os.ReadFile(inc1DumpPath)
+		require.NoError(t, err, "Failed to read incremental dump file")
+		assert.NotEmpty(t, inc1Data, "Incremental dump file is empty")
+	})
+
+	t.Run("ReadManifest_Reads_First_Incremental_Manifest", func(t *testing.T) {
+		var err error
+		inc1Manifest, err = surrealdump.ReadManifest(inc1DumpPath)
+		require.NoError(t, err, "Failed to read first incremental manifest")
+
+		// Validate incremental manifest fields
+		assert.Equal(t, surrealdump.ManifestTypeIncremental, inc1Manifest.Type, "Expected type incremental")
+		assert.Equal(t, fullManifest.EndVersionstamp, inc1Manifest.StartVersionstamp, "StartVersionstamp mismatch")
+		assert.Greater(t, inc1Manifest.EndVersionstamp, inc1Manifest.StartVersionstamp, "EndVersionstamp should be greater than StartVersionstamp")
+
+		t.Logf("First incremental dump created: %s (vs: %d-%d, size: %d bytes)",
+			inc1Manifest.Filename, inc1Manifest.StartVersionstamp, inc1Manifest.EndVersionstamp, inc1Manifest.Size)
+	})
+
+	t.Run("Do_Creates_Second_Incremental_Dump", func(t *testing.T) {
+		_, change2Err := surrealdb.Query[any](ctx, db, `
+			UPDATE products:phone SET price = 549.99, on_sale = true;
+			CREATE products:watch SET name = "Smart Watch", price = 299.99, stock = 30;
+			CREATE users:charlie SET name = "Charlie", role = "moderator", age = 35;
+			DELETE products WHERE name = "Mouse";
+			CREATE orders:order2 SET user = users:charlie, product = products:watch, quantity = 2;
+		`, nil)
+		require.NoError(t, change2Err, "Failed to make second changes")
+
+		inc2DumpPath = filepath.Join(tempDir, "dump-003-inc.cbor")
+
+		// Use Do function with Config for second incremental dump
+		config := &surrealdump.Config{
+			Endpoint:          testenv.MustParseSurrealDBWSURL().String(),
+			Username:          "root",
+			Password:          "root",
+			Namespace:         ns,
+			Database:          testdb,
+			Output:            inc2DumpPath,
+			Incremental:       true, // Incremental dump
+			SinceVersionstamp: inc1Manifest.EndVersionstamp,
+			Tables:            []string{"products", "users", "orders"},
+			Verbose:           false, // Suppress verbose logging in tests
+		}
+
+		inc2Err := surrealdump.Do(ctx, config)
+		require.NoError(t, inc2Err, "Failed to create second incremental dump using Do")
+	})
+
+	t.Run("ReadManifest_Reads_Second_Incremental_Manifest", func(t *testing.T) {
+		var err error
+		inc2Manifest, err = surrealdump.ReadManifest(inc2DumpPath)
+		require.NoError(t, err, "Failed to read second incremental manifest")
+
+		// Verify second incremental builds on first
+		assert.Equal(t, inc1Manifest.EndVersionstamp, inc2Manifest.StartVersionstamp, "Second incremental base doesn't match first incremental max")
+
+		t.Logf("Second incremental dump created: %s (vs: %d-%d, size: %d bytes)",
+			inc2Manifest.Filename, inc2Manifest.StartVersionstamp, inc2Manifest.EndVersionstamp, inc2Manifest.Size)
+	})
+
+	t.Run("Create_Orphan_Dump_Without_Manifest", func(t *testing.T) {
+		orphanPath := filepath.Join(tempDir, "dump-orphan.cbor")
+		writeErr := os.WriteFile(orphanPath, []byte("SURDUMP01fake_content"), 0600)
+		require.NoError(t, writeErr, "Failed to create orphan dump")
+
+		// Also create an invalid manifest to test error handling
+		invalidManifestPath := filepath.Join(tempDir, "dump-invalid.cbor.manifest")
+		writeErr = os.WriteFile(invalidManifestPath, []byte("invalid json"), 0600)
+		require.NoError(t, writeErr, "Failed to create invalid manifest")
+	})
+
+	t.Run("ScanChains_Scans_Directory_And_Builds_Chains", func(t *testing.T) {
+		var err error
+		chains, err = surrealdump.ScanChains(tempDir)
+		require.NoError(t, err, "Failed to scan and build chains")
+		require.Len(t, chains, 1, "Expected 1 chain")
+	})
+
+	t.Run("Chain_Validate_Validates_Chain_Consistency", func(t *testing.T) {
+		chain := chains[0]
+
+		require.NotNil(t, chain.FullDump, "Chain missing full dump")
+		assert.Equal(t, "dump-001-full.cbor", chain.FullDump.Filename, "Expected full dump filename")
+
+		assert.Len(t, chain.IncrementalDumps, 2, "Expected 2 incremental dumps in chain")
+
+		// Verify incremental dumps are in correct order
+		if len(chain.IncrementalDumps) >= 1 {
+			assert.Equal(t, "dump-002-inc.cbor", chain.IncrementalDumps[0].Filename, "First incremental filename")
+		}
+		if len(chain.IncrementalDumps) >= 2 {
+			assert.Equal(t, "dump-003-inc.cbor", chain.IncrementalDumps[1].Filename, "Second incremental filename")
+		}
+
+		// Explicitly test Validate() method
+		validateErr := chain.Validate()
+		assert.NoError(t, validateErr, "Chain validation failed")
+
+		// Verify chain metadata
+		expectedSize := fullManifest.Size + inc1Manifest.Size + inc2Manifest.Size
+		assert.Equal(t, expectedSize, chain.TotalSize, "Chain total size mismatch")
+		assert.Equal(t, inc2Manifest.EndVersionstamp, chain.LatestVersionstamp, "Chain latest versionstamp mismatch")
+	})
+
+	t.Run("Chain_GetPointInTimeOptions_Retrieves_Restore_Points", func(t *testing.T) {
+		chain := chains[0]
+		points := chain.GetRestorationPoints()
+
+		assert.Len(t, points, 3, "Expected 3 restore points (1 full + 2 incremental)")
+
+		// Verify points are in order
+		if len(points) >= 3 {
+			assert.Equal(t, fullManifest.EndVersionstamp, points[0], "First point should be full dump versionstamp")
+			assert.Equal(t, inc1Manifest.EndVersionstamp, points[1], "Second point should be first incremental versionstamp")
+			assert.Equal(t, inc2Manifest.EndVersionstamp, points[2], "Third point should be second incremental versionstamp")
+		}
+	})
+
+	t.Run("Chain_GetDumpsForVersionstamp_Tests_Dump_Selection", func(t *testing.T) {
+		chain := chains[0]
+
+		// Test restoration to full dump point
+		dumpsForFull, err := chain.GetManifestsForVersionstamp(fullManifest.EndVersionstamp)
+		assert.NoError(t, err, "Failed to get dumps for full versionstamp")
+		assert.Len(t, dumpsForFull, 1, "Expected 1 dump for full restore point")
+		if len(dumpsForFull) > 0 {
+			assert.Equal(t, "dump-001-full.cbor", dumpsForFull[0].Filename, "Expected full dump for full restore point")
+		}
+
+		// Test restoration to first incremental point
+		dumpsForInc1, err := chain.GetManifestsForVersionstamp(inc1Manifest.EndVersionstamp)
+		assert.NoError(t, err, "Failed to get dumps for first incremental")
+		assert.Len(t, dumpsForInc1, 2, "Expected 2 dumps for first incremental restore point")
+
+		// Test restoration to latest point
+		dumpsForLatest, err := chain.GetManifestsForVersionstamp(chain.LatestVersionstamp)
+		assert.NoError(t, err, "Failed to get dumps for latest point")
+		assert.Len(t, dumpsForLatest, 3, "Expected 3 dumps for latest restore point")
+
+		// Test error case: versionstamp before full dump
+		if fullManifest.EndVersionstamp > 0 {
+			_, err := chain.GetManifestsForVersionstamp(fullManifest.EndVersionstamp - 1)
+			assert.Error(t, err, "Expected error when requesting versionstamp before full dump")
+		}
+	})
+
+	t.Run("GetCurrentVersionstamp_Retrieves_Current_DB_Versionstamp", func(t *testing.T) {
+		currentVs, err := dumper.GetCurrentVersionstamp(ctx)
+		assert.NoError(t, err, "Failed to get current versionstamp")
+		assert.Greater(t, currentVs, inc2Manifest.EndVersionstamp, "Current versionstamp should be greater than last dump")
+		t.Logf("Current datastart versionstamp: %d", currentVs)
+	})
+
+	t.Run("CanApplyIncremental_Checks_Incremental_Applicability", func(t *testing.T) {
+		// Should be able to apply inc1 after full dump
+		err := surrealdump.CanApplyIncremental(fullManifest.EndVersionstamp, inc1Manifest)
+		assert.NoError(t, err, "Should be able to apply first incremental after full dump")
+
+		// Should be able to apply inc2 after inc1
+		err = surrealdump.CanApplyIncremental(inc1Manifest.EndVersionstamp, inc2Manifest)
+		assert.NoError(t, err, "Should be able to apply second incremental after first")
+
+		// Should NOT be able to apply inc2 directly after full (gap)
+		err = surrealdump.CanApplyIncremental(fullManifest.EndVersionstamp, inc2Manifest)
+		assert.Error(t, err, "Should not be able to apply second incremental directly after full dump (gap)")
+
+		// Should NOT be able to apply full dump as incremental
+		err = surrealdump.CanApplyIncremental(fullManifest.EndVersionstamp, fullManifest)
+		assert.Error(t, err, "Should not be able to apply full dump as incremental")
+	})
+
+	t.Run("Do_Creates_Incremental_With_Auto_Detected_Versionstamp", func(t *testing.T) {
+		// Make some additional changes
+		_, changeErr := surrealdb.Query[any](ctx, db, `
+			UPDATE products:tablet SET price = 699.99;
+			CREATE products:headphones SET name = "Wireless Headphones", price = 199.99, stock = 25;
+			CREATE users:david SET name = "David", role = "user", age = 28;
+		`, nil)
+		require.NoError(t, changeErr, "Failed to make changes for auto-detected incremental")
+
+		// Create a new incremental dump with zero versionstamp to trigger auto-detection
+		inc3DumpPath := filepath.Join(tempDir, "dump-004-inc-auto.cbor")
+
+		// Use Do function with Config for incremental dump with auto-detection
+		// Note: Output path is already in tempDir, and Config.FindLatestVersionstamp will
+		// use the directory of the output path when Dir is empty
+		config := &surrealdump.Config{
+			Endpoint:          testenv.MustParseSurrealDBWSURL().String(),
+			Username:          "root",
+			Password:          "root",
+			Namespace:         ns,
+			Database:          testdb,
+			Output:            inc3DumpPath,
+			Dir:               "",   // Empty Dir - FindLatestVersionstamp will use directory of Output
+			Incremental:       true, // Incremental dump
+			SinceVersionstamp: 0,    // Zero triggers auto-detection
+			Tables:            []string{"products", "users", "orders"},
+			Verbose:           false, // Suppress verbose logging in tests
+		}
+
+		inc3Err := surrealdump.Do(ctx, config)
+		require.NoError(t, inc3Err, "Failed to create incremental dump with auto-detected versionstamp")
+
+		// Verify the dump was created
+		inc3Data, err := os.ReadFile(inc3DumpPath)
+		require.NoError(t, err, "Failed to read auto-detected incremental dump file")
+		assert.NotEmpty(t, inc3Data, "Auto-detected incremental dump file is empty")
+
+		// Read and validate the manifest
+		inc3Manifest, err := surrealdump.ReadManifest(inc3DumpPath)
+		require.NoError(t, err, "Failed to read auto-detected incremental manifest")
+
+		// Verify it's an incremental dump
+		assert.Equal(t, surrealdump.ManifestTypeIncremental, inc3Manifest.Type, "Expected type incremental")
+
+		// Verify the auto-detected start versionstamp matches the latest previous dump
+		assert.Equal(t, inc2Manifest.EndVersionstamp, inc3Manifest.StartVersionstamp,
+			"Auto-detected start versionstamp should match the previous incremental's end versionstamp")
+
+		// Verify the new versionstamp is greater than the base
+		assert.Greater(t, inc3Manifest.EndVersionstamp, inc3Manifest.StartVersionstamp,
+			"EndVersionstamp should be greater than StartVersionstamp")
+
+		t.Logf("Auto-detected incremental dump created: %s (vs: %d-%d, size: %d bytes)",
+			inc3Manifest.Filename, inc3Manifest.StartVersionstamp, inc3Manifest.EndVersionstamp, inc3Manifest.Size)
+	})
+
+	t.Run("Dumps_Without_Manifests_Correctly_Ignored", func(t *testing.T) {
+		// Check that no chain contains the orphan dump
+		for _, c := range chains {
+			if c.FullDump != nil {
+				assert.NotEqual(t, "dump-orphan.cbor", c.FullDump.Filename, "Orphan dump without manifest should have been ignored")
+			}
+			for _, inc := range c.IncrementalDumps {
+				assert.NotEqual(t, "dump-orphan.cbor", inc.Filename, "Orphan dump without manifest should have been ignored")
+			}
+		}
+
+		// Verify that files in the directory that aren't dumps are handled correctly
+		files, _ := os.ReadDir(tempDir)
+		t.Logf("Directory contains %d files total", len(files))
+	})
+
+	t.Run("All_Manifests_Contain_Required_Metadata", func(t *testing.T) {
+		// Verify full manifest has required fields
+		assert.NotEmpty(t, fullManifest.SHA256, "Full manifest missing SHA256")
+		assert.NotZero(t, fullManifest.Size, "Full manifest missing size")
+		assert.NotZero(t, fullManifest.EndVersionstamp, "Full manifest missing EndVersionstamp")
+
+		// Verify incremental manifests have required fields
+		assert.NotEmpty(t, inc1Manifest.SHA256, "First incremental manifest missing SHA256")
+		assert.NotZero(t, inc1Manifest.Size, "First incremental manifest missing size")
+		assert.NotZero(t, inc1Manifest.EndVersionstamp, "First incremental manifest missing EndVersionstamp")
+
+		assert.NotEmpty(t, inc2Manifest.SHA256, "Second incremental manifest missing SHA256")
+		assert.NotZero(t, inc2Manifest.Size, "Second incremental manifest missing size")
+		assert.NotZero(t, inc2Manifest.EndVersionstamp, "Second incremental manifest missing EndVersionstamp")
+	})
+}

--- a/contrib/surrealdump/manifest.go
+++ b/contrib/surrealdump/manifest.go
@@ -1,0 +1,138 @@
+package surrealdump
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// ManifestType represents the type of a dump manifest
+type ManifestType string
+
+// Manifest type constants
+const (
+	ManifestTypeFull        ManifestType = "full"
+	ManifestTypeIncremental ManifestType = "incremental"
+)
+
+// Manifest represents metadata about a dump file for chain validation
+type Manifest struct {
+	// File information
+	Filename  string       `json:"filename"`
+	Type      ManifestType `json:"type"` // ManifestTypeFull or ManifestTypeIncremental
+	CreatedAt time.Time    `json:"created_at"`
+	Size      int64        `json:"size"`
+
+	// Database context
+	Namespace string `json:"namespace"`
+	Database  string `json:"database"`
+
+	// EndVersionstamp designates the ending versionstamp of this dump,
+	// which does not necessarily correspond to the latest versionstamp in the database.
+	// In case this is a full dump, it should be the versionstamp that is considered larger
+	// than any change feed entries' versionstamps.
+	// In case this is an incremental dump, it should be the versionstamp that corresponds
+	// to the maximum versionstamp of the changes captured in the dump.
+	EndVersionstamp uint64 `json:"end_versionstamp"`
+
+	// StartVersionstamp designates the starting versionstamp of this dump,
+	// which is 0 for initial full dumps, non-zero for subsequent full dumps,
+	// and the previous dump's EndVersionstamp for incremental dumps.
+	StartVersionstamp uint64 `json:"start_versionstamp,omitempty"`
+
+	// Checksum for integrity
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+// Validate validates the manifest fields for consistency and completeness
+func (m *Manifest) Validate() error {
+	// Validate manifest type
+	if m.Type != ManifestTypeFull && m.Type != ManifestTypeIncremental {
+		return fmt.Errorf("invalid manifest type: %s", m.Type)
+	}
+
+	// Validate required fields
+	if m.Namespace == "" {
+		return fmt.Errorf("manifest missing namespace")
+	}
+
+	if m.Database == "" {
+		return fmt.Errorf("manifest missing database")
+	}
+
+	// Validate versionstamp fields based on type
+	if m.Type == ManifestTypeFull {
+		// Full dumps should have StartVersionstamp as 0
+		if m.StartVersionstamp != 0 {
+			return fmt.Errorf("full manifest should have zero StartVersionstamp")
+		}
+		// EndVersionstamp of 0 is valid (could be the initial state)
+	}
+
+	if m.Type == ManifestTypeIncremental {
+		// Incremental dumps must have a StartVersionstamp (where they start from)
+		if m.StartVersionstamp == 0 {
+			return fmt.Errorf("incremental manifest missing start versionstamp")
+		}
+		// EndVersionstamp must be greater than StartVersionstamp
+		if m.EndVersionstamp <= m.StartVersionstamp {
+			return fmt.Errorf("incremental manifest EndVersionstamp must be greater than StartVersionstamp")
+		}
+	}
+
+	return nil
+}
+
+// WriteManifest writes a manifest file alongside the dump
+func WriteManifest(dumpPath string, manifest *Manifest) error {
+	manifestPath := dumpPath + ".manifest.json"
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	return os.WriteFile(manifestPath, data, 0600)
+}
+
+// ReadManifest reads a manifest file for a dump
+// It returns an error if the manifest doesn't exist (manifests are mandatory)
+// or if the manifest data is invalid
+func ReadManifest(dumpPath string) (*Manifest, error) {
+	manifestPath := dumpPath + ".manifest.json"
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("manifest not found for %s (manifests are mandatory)", dumpPath)
+		}
+		return nil, fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+
+	// Validate the manifest
+	if err := manifest.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+// CanApplyIncremental checks if an incremental dump can be applied to the current state
+func CanApplyIncremental(currentVersionstamp uint64, incrementalManifest *Manifest) error {
+	if incrementalManifest.Type != ManifestTypeIncremental {
+		return fmt.Errorf("not an incremental dump")
+	}
+
+	if incrementalManifest.StartVersionstamp != currentVersionstamp {
+		return fmt.Errorf("incremental dump expects start versionstamp %d, but current is %d",
+			incrementalManifest.StartVersionstamp, currentVersionstamp)
+	}
+
+	return nil
+}

--- a/contrib/surrealdump/manifest_test.go
+++ b/contrib/surrealdump/manifest_test.go
@@ -1,0 +1,345 @@
+package surrealdump_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+)
+
+func TestManifestReadWrite(t *testing.T) {
+	// Create temp directory
+	tempDir := t.TempDir()
+	dumpPath := filepath.Join(tempDir, "test.cbor")
+
+	// Create test manifest
+	original := &surrealdump.Manifest{
+		Filename:          "test.cbor",
+		Type:              surrealdump.ManifestTypeFull,
+		CreatedAt:         time.Now().UTC().Round(time.Second),
+		Size:              12345,
+		Namespace:         "test_ns",
+		Database:          "test_db",
+		EndVersionstamp:   2000,
+		StartVersionstamp: 0, // Full dump starts from 0
+		SHA256:            "abcdef123456",
+	}
+
+	// Write manifest
+	err := surrealdump.WriteManifest(dumpPath, original)
+	require.NoError(t, err, "Failed to write manifest")
+
+	// Read manifest back
+	read, err := surrealdump.ReadManifest(dumpPath)
+	require.NoError(t, err, "Failed to read manifest")
+
+	// Compare
+	assert.Equal(t, original, read)
+}
+
+func TestReadManifest_FileOperations(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("MissingManifestFile", func(t *testing.T) {
+		// Try to read a manifest that doesn't exist
+		nonExistentPath := filepath.Join(tempDir, "nonexistent.cbor")
+		manifest, err := surrealdump.ReadManifest(nonExistentPath)
+		assert.Error(t, err, "Should error when manifest file doesn't exist")
+		assert.Nil(t, manifest, "Should return nil manifest on error")
+		assert.Contains(t, err.Error(), "manifest not found")
+	})
+
+	t.Run("InvalidJSON", func(t *testing.T) {
+		// Create a manifest with invalid JSON
+		invalidPath := filepath.Join(tempDir, "invalid.cbor")
+		manifestPath := invalidPath + ".manifest.json"
+
+		// Write invalid JSON to manifest file
+		err := os.WriteFile(manifestPath, []byte("not valid json{"), 0600)
+		require.NoError(t, err, "Failed to write invalid manifest")
+
+		manifest, err := surrealdump.ReadManifest(invalidPath)
+		assert.Error(t, err, "Should error on invalid JSON")
+		assert.Nil(t, manifest, "Should return nil manifest on invalid JSON")
+		assert.Contains(t, err.Error(), "failed to unmarshal manifest")
+	})
+
+	t.Run("EmptyManifestFile", func(t *testing.T) {
+		// Create an empty manifest file
+		emptyPath := filepath.Join(tempDir, "empty.cbor")
+		manifestPath := emptyPath + ".manifest.json"
+
+		err := os.WriteFile(manifestPath, []byte(""), 0600)
+		require.NoError(t, err, "Failed to write empty manifest")
+
+		manifest, err := surrealdump.ReadManifest(emptyPath)
+		assert.Error(t, err, "Should error on empty manifest file")
+		assert.Nil(t, manifest, "Should return nil manifest on empty file")
+	})
+
+	t.Run("ValidJSONButFailsValidation", func(t *testing.T) {
+		// Create a manifest with valid JSON but that fails validation
+		incompletePath := filepath.Join(tempDir, "incomplete.cbor")
+		manifestPath := incompletePath + ".manifest.json"
+
+		incompleteManifest := map[string]any{
+			"filename": "incomplete.cbor",
+			"type":     "full",
+			// Missing required fields like namespace, database
+		}
+
+		data, err := json.Marshal(incompleteManifest)
+		require.NoError(t, err, "Failed to marshal incomplete manifest")
+
+		err = os.WriteFile(manifestPath, data, 0600)
+		require.NoError(t, err, "Failed to write incomplete manifest")
+
+		manifest, err := surrealdump.ReadManifest(incompletePath)
+		assert.Error(t, err, "Should error when validation fails")
+		assert.Nil(t, manifest, "Should return nil manifest when validation fails")
+		// The error should come from validation
+		assert.Contains(t, err.Error(), "missing namespace")
+	})
+
+	t.Run("SuccessfulReadWithCompleteManifest", func(t *testing.T) {
+		// Create a valid manifest file
+		validPath := filepath.Join(tempDir, "valid.cbor")
+
+		manifest := &surrealdump.Manifest{
+			Filename:        "valid.cbor",
+			Type:            surrealdump.ManifestTypeFull,
+			CreatedAt:       time.Now().UTC().Round(time.Second),
+			Size:            5000,
+			Namespace:       "test_ns",
+			Database:        "test_db",
+			EndVersionstamp: 1000,
+			SHA256:          "sha256hash",
+		}
+
+		err := surrealdump.WriteManifest(validPath, manifest)
+		require.NoError(t, err, "Failed to write manifest")
+
+		readManifest, err := surrealdump.ReadManifest(validPath)
+		require.NoError(t, err, "Should successfully read valid manifest")
+		assert.Equal(t, manifest, readManifest, "Read manifest should match written manifest")
+	})
+}
+
+func TestManifest_Validate(t *testing.T) {
+	t.Run("ValidFullManifest", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:          "full.cbor",
+			Type:              surrealdump.ManifestTypeFull,
+			CreatedAt:         time.Now().UTC(),
+			Size:              5000,
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			StartVersionstamp: 0, // Full dumps should have 0 base
+			EndVersionstamp:   1000,
+			SHA256:            "sha256hash",
+		}
+
+		err := manifest.Validate()
+		assert.NoError(t, err, "Valid full manifest should not return error")
+	})
+
+	t.Run("ValidIncrementalManifest", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:          "incremental.cbor",
+			Type:              surrealdump.ManifestTypeIncremental,
+			CreatedAt:         time.Now().UTC(),
+			Size:              3000,
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			StartVersionstamp: 1000, // Incremental should have non-zero base
+			EndVersionstamp:   2000,
+			SHA256:            "sha256hash_inc",
+		}
+
+		err := manifest.Validate()
+		assert.NoError(t, err, "Valid incremental manifest should not return error")
+	})
+
+	t.Run("InvalidManifestType", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:        "invalid.cbor",
+			Type:            "invalid_type",
+			Namespace:       "test_ns",
+			Database:        "test_db",
+			EndVersionstamp: 1000,
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error on invalid manifest type")
+		assert.Contains(t, err.Error(), "invalid manifest type")
+	})
+
+	t.Run("MissingNamespace", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:        "missing_ns.cbor",
+			Type:            surrealdump.ManifestTypeFull,
+			Namespace:       "", // Missing namespace
+			Database:        "test_db",
+			EndVersionstamp: 1000,
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error when namespace is missing")
+		assert.Contains(t, err.Error(), "missing namespace")
+	})
+
+	t.Run("MissingDatabase", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:        "missing_db.cbor",
+			Type:            surrealdump.ManifestTypeFull,
+			Namespace:       "test_ns",
+			Database:        "", // Missing database
+			EndVersionstamp: 1000,
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error when database is missing")
+		assert.Contains(t, err.Error(), "missing database")
+	})
+
+	t.Run("IncrementalWithoutStartVersionstamp", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:          "inc_no_base.cbor",
+			Type:              surrealdump.ManifestTypeIncremental,
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			StartVersionstamp: 0, // Missing base for incremental
+			EndVersionstamp:   1000,
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error when incremental manifest has no start versionstamp")
+		assert.Contains(t, err.Error(), "incremental manifest missing start versionstamp")
+	})
+
+	t.Run("IncrementalWithInvalidVersionstampOrder", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:          "inc_bad_order.cbor",
+			Type:              surrealdump.ManifestTypeIncremental,
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			StartVersionstamp: 2000,
+			EndVersionstamp:   1000, // Max is less than base
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error when EndVersionstamp <= StartVersionstamp for incremental")
+		assert.Contains(t, err.Error(), "EndVersionstamp must be greater than StartVersionstamp")
+	})
+
+	t.Run("FullManifestWithNonZeroBase", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:          "full_with_base.cbor",
+			Type:              surrealdump.ManifestTypeFull,
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			StartVersionstamp: 1000, // Full should have zero base
+			EndVersionstamp:   2000,
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error when full manifest has non-zero StartVersionstamp")
+		assert.Contains(t, err.Error(), "full manifest should have zero StartVersionstamp")
+	})
+
+	t.Run("EmptyManifestType", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:        "empty_type.cbor",
+			Type:            "", // Empty type
+			Namespace:       "test_ns",
+			Database:        "test_db",
+			EndVersionstamp: 1000,
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error on empty manifest type")
+		assert.Contains(t, err.Error(), "invalid manifest type")
+	})
+
+	t.Run("ManifestWithZeroEndVersionstamp", func(t *testing.T) {
+		// Zero EndVersionstamp is allowed as it's a valid versionstamp
+		manifest := &surrealdump.Manifest{
+			Filename:        "zero_max.cbor",
+			Type:            surrealdump.ManifestTypeFull,
+			Namespace:       "test_ns",
+			Database:        "test_db",
+			EndVersionstamp: 0, // Zero is valid
+		}
+
+		err := manifest.Validate()
+		assert.NoError(t, err, "Zero EndVersionstamp should be valid")
+	})
+
+	t.Run("ManifestWithEmptySHA256", func(t *testing.T) {
+		// Empty SHA256 is allowed as it's optional
+		manifest := &surrealdump.Manifest{
+			Filename:        "no_hash.cbor",
+			Type:            surrealdump.ManifestTypeFull,
+			Namespace:       "test_ns",
+			Database:        "test_db",
+			EndVersionstamp: 1000,
+			SHA256:          "", // Empty is ok
+		}
+
+		err := manifest.Validate()
+		assert.NoError(t, err, "Empty SHA256 should be valid (optional field)")
+	})
+
+	t.Run("ManifestWithZeroSize", func(t *testing.T) {
+		// Zero size is allowed (though unusual)
+		manifest := &surrealdump.Manifest{
+			Filename:        "zero_size.cbor",
+			Type:            surrealdump.ManifestTypeFull,
+			Namespace:       "test_ns",
+			Database:        "test_db",
+			EndVersionstamp: 1000,
+			Size:            0, // Zero size
+		}
+
+		err := manifest.Validate()
+		assert.NoError(t, err, "Zero size should be valid")
+	})
+
+	t.Run("IncrementalWithEqualBaseAndEndVersionstamp", func(t *testing.T) {
+		manifest := &surrealdump.Manifest{
+			Filename:          "inc_equal.cbor",
+			Type:              surrealdump.ManifestTypeIncremental,
+			Namespace:         "test_ns",
+			Database:          "test_db",
+			StartVersionstamp: 1000,
+			EndVersionstamp:   1000, // Equal to base
+		}
+
+		err := manifest.Validate()
+		assert.Error(t, err, "Should error when EndVersionstamp equals StartVersionstamp for incremental")
+		assert.Contains(t, err.Error(), "EndVersionstamp must be greater than StartVersionstamp")
+	})
+
+	t.Run("CompleteManifestWithAllFields", func(t *testing.T) {
+		// Test a manifest with all fields populated
+		manifest := &surrealdump.Manifest{
+			Filename:          "complete.cbor",
+			Type:              surrealdump.ManifestTypeFull,
+			CreatedAt:         time.Now().UTC(),
+			Size:              123456,
+			Namespace:         "production",
+			Database:          "main_db",
+			EndVersionstamp:   999999,
+			StartVersionstamp: 0,
+			SHA256:            "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		}
+
+		err := manifest.Validate()
+		assert.NoError(t, err, "Complete manifest with all fields should be valid")
+	})
+}

--- a/contrib/surrealdump/scan.go
+++ b/contrib/surrealdump/scan.go
@@ -1,0 +1,106 @@
+package surrealdump
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// ScanChains scans a directory for dump files, builds chains from manifests, and validates them.
+// It returns all valid chains found in the directory.
+// All chains are validated to ensure they form valid sequences (no gaps in versionstamps).
+func ScanChains(dir string) ([]*Chain, error) {
+	// Scan directory for manifests
+	manifests, err := scanDirectory(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan directory: %w", err)
+	}
+
+	if len(manifests) == 0 {
+		// Return empty slice, not an error - caller can decide how to handle
+		return []*Chain{}, nil
+	}
+
+	// Build chains from manifests
+	chains := buildChains(manifests)
+
+	// Always validate all chains to ensure correctness
+	for _, chain := range chains {
+		if err := chain.Validate(); err != nil {
+			return nil, fmt.Errorf("chain validation failed for %s.%s: %w",
+				chain.FullDump.Namespace, chain.FullDump.Database, err)
+		}
+	}
+
+	return chains, nil
+}
+
+// scanDirectory scans a directory for dump files and their manifests.
+// This is a private function - callers should use ScanChains instead.
+//
+// Do not use this directly to work with invalid chains.
+// If chains are invalid, they should be fixed at the source, not worked around.
+// Invalid chains cannot be used for restoration and should not be displayed to users.
+func scanDirectory(dir string) ([]*Manifest, error) {
+	var manifests []*Manifest
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Look for .cbor files
+		if filepath.Ext(path) == ".cbor" {
+			// Try to read the manifest (mandatory)
+			manifest, err := ReadManifest(path)
+			if err == nil {
+				manifests = append(manifests, manifest)
+			}
+			// Skip dumps without manifests - they are considered invalid
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan directory: %w", err)
+	}
+
+	// Sort by start versionstamp (full dumps have 0, incrementals have their starting point)
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].StartVersionstamp < manifests[j].StartVersionstamp
+	})
+
+	return manifests, nil
+}
+
+// findLatestVersionstamp searches for the latest versionstamp from previous dumps
+// in the specified directory for the given namespace and database.
+func findLatestVersionstamp(dir, namespace, database string) (uint64, error) {
+	// Use ScanChains to get all dump chains
+	chains, err := ScanChains(dir)
+	if err != nil {
+		return 0, err
+	}
+
+	var latestVs uint64
+	for _, chain := range chains {
+		// Check if this chain matches our namespace/database
+		if chain.FullDump != nil &&
+			chain.FullDump.Namespace == namespace &&
+			chain.FullDump.Database == database {
+			// Get the latest versionstamp from this chain
+			points := chain.GetRestorationPoints()
+			if len(points) > 0 {
+				// The last point is the latest versionstamp
+				lastVs := points[len(points)-1]
+				if lastVs > latestVs {
+					latestVs = lastVs
+				}
+			}
+		}
+	}
+
+	return latestVs, nil
+}

--- a/contrib/surrealdump/scan_test.go
+++ b/contrib/surrealdump/scan_test.go
@@ -1,0 +1,389 @@
+package surrealdump_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+//nolint:gocyclo // Test requires complex scenario validation
+func TestScanChains_integration(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup connection
+	conf := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
+	codec := surrealcbor.New()
+	conf.Marshaler = codec
+	conf.Unmarshaler = codec
+	conf.Logger = nil
+
+	conn := gws.New(conf)
+	db, err := surrealdb.FromConnection(ctx, conn)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer db.Close(ctx)
+
+	ns := "test_scan"
+	testdb := fmt.Sprintf("scan_db_%d", time.Now().UnixNano())
+
+	// Initialize database
+	if _, initErr := testenv.Init(db, ns, testdb); initErr != nil {
+		t.Fatalf("Failed to init test environment: %v", initErr)
+	}
+
+	// Create temporary directory for dumps
+	tempDir := t.TempDir()
+
+	// Test 1: Empty directory should return no chains
+	t.Run("EmptyDirectory", func(t *testing.T) {
+		chains, scanErr := surrealdump.ScanChains(tempDir)
+		if scanErr != nil {
+			t.Fatalf("ScanChains failed: %v", scanErr)
+		}
+		if len(chains) != 0 {
+			t.Errorf("Expected 0 chains, got %d", len(chains))
+		}
+	})
+
+	// Test 2: Directory with dumps and manifests
+	t.Run("WithDumpsAndManifests", func(t *testing.T) {
+		// Enable change feeds
+		if _, feedErr := surrealdb.Query[any](ctx, db, `
+			DEFINE TABLE products CHANGEFEED 1h;
+		`, nil); feedErr != nil {
+			t.Fatalf("Failed to enable change feed: %v", feedErr)
+		}
+
+		// Create initial data
+		if _, createErr := surrealdb.Query[any](ctx, db, `
+			CREATE products:laptop SET name = "Laptop", price = 999.99;
+			CREATE products:phone SET name = "Phone", price = 599.99;
+		`, nil); createErr != nil {
+			t.Fatalf("Failed to create data: %v", createErr)
+		}
+
+		// Create full dump
+		fullPath := filepath.Join(tempDir, "full.cbor")
+		dumper := surrealdump.New(db, ns, testdb)
+		if fullErr := dumper.Full(ctx, fullPath); fullErr != nil {
+			t.Fatalf("Failed to create full dump: %v", fullErr)
+		}
+
+		// Make changes for incremental dump
+		if _, changeErr := surrealdb.Query[any](ctx, db, `
+			CREATE products:tablet SET name = "Tablet", price = 799.99;
+		`, nil); changeErr != nil {
+			t.Fatalf("Failed to create tablet: %v", changeErr)
+		}
+
+		// Get versionstamp from full dump manifest
+		fullManifest, readErr := surrealdump.ReadManifest(fullPath)
+		if readErr != nil {
+			t.Fatalf("Failed to read full manifest: %v", readErr)
+		}
+
+		// Create incremental dump
+		incPath := filepath.Join(tempDir, "inc.cbor")
+		if incErr := dumper.Incremental(ctx, incPath, fullManifest.EndVersionstamp); incErr != nil {
+			t.Fatalf("Failed to create incremental dump: %v", incErr)
+		}
+
+		// Test ScanChains (always validates)
+		chains, scanErr := surrealdump.ScanChains(tempDir)
+		if scanErr != nil {
+			t.Fatalf("ScanChains failed: %v", scanErr)
+		}
+
+		if len(chains) != 1 {
+			t.Fatalf("Expected 1 chain, got %d", len(chains))
+		}
+
+		chain := chains[0]
+		if chain.FullDump == nil {
+			t.Error("Chain missing full dump")
+		}
+		if len(chain.IncrementalDumps) != 1 {
+			t.Errorf("Expected 1 incremental dump, got %d", len(chain.IncrementalDumps))
+		}
+
+		// Chains are already validated by ScanChains
+	})
+
+	// Test 3: Directory with dump but no manifest (should be ignored)
+	t.Run("DumpWithoutManifest", func(t *testing.T) {
+		orphanDir := t.TempDir()
+		orphanPath := filepath.Join(orphanDir, "orphan.cbor")
+		if writeErr := os.WriteFile(orphanPath, []byte("SURDUMP01fake"), 0600); writeErr != nil {
+			t.Fatalf("Failed to create orphan dump: %v", writeErr)
+		}
+
+		chains, scanErr := surrealdump.ScanChains(orphanDir)
+		if scanErr != nil {
+			t.Fatalf("ScanChains failed: %v", scanErr)
+		}
+
+		if len(chains) != 0 {
+			t.Errorf("Expected 0 chains (orphan should be ignored), got %d", len(chains))
+		}
+	})
+
+	// Test 4: Invalid chain should fail validation
+	t.Run("InvalidChainValidation", func(t *testing.T) {
+		invalidDir := t.TempDir()
+
+		// Create a full dump manifest first
+		fullManifest := &surrealdump.Manifest{
+			Filename:          "full.cbor",
+			Type:              surrealdump.ManifestTypeFull,
+			Namespace:         ns,
+			Database:          testdb,
+			EndVersionstamp:   100,
+			StartVersionstamp: 0,
+		}
+
+		fullPath := filepath.Join(invalidDir, "full.cbor")
+		if writeErr := os.WriteFile(fullPath, []byte("SURDUMP01fake"), 0600); writeErr != nil {
+			t.Fatalf("Failed to create full dump file: %v", writeErr)
+		}
+		if manifestErr := surrealdump.WriteManifest(fullPath, fullManifest); manifestErr != nil {
+			t.Fatalf("Failed to write full manifest: %v", manifestErr)
+		}
+
+		// Create an incremental manifest with invalid versionstamp range
+		incManifest := &surrealdump.Manifest{
+			Filename:          "inc.cbor",
+			Type:              surrealdump.ManifestTypeIncremental,
+			Namespace:         ns,
+			Database:          testdb,
+			EndVersionstamp:   120, // Invalid: max < base
+			StartVersionstamp: 150, // Invalid: base > max
+		}
+
+		incPath := filepath.Join(invalidDir, "inc.cbor")
+		if writeIncErr := os.WriteFile(incPath, []byte("SURINC01fake"), 0600); writeIncErr != nil {
+			t.Fatalf("Failed to create inc dump file: %v", writeIncErr)
+		}
+		if incManifestErr := surrealdump.WriteManifest(incPath, incManifest); incManifestErr != nil {
+			t.Fatalf("Failed to write inc manifest: %v", incManifestErr)
+		}
+
+		// ScanChains should succeed but exclude the invalid incremental dump
+		chains, err := surrealdump.ScanChains(invalidDir)
+		if err != nil {
+			t.Fatalf("ScanChains failed: %v", err)
+		}
+
+		// Should have one chain with only the full dump (invalid incremental is excluded)
+		if len(chains) != 1 {
+			t.Errorf("Expected 1 chain, got %d", len(chains))
+		} else {
+			chain := chains[0]
+			if chain.FullDump == nil {
+				t.Error("Chain missing full dump")
+			}
+			if len(chain.IncrementalDumps) != 0 {
+				t.Error("Invalid incremental dump should not be included in chain")
+			}
+			t.Log("Invalid incremental correctly excluded from chain")
+		}
+	})
+}
+
+func TestScanChains(t *testing.T) {
+	// Test chain building through ScanChains
+	tempDir := t.TempDir()
+
+	// Use UTC time for consistent comparison
+	now := time.Now().UTC().Round(time.Second)
+
+	// Create manifests for two different databases
+	db1Full := &surrealdump.Manifest{
+		Filename:          "db1-001.cbor",
+		Type:              surrealdump.ManifestTypeFull,
+		Namespace:         "ns1",
+		Database:          "db1",
+		EndVersionstamp:   200,
+		StartVersionstamp: 0,
+		Size:              1000,
+		CreatedAt:         now,
+	}
+
+	db1Inc1 := &surrealdump.Manifest{
+		Filename:          "db1-002.cbor",
+		Type:              surrealdump.ManifestTypeIncremental,
+		Namespace:         "ns1",
+		Database:          "db1",
+		EndVersionstamp:   300,
+		StartVersionstamp: 200,
+		Size:              500,
+		CreatedAt:         now,
+	}
+
+	db2Full := &surrealdump.Manifest{
+		Filename:          "db2-001.cbor",
+		Type:              surrealdump.ManifestTypeFull,
+		Namespace:         "ns1",
+		Database:          "db2",
+		EndVersionstamp:   250,
+		StartVersionstamp: 0,
+		Size:              800,
+		CreatedAt:         now,
+	}
+
+	// Create dump files and manifests
+	for _, manifest := range []*surrealdump.Manifest{db1Full, db1Inc1, db2Full} {
+		dumpPath := filepath.Join(tempDir, manifest.Filename)
+		err := os.WriteFile(dumpPath, []byte("SURDUMP01fake"), 0600)
+		require.NoError(t, err)
+		err = surrealdump.WriteManifest(dumpPath, manifest)
+		require.NoError(t, err)
+	}
+
+	// Use ScanChains which internally calls buildChains
+	chains, err := surrealdump.ScanChains(tempDir)
+	require.NoError(t, err, "Failed to scan and build chains")
+	assert.Len(t, chains, 2, "Should build 2 chains for 2 databases")
+
+	// Find chains by database
+	var db1Chain, db2Chain *surrealdump.Chain
+	for _, chain := range chains {
+		switch chain.FullDump.Database {
+		case "db1":
+			db1Chain = chain
+		case "db2":
+			db2Chain = chain
+		}
+	}
+
+	require.NotNil(t, db1Chain, "Should have chain for db1")
+	require.NotNil(t, db2Chain, "Should have chain for db2")
+
+	// Verify db1 chain
+	assert.Equal(t, db1Full, db1Chain.FullDump)
+	assert.Len(t, db1Chain.IncrementalDumps, 1)
+	assert.Equal(t, db1Inc1, db1Chain.IncrementalDumps[0])
+	assert.Equal(t, uint64(300), db1Chain.LatestVersionstamp)
+
+	// Verify db2 chain
+	assert.Equal(t, db2Full, db2Chain.FullDump)
+	assert.Len(t, db2Chain.IncrementalDumps, 0)
+	assert.Equal(t, uint64(250), db2Chain.LatestVersionstamp)
+}
+
+func TestScanChains_onlyProcessDumpsWithManifests(t *testing.T) {
+	// This test verifies that ScanChains only processes dumps that have manifests.
+	// Dumps without manifests are not valid and cannot be processed since we need
+	// the metadata to build and validate chains.
+	tempDir := t.TempDir()
+
+	// Create a valid full dump with manifest
+	dumpPath1 := filepath.Join(tempDir, "dump1.cbor")
+	err := os.WriteFile(dumpPath1, []byte("SURDUMP01..."), 0600)
+	require.NoError(t, err)
+
+	// Create manifest for the valid dump
+	manifest1 := &surrealdump.Manifest{
+		Filename:          "dump1.cbor",
+		Type:              surrealdump.ManifestTypeFull,
+		CreatedAt:         time.Now().UTC().Round(time.Second),
+		Size:              12,
+		Namespace:         "test",
+		Database:          "db",
+		EndVersionstamp:   200,
+		StartVersionstamp: 0,
+	}
+	err = surrealdump.WriteManifest(dumpPath1, manifest1)
+	require.NoError(t, err)
+
+	// Create a dump file without manifest - this represents a corrupted or incomplete dump
+	// that should not be processed
+	orphanDumpPath := filepath.Join(tempDir, "orphan.cbor")
+	err = os.WriteFile(orphanDumpPath, []byte("SURINC01..."), 0600)
+	require.NoError(t, err)
+
+	// ScanChains should only find and process the dump with a manifest
+	chains, err := surrealdump.ScanChains(tempDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(chains), "Should find exactly one valid chain")
+
+	// Check the chain
+	if len(chains) > 0 {
+		chain := chains[0]
+		assert.NotNil(t, chain.FullDump)
+		assert.Equal(t, "dump1.cbor", chain.FullDump.Filename)
+		assert.Equal(t, manifest1.Type, chain.FullDump.Type)
+		assert.Equal(t, manifest1.Namespace, chain.FullDump.Namespace)
+		assert.Equal(t, manifest1.Database, chain.FullDump.Database)
+		assert.Equal(t, manifest1.StartVersionstamp, chain.FullDump.StartVersionstamp)
+		assert.Equal(t, manifest1.EndVersionstamp, chain.FullDump.EndVersionstamp)
+	}
+}
+
+func TestScanChainsExcludesIncrementalDumpsWithGaps(t *testing.T) {
+	// This test verifies that ScanChains excludes incremental dumps that would create gaps
+	// in the chain. Only continuous sequences of dumps are included in valid chains.
+	tempDir := t.TempDir()
+
+	// Create a full dump
+	fullPath := filepath.Join(tempDir, "full.cbor")
+	err := os.WriteFile(fullPath, []byte("SURDUMP01..."), 0600)
+	require.NoError(t, err)
+
+	fullManifest := &surrealdump.Manifest{
+		Filename:          "full.cbor",
+		Type:              surrealdump.ManifestTypeFull,
+		CreatedAt:         time.Now().UTC().Round(time.Second),
+		Size:              100,
+		Namespace:         "test",
+		Database:          "db",
+		EndVersionstamp:   200,
+		StartVersionstamp: 0,
+	}
+	err = surrealdump.WriteManifest(fullPath, fullManifest)
+	require.NoError(t, err)
+
+	// Create an incremental dump with a gap (invalid chain)
+	incPath := filepath.Join(tempDir, "inc.cbor")
+	err = os.WriteFile(incPath, []byte("SURINC01..."), 0600)
+	require.NoError(t, err)
+
+	incManifest := &surrealdump.Manifest{
+		Filename:          "inc.cbor",
+		Type:              surrealdump.ManifestTypeIncremental,
+		CreatedAt:         time.Now().UTC().Round(time.Second),
+		Size:              50,
+		Namespace:         "test",
+		Database:          "db",
+		EndVersionstamp:   400,
+		StartVersionstamp: 300, // Gap! Should be 200 to match full dump's EndVersionstamp
+	}
+	err = surrealdump.WriteManifest(incPath, incManifest)
+	require.NoError(t, err)
+
+	// ScanChains will succeed but the incremental dump with gap won't be included
+	chains, err := surrealdump.ScanChains(tempDir)
+	require.NoError(t, err, "ScanChains should succeed")
+
+	// Verify that the chain only contains the full dump (incremental with gap is excluded)
+	require.Len(t, chains, 1, "Should have one chain")
+	chain := chains[0]
+	assert.NotNil(t, chain.FullDump, "Should have full dump")
+	assert.Empty(t, chain.IncrementalDumps, "Incremental dump with gap should not be included")
+
+	// The chain is valid because it only contains the full dump
+	// Incremental dumps that would create gaps are simply not included in the chain
+}

--- a/contrib/surrealrestore/.gitignore
+++ b/contrib/surrealrestore/.gitignore
@@ -1,0 +1,5 @@
+/cmd/surrealrestore/surrealrestore
+/surrealrestore
+/*.cbor
+/*.json
+/*.sh

--- a/contrib/surrealrestore/README.md
+++ b/contrib/surrealrestore/README.md
@@ -1,0 +1,163 @@
+# surrealrestore
+
+A Go-based tool for restoring SurrealDB databases from CBOR format dumps created by [surrealdump](../surrealdump).
+
+> This tool is for demonstrating the Go SDK usage and not intended for production use
+
+## Features
+
+- Full database restore from CBOR dumps
+- Incremental restore using change feed data
+- Automatic namespace and database creation
+- Preserves record IDs and relationships
+- Detailed restore statistics
+- Dump chain validation with manifest files
+- Point-in-time recovery to specific versionstamps
+- Automatic chain discovery and validation
+- Safety guards against incompatible incremental dumps
+
+## Installation
+
+```bash
+go install github.com/surrealdb/surrealdb.go/contrib/surrealrestore/cmd/surrealrestore@latest
+```
+
+## Usage
+
+- [Full restore](#full-restore) creates namespaces and databases as needed
+- [Incremental restore](#incremental-restore) applies changes in order based on versionstamps
+- [Scan dump chain](#scan-dump-chains) to review restoration points
+- [Point-in-time restore](#point-in-time-restore) to a specific restoration point
+- [Starting another dump chain](#starting-another-dump-chain) after the restoration
+
+### Full Restore
+
+Restore a complete database from a full dump (requires clean or non-existent target database):
+
+```bash
+surrealrestore -endpoint ws://localhost:8000 -username root -password root -input dump.cbor
+```
+
+### Incremental Restore
+
+Apply incremental changes from an incremental dump:
+
+```bash
+surrealrestore -incremental -endpoint ws://localhost:8000 -username root -password root -input increment.cbor
+```
+
+### Scan Dump Chains
+
+View available dump chains and restore points:
+
+```bash
+# Show dump chain information
+surrealrestore -dir backups/
+
+# Or explicitly with -info flag
+surrealrestore -dir backups/ -info
+```
+
+### Point-in-Time Restore
+
+Restore a database to a specific point in time using a dump chain:
+
+```bash
+# Restore to specific versionstamp
+surrealrestore -dir backups/ -point-in-time 655360 -endpoint ws://localhost:8000 -username root -password root
+
+# Restore to latest available state
+surrealrestore -dir backups/ -latest -endpoint ws://localhost:8000 -username root -password root
+```
+
+### Starting another dump chain
+
+You can apply incremental dumps from the original database to a restored database, but you cannot continue the dump chain after restoration.
+
+This is because restored databases have different versionstamps than the original database it was restored from.
+
+To start a new backup chain:
+
+1. **Re-enable Change Feeds** on the restored database:
+   ```sql
+   DEFINE DATABASE OVERWRITE <database_name> CHANGEFEED <retention_period>
+   ```
+
+   > This is necessary because change Feeds are not preserved during restoration.
+   > You must manually re-enable Change Feeds on the restored database if you want to create incremental dumps from it.
+
+2. **Take a new full dump** of the restored database to establish a new baseline:
+   ```bash
+   surrealdump -endpoint ws://localhost:8001 -namespace restored -database prod -output new-full.cbor
+   ```
+
+3. **Continue with incremental dumps** based on the new full dump:
+   ```bash
+   surrealdump -incremental -endpoint ws://localhost:8001 -namespace restored -database prod -output new-inc.cbor
+   ```
+
+### Options
+
+- `-endpoint`: SurrealDB server endpoint (default: ws://localhost:8000)
+- `-username`: Authentication username (default: root)
+- `-password`: Authentication password (default: root)
+- `-input`: Input dump file path (required for single file restore)
+- `-incremental`: Perform incremental restore from change feed data
+- `-verbose`: Enable verbose logging for debugging
+- `-validate`: Validate dump chain using manifests (default: true)
+- `-dir`: Directory containing dump chain (shows chain info when used alone, or with -info flag)
+- `-info`: Show dump chain information without restoring (use with -dir)
+- `-latest`: Restore to latest available versionstamp (use with -dir)
+- `-point-in-time`: Restore to specific versionstamp (use with -dir)
+
+## Example Usage
+
+### Creating a Backup and Restore Strategy
+
+```bash
+# Enable Change Feeds first (required for incremental dumps)
+echo "DEFINE DATABASE OVERWRITE prod CHANGEFEED 1h" | surreal sql -e ws://localhost:8000 -u root -p root --ns myapp
+
+# Create initial full backup
+surrealdump -endpoint ws://localhost:8000 -namespace myapp -database prod -dir backups -output full-001.cbor
+
+# Create incremental backups (auto-detects base from directory)
+surrealdump -incremental -namespace myapp -database prod -dir backups -output inc-002.cbor
+surrealdump -incremental -namespace myapp -database prod -dir backups -output inc-003.cbor
+
+# View the backup chain
+surrealrestore -dir backups/
+
+# Restore to a specific point
+surrealrestore -dir backups/ -point-in-time 655360 -endpoint ws://localhost:8001
+
+# Or restore to latest state
+surrealrestore -dir backups/ -latest -endpoint ws://localhost:8001
+
+# Re-enable Change Feeds on restored database for new backup chain
+echo "DEFINE DATABASE OVERWRITE prod CHANGEFEED 1h" | surreal sql -e ws://localhost:8001 -u root -p root --ns myapp
+
+# Start new backup chain from restored database
+surrealdump -endpoint ws://localhost:8001 -namespace myapp -database prod -dir restored-backups -output full-001.cbor
+```
+
+### Manual Step-by-Step Restore
+
+```bash
+# First restore the full dump
+surrealrestore -endpoint ws://localhost:8001 -input backups/full-001.cbor
+
+# Then apply incremental changes in order
+surrealrestore -incremental -endpoint ws://localhost:8001 -input backups/inc-002.cbor
+surrealrestore -incremental -endpoint ws://localhost:8001 -input backups/inc-003.cbor
+```
+
+## Safety Guards
+
+The restore tool includes automatic validation to prevent data corruption:
+- Validates dump type matches restore mode (full vs incremental)
+- Checks versionstamp continuity in dump chains
+- Prevents applying incremental dumps with gaps
+- Ensures namespace/database consistency across dumps
+
+For detailed information about dump chain validation and safety mechanisms, see the [surrealdump design documentation](../surrealdump/docs/design.md).

--- a/contrib/surrealrestore/cmd/surrealexec/main.go
+++ b/contrib/surrealrestore/cmd/surrealexec/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/surrealdb/surrealdb.go"
+)
+
+func main() {
+	if err := Main(); err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func Main() error {
+	var (
+		addr     = flag.String("addr", "ws://localhost:8000/rpc", "SurrealDB address")
+		user     = flag.String("user", "root", "Database user")
+		pass     = flag.String("pass", "root", "Database password")
+		ns       = flag.String("ns", "", "Namespace")
+		db       = flag.String("db", "", "Database")
+		varsFile = flag.String("vars", "", "Variables JSON file")
+		exec     = flag.String("exec", "", "Query to execute")
+	)
+	flag.Parse()
+
+	if *exec == "" {
+		return errors.New("no query provided. Use -exec flag")
+	}
+
+	ctx := context.Background()
+
+	conn, err := initConn(ctx, *addr, *user, *pass, *ns, *db)
+	if err != nil {
+		return fmt.Errorf("failed to initialize connection: %w", err)
+	}
+
+	vars, err := loadVars(*varsFile)
+	if err != nil {
+		return fmt.Errorf("failed to load variables: %w", err)
+	}
+
+	resp, err := surrealdb.Query[any](ctx, conn, *exec, vars)
+	if err != nil {
+		return fmt.Errorf("query failed: %v", err)
+	}
+
+	for _, result := range *resp {
+		if result.Status == "OK" {
+			switch v := result.Result.(type) {
+			case []interface{}:
+				for _, item := range v {
+					if err := printResult(item); err != nil {
+						return err
+					}
+				}
+			case map[string]interface{}:
+				if err := printResult(v); err != nil {
+					return err
+				}
+			default:
+				if v != nil {
+					fmt.Printf("%v\n", v)
+				}
+			}
+		} else {
+			return result.Error
+		}
+	}
+
+	return nil
+}
+
+func initConn(ctx context.Context, addr, user, pass, ns, db string) (*surrealdb.DB, error) {
+	conn, err := surrealdb.FromEndpointURLString(ctx, addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	authData := &surrealdb.Auth{
+		Username: user,
+		Password: pass,
+	}
+	if _, err := conn.SignIn(ctx, authData); err != nil {
+		return nil, fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	if ns != "" && db != "" {
+		if err := conn.Use(ctx, ns, db); err != nil {
+			return nil, fmt.Errorf("failed to use namespace/database: %v", err)
+		}
+	}
+
+	return conn, nil
+}
+
+func loadVars(varsFile string) (map[string]any, error) {
+	var vars map[string]any
+	if varsFile != "" {
+		jsonData, err := os.ReadFile(varsFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read variables file: %v", err)
+		}
+
+		if err := json.Unmarshal(jsonData, &vars); err != nil {
+			return nil, fmt.Errorf("failed to parse variables JSON: %v", err)
+		}
+	}
+
+	return vars, nil
+}
+
+func printResult(item interface{}) error {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return fmt.Errorf("failed to marshal result: %v", err)
+	}
+	fmt.Printf("%s\n", data)
+	return nil
+}

--- a/contrib/surrealrestore/cmd/surrealrestore/main.go
+++ b/contrib/surrealrestore/cmd/surrealrestore/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealrestore"
+)
+
+func main() {
+	// Create config with defaults
+	config := surrealrestore.NewConfig()
+
+	// Parse command-line flags into config
+	flag.StringVar(&config.Endpoint, "endpoint", config.Endpoint, "SurrealDB server endpoint")
+	flag.StringVar(&config.Username, "username", config.Username, "Authentication username")
+	flag.StringVar(&config.Password, "password", config.Password, "Authentication password")
+	flag.StringVar(&config.Input, "input", "", "Input file path for single dump restore (use -dir for chain restoration)")
+	flag.BoolVar(&config.Incremental, "incremental", false, "Perform incremental restore (used with -input)")
+	flag.BoolVar(&config.Verbose, "verbose", false, "Enable verbose logging")
+	flag.Uint64Var(&config.PointInTime, "point-in-time", 0, "Restore to specific versionstamp (used with -dir)")
+	flag.StringVar(&config.Dir, "dir", "", "Directory containing dump chain (alternative to -input)")
+	flag.BoolVar(&config.Latest, "latest", false, "Restore to latest available versionstamp (used with -dir)")
+	flag.BoolVar(&config.Info, "info", false, "Show dump chain information only (used with -dir)")
+
+	flag.Parse()
+
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Execute the restore
+	ctx := context.Background()
+	if err := surrealrestore.Do(ctx, config); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/contrib/surrealrestore/config.go
+++ b/contrib/surrealrestore/config.go
@@ -1,0 +1,163 @@
+package surrealrestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// Configuration validation errors
+var (
+	// ErrMutuallyExclusive is returned when both -dir and -input flags are provided
+	ErrMutuallyExclusive = errors.New("-dir and -input are mutually exclusive. Use one or the other.\n" +
+		"  -dir: For point-in-time restoration from a dump chain\n" +
+		"  -input: For restoring a single dump file")
+
+	// ErrNoInput is returned when neither -dir nor -input flags are provided
+	ErrNoInput = errors.New("either -dir or -input must be provided.\nUsage:\n" +
+		"  For single dump: surrealrestore -input dump.cbor\n" +
+		"  For dump chain: surrealrestore -dir /path/to/dumps -latest\n" +
+		"  For chain info: surrealrestore -dir /path/to/dumps -info")
+
+	// ErrInvalidDirFlags is returned when -latest, -point-in-time, or -info are used with -input
+	ErrInvalidDirFlags = errors.New("-latest, -point-in-time, and -info can only be used with -dir")
+
+	// ErrInvalidIncrementalFlag is returned when -incremental is used with -dir
+	ErrInvalidIncrementalFlag = errors.New("-incremental can only be used with -input\n" +
+		"Note: Incremental restoration from chains is automatic based on the selected point-in-time")
+)
+
+// Config holds all configuration for the restore operation
+type Config struct {
+	// Connection settings
+
+	Endpoint string
+	Username string
+	Password string
+
+	// Input options (mutually exclusive: Input OR Dir)
+
+	// Input file path for single dump restore
+	Input string
+	// Directory containing dump chain
+	Dir string
+
+	// Operation flags
+
+	// Namespace to which the database belongs
+	// Defaults to the namespace in the manifest
+	Namespace string
+	// Database to restore
+	// Defaults to the database in the manifest
+	Database string
+
+	// Perform incremental restore (used with Input)
+	Incremental bool
+	// Restore to specific versionstamp (used with Dir)
+	PointInTime uint64
+	// Restore to latest available versionstamp (used with Dir)
+	Latest bool
+	// Show dump chain information only (used with Dir)
+	Info bool
+	// Enable verbose logging
+	Verbose bool
+}
+
+// NewConfig creates a new Config with default values
+func NewConfig() *Config {
+	return &Config{
+		Endpoint: "ws://localhost:8000",
+		Username: "root",
+		Password: "root",
+	}
+}
+
+// Validate validates the configuration
+func (c *Config) Validate() error {
+	// Validate mutually exclusive options
+	if c.Dir != "" && c.Input != "" {
+		return ErrMutuallyExclusive
+	}
+
+	// Validate that at least one is provided
+	if c.Dir == "" && c.Input == "" {
+		return ErrNoInput
+	}
+
+	// Validate flag combinations
+	if c.Input != "" {
+		// With -input, only -incremental and -verbose are valid
+		if c.Latest || c.PointInTime > 0 || c.Info {
+			return ErrInvalidDirFlags
+		}
+	}
+
+	if c.Dir != "" {
+		// With -dir, -incremental is not valid
+		if c.Incremental {
+			return ErrInvalidIncrementalFlag
+		}
+	}
+
+	return nil
+}
+
+// newRestorer creates a new restorer from the configuration
+func newRestorer(ctx context.Context, config *Config) (*Restorer, func(), error) {
+	// Parse URL
+	u, err := url.ParseRequestURI(config.Endpoint)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse server endpoint: %w", err)
+	}
+
+	// Setup connection with surrealcbor
+	conf := connection.NewConfig(u)
+	codec := surrealcbor.New()
+	conf.Marshaler = codec
+	conf.Unmarshaler = codec
+
+	if !config.Verbose {
+		conf.Logger = nil
+	}
+
+	// Use gws connection
+	conn := gws.New(conf)
+
+	// Connect to database
+	db, err := surrealdb.FromConnection(ctx, conn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to SurrealDB: %w", err)
+	}
+
+	// Create cleanup function
+	cleanup := func() {
+		if closeErr := db.Close(ctx); closeErr != nil {
+			log.Printf("Warning: failed to close database connection: %v", closeErr)
+		}
+	}
+
+	// Authenticate
+	_, err = db.SignIn(ctx, surrealdb.Auth{
+		Username: config.Username,
+		Password: config.Password,
+	})
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	// Create restorer
+	restorer := New(db)
+	restorer.Verbose = config.Verbose
+	restorer.Namespace = config.Namespace
+	restorer.Database = config.Database
+
+	return restorer, cleanup, nil
+}

--- a/contrib/surrealrestore/do.go
+++ b/contrib/surrealrestore/do.go
@@ -1,0 +1,217 @@
+package surrealrestore
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+)
+
+// Do executes the restore operation based on the configuration.
+// It performs either:
+//   - Directory-based operation: Restores DB to a specified or latest versionstamp by
+//     replaying full and incremental dumps in creation order
+//   - File-based operation: Applies a specific dump file (full or incremental) to the
+//     target DB. User must ensure correct order (full before incremental) to avoid
+//     inconsistent state
+func Do(ctx context.Context, config *Config) error {
+	// Handle directory-based operations (point-in-time restoration from dump chain)
+	if config.Dir != "" {
+		return performDirectoryRestore(ctx, config)
+	}
+
+	// Handle file-based operations (single dump file restoration)
+	return performFileRestore(ctx, config)
+}
+
+// performDirectoryRestore handles restoration from a directory containing a dump chain.
+// It can restore to a specific versionstamp or the latest available versionstamp.
+func performDirectoryRestore(ctx context.Context, config *Config) error {
+	// If only showing info, display chain information
+	if config.Info || (!config.Latest && config.PointInTime == 0) {
+		return showChainInfo(config.Dir)
+	}
+
+	return performPointInTimeRestore(ctx, config)
+}
+
+// performFileRestore handles restoration from a single dump file.
+// It applies either a full or incremental dump based on the file's manifest.
+func performFileRestore(ctx context.Context, config *Config) error {
+	// Create restorer
+	restorer, cleanup, err := newRestorer(ctx, config)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	startTime := time.Now()
+
+	if config.Incremental {
+		log.Println("Starting incremental restore...")
+		if err := restorer.Incremental(ctx, config.Input); err != nil {
+			return fmt.Errorf("incremental restore failed: %w", err)
+		}
+		log.Printf("Incremental restore completed successfully")
+	} else {
+		log.Println("Starting full database restore...")
+		if err := restorer.Full(ctx, config.Input); err != nil {
+			return fmt.Errorf("full restore failed: %w", err)
+		}
+		log.Printf("Full restore completed successfully")
+	}
+
+	elapsed := time.Since(startTime)
+	stats := restorer.Stats()
+
+	// Display statistics
+	log.Printf("Restore completed in %v", elapsed)
+	if !config.Incremental {
+		log.Printf("Statistics:")
+		log.Printf("  - Records restored: %d", stats.RecordsRestored)
+		log.Printf("  - Tables restored: %d", stats.TablesRestored)
+		log.Printf("  - Namespaces created: %d", stats.NamespacesCreated)
+		log.Printf("  - Databases created: %d", stats.DatabasesCreated)
+	} else {
+		log.Printf("  - Changes applied: %d", stats.ChangesApplied)
+	}
+
+	return nil
+}
+
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func showChainInfo(dir string) error {
+	// Scan, build and validate chains
+	chains, err := surrealdump.ScanChains(dir)
+	if err != nil {
+		return err
+	}
+
+	if len(chains) == 0 {
+		fmt.Println("No valid dump chains found in directory")
+		return nil
+	}
+
+	fmt.Printf("Found %d valid dump chain(s) in %s:\n\n", len(chains), dir)
+
+	for i, chain := range chains {
+		fmt.Printf("Chain %d: %s.%s\n", i+1, chain.FullDump.Namespace, chain.FullDump.Database)
+		fmt.Println("  Dumps:")
+		fmt.Printf("    [FULL] %s (vs: %d)\n", chain.FullDump.Filename, chain.FullDump.EndVersionstamp)
+
+		for _, inc := range chain.IncrementalDumps {
+			fmt.Printf("    [INCR] %s (vs: %d -> %d)\n",
+				inc.Filename, inc.StartVersionstamp, inc.EndVersionstamp)
+		}
+
+		fmt.Printf("\n  Available restore points:\n")
+		points := chain.GetRestorationPoints()
+		for j, vs := range points {
+			marker := ""
+			if j == len(points)-1 {
+				marker = " (latest)"
+			}
+			fmt.Printf("    - Versionstamp %d%s\n", vs, marker)
+		}
+
+		fmt.Printf("\n  Total size: %s\n", formatBytes(chain.TotalSize))
+		fmt.Printf("  ✓ Chain validated successfully\n")
+
+		fmt.Println()
+	}
+
+	fmt.Println("To restore, use one of:")
+	fmt.Printf("  surrealrestore -dir %s -latest\n", dir)
+	fmt.Printf("  surrealrestore -dir %s -point-in-time <versionstamp>\n", dir)
+
+	return nil
+}
+
+func performPointInTimeRestore(ctx context.Context, config *Config) error {
+	// Scan, build, and validate chains
+	chains, err := surrealdump.ScanChains(config.Dir)
+	if err != nil {
+		return err
+	}
+
+	if len(chains) == 0 {
+		return fmt.Errorf("no valid dump chains found in directory")
+	}
+
+	// Use the first valid chain (could be enhanced to let user choose)
+	chain := chains[0]
+
+	// Determine target versionstamp
+	targetVs := config.PointInTime
+	if targetVs == 0 {
+		targetVs = chain.LatestVersionstamp
+		log.Printf("Restoring to latest versionstamp: %d", targetVs)
+	} else {
+		log.Printf("Restoring to versionstamp: %d", targetVs)
+	}
+
+	// Get dumps needed for restoration
+	dumps, err := chain.GetManifestsForVersionstamp(targetVs)
+	if err != nil {
+		return fmt.Errorf("failed to get dumps for versionstamp %d: %w", targetVs, err)
+	}
+
+	log.Printf("Restoring to versionstamp %d using %d dump(s)", targetVs, len(dumps))
+
+	// Create restorer
+	restorer, cleanup, err := newRestorer(ctx, config)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	// Apply dumps in order
+	for i, manifest := range dumps {
+		dumpPath := filepath.Join(config.Dir, manifest.Filename)
+		log.Printf("Applying dump %d/%d: %s", i+1, len(dumps), manifest.Filename)
+
+		file, err := os.Open(dumpPath)
+		if err != nil {
+			return fmt.Errorf("failed to open dump file %s: %w", dumpPath, err)
+		}
+
+		if i == 0 {
+			// First dump is always full
+			if err := restorer.fullFromManifest(ctx, dumpPath, manifest); err != nil {
+				file.Close()
+				return fmt.Errorf("failed to restore full dump: %w", err)
+			}
+		} else {
+			// Subsequent dumps are incremental
+			if err := restorer.incrementalFromManifest(ctx, dumpPath, manifest); err != nil {
+				file.Close()
+				return fmt.Errorf("failed to apply incremental dump: %w", err)
+			}
+		}
+
+		file.Close()
+	}
+
+	stats := restorer.Stats()
+	log.Printf("Point-in-time restore completed to versionstamp %d", targetVs)
+	log.Printf("  Records restored: %d", stats.RecordsRestored)
+	log.Printf("  Changes applied:  %d", stats.ChangesApplied)
+
+	return nil
+}

--- a/contrib/surrealrestore/dump_and_restore_test.go
+++ b/contrib/surrealrestore/dump_and_restore_test.go
@@ -1,0 +1,472 @@
+package surrealrestore_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealrestore"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// Product represents a product in our test database
+type Product struct {
+	ID          string    `json:"id,omitempty"`
+	Name        string    `json:"name"`
+	Price       float64   `json:"price"`
+	Category    string    `json:"category"`
+	InStock     bool      `json:"in_stock"`
+	LastUpdated time.Time `json:"last_updated"`
+}
+
+// Order represents an order in our test database
+type Order struct {
+	ID         string    `json:"id,omitempty"`
+	ProductID  string    `json:"product_id"`
+	Quantity   int       `json:"quantity"`
+	Total      float64   `json:"total"`
+	OrderDate  time.Time `json:"order_date"`
+	CustomerID string    `json:"customer_id"`
+}
+
+func setupTestDB(t *testing.T) (*surrealdb.DB, context.Context) {
+	ctx := context.Background()
+
+	// Setup connection with surrealcbor
+	conf := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
+	codec := surrealcbor.New()
+	conf.Marshaler = codec
+	conf.Unmarshaler = codec
+	conf.Logger = nil
+
+	// Use gws connection
+	conn := gws.New(conf)
+	db, err := surrealdb.FromConnection(ctx, conn)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+
+	return db, ctx
+}
+
+//nolint:gocyclo // End-to-end test requires comprehensive validation
+func TestDumpAndRestore(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	// Initialize source database
+	sourceDB, err := testenv.Init(db, "e2e_test", "source_db", "products", "orders")
+	if err != nil {
+		t.Fatalf("Failed to init source db: %v", err)
+	}
+
+	// Create test data
+	products := []Product{
+		{Name: "Laptop", Price: 999.99, Category: "Electronics", InStock: true, LastUpdated: time.Now()},
+		{Name: "Mouse", Price: 29.99, Category: "Electronics", InStock: true, LastUpdated: time.Now()},
+		{Name: "Keyboard", Price: 79.99, Category: "Electronics", InStock: false, LastUpdated: time.Now()},
+		{Name: "Monitor", Price: 299.99, Category: "Electronics", InStock: true, LastUpdated: time.Now()},
+		{Name: "Desk", Price: 499.99, Category: "Furniture", InStock: true, LastUpdated: time.Now()},
+	}
+
+	var insertedProducts []Product
+	for _, p := range products {
+		result, insertErr := surrealdb.Insert[Product](ctx, sourceDB, "products", p)
+		if insertErr != nil {
+			t.Fatalf("Failed to insert product: %v", insertErr)
+		}
+		if result != nil && len(*result) > 0 {
+			insertedProducts = append(insertedProducts, (*result)[0])
+		}
+	}
+
+	// Create orders referencing products
+	orders := []Order{
+		{ProductID: insertedProducts[0].ID, Quantity: 2, Total: 1999.98, OrderDate: time.Now(), CustomerID: "customer:1"},
+		{ProductID: insertedProducts[1].ID, Quantity: 5, Total: 149.95, OrderDate: time.Now(), CustomerID: "customer:2"},
+		{ProductID: insertedProducts[2].ID, Quantity: 1, Total: 79.99, OrderDate: time.Now(), CustomerID: "customer:1"},
+	}
+
+	for _, o := range orders {
+		_, orderErr := surrealdb.Insert[Order](ctx, sourceDB, "orders", o)
+		if orderErr != nil {
+			t.Fatalf("Failed to insert order: %v", orderErr)
+		}
+	}
+
+	// Perform full dump (current namespace/database was set by testenv.Init)
+	tempDir := t.TempDir()
+	dumpPath := filepath.Join(tempDir, "dump.cbor")
+	dumper := surrealdump.New(sourceDB, "e2e_test", "source_db")
+	if fullErr := dumper.Full(ctx, dumpPath); fullErr != nil {
+		t.Fatalf("Full dump failed: %v", fullErr)
+	}
+
+	// Check dump size for logging
+	if fileInfo, statErr := os.Stat(dumpPath); statErr == nil {
+		t.Logf("Full dump size: %d bytes", fileInfo.Size())
+	}
+
+	// Create a new connection for target database
+	targetDB, ctx2 := setupTestDB(t)
+	defer targetDB.Close(ctx2)
+
+	// Initialize target database (different namespace/database to ensure it's clean)
+	targetDB, err = testenv.Init(targetDB, "e2e_restore_test", "restored_db")
+	if err != nil {
+		t.Fatalf("Failed to init target db: %v", err)
+	}
+
+	// Clean any existing data in the namespace we're about to restore
+	if useErr := targetDB.Use(ctx2, "e2e_test", "source_db"); useErr == nil {
+		// If it exists, clean all tables
+		targetDB, _ = testenv.Init(targetDB, "e2e_test", "source_db")
+	}
+
+	// Restore from dump file - this is the new simpler API
+	restorer := surrealrestore.New(targetDB)
+
+	if restoreErr := restorer.Full(ctx2, dumpPath); restoreErr != nil {
+		t.Fatalf("Full restore failed: %v", restoreErr)
+	}
+
+	stats := restorer.Stats()
+	t.Logf("Restore stats: Records=%d, Tables=%d", stats.RecordsRestored, stats.TablesRestored)
+
+	// Verify restored data with SELECT queries
+	// Switch to restored namespace/database
+	if switchErr := targetDB.Use(ctx2, "e2e_test", "source_db"); switchErr != nil {
+		t.Fatalf("Failed to use restored db: %v", switchErr)
+	}
+
+	// Query 1: Count products
+	type CountResult struct {
+		Count int `json:"count"`
+	}
+	countResult, err := surrealdb.Query[[]CountResult](ctx2, targetDB, "SELECT count() as count FROM products GROUP ALL", nil)
+	if err != nil {
+		t.Fatalf("Failed to count products: %v", err)
+	}
+	if len(*countResult) > 0 && len((*countResult)[0].Result) > 0 {
+		count := (*countResult)[0].Result[0].Count
+		if count != len(products) {
+			t.Errorf("Product count mismatch: expected %d, got %d", len(products), count)
+		}
+	} else {
+		t.Error("No count result returned")
+	}
+
+	// Query 2: Select all products
+	productsResult, err := surrealdb.Query[[]Product](ctx2, targetDB, "SELECT * FROM products", nil)
+	if err != nil {
+		t.Fatalf("Failed to select products: %v", err)
+	}
+	if len(*productsResult) > 0 && len((*productsResult)[0].Result) != len(products) {
+		t.Errorf("Products mismatch: expected %d, got %d", len(products), len((*productsResult)[0].Result))
+	}
+
+	// Query 3: Check specific product
+	laptopResult, err := surrealdb.Query[[]Product](ctx2, targetDB,
+		"SELECT * FROM products WHERE name = 'Laptop'", nil)
+	if err != nil {
+		t.Fatalf("Failed to query laptop: %v", err)
+	}
+	if len(*laptopResult) > 0 && len((*laptopResult)[0].Result) > 0 {
+		laptop := (*laptopResult)[0].Result[0]
+		if laptop.Price != 999.99 {
+			t.Errorf("Laptop price mismatch: expected 999.99, got %f", laptop.Price)
+		}
+		if laptop.Category != "Electronics" {
+			t.Errorf("Laptop category mismatch: expected Electronics, got %s", laptop.Category)
+		}
+	}
+
+	// Query 4: Count orders
+	orderCountResult, err := surrealdb.Query[[]CountResult](ctx2, targetDB, "SELECT count() as count FROM orders GROUP ALL", nil)
+	if err != nil {
+		t.Fatalf("Failed to count orders: %v", err)
+	}
+	if len(*orderCountResult) > 0 && len((*orderCountResult)[0].Result) > 0 {
+		count := (*orderCountResult)[0].Result[0].Count
+		if count != len(orders) {
+			t.Errorf("Order count mismatch: expected %d, got %d", len(orders), count)
+		}
+	}
+
+	// Query 5: Check relationships
+	orderResult, err := surrealdb.Query[[]Order](ctx2, targetDB,
+		"SELECT * FROM orders WHERE customer_id = 'customer:1'", nil)
+	if err != nil {
+		t.Fatalf("Failed to query customer orders: %v", err)
+	}
+	if len(*orderResult) > 0 && len((*orderResult)[0].Result) != 2 {
+		t.Errorf("Customer 1 orders mismatch: expected 2, got %d", len((*orderResult)[0].Result))
+	}
+
+	// Query 6: Aggregate query
+	type CategoryCount struct {
+		Category string `json:"category"`
+		Count    int    `json:"count"`
+	}
+	aggResult, err := surrealdb.Query[[]CategoryCount](ctx2, targetDB,
+		"SELECT category, count() as count FROM products GROUP BY category", nil)
+	if err != nil {
+		t.Fatalf("Failed to run aggregate query: %v", err)
+	}
+	if len(*aggResult) > 0 {
+		for _, cc := range (*aggResult)[0].Result {
+			t.Logf("Category %s has %d products", cc.Category, cc.Count)
+			if cc.Category == "Electronics" && cc.Count != 4 {
+				t.Errorf("Electronics count mismatch: expected 4, got %d", cc.Count)
+			}
+			if cc.Category == "Furniture" && cc.Count != 1 {
+				t.Errorf("Furniture count mismatch: expected 1, got %d", cc.Count)
+			}
+		}
+	}
+}
+
+//nolint:gocyclo // End-to-end test requires comprehensive validation
+func TestE2E_IncrementalDumpAndRestore(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	// Initialize database with change feed
+	sourceDB, err := testenv.Init(db, "e2e_incr", "source_db", "products")
+	if err != nil {
+		t.Fatalf("Failed to init source db: %v", err)
+	}
+
+	// Enable change feed
+	_, err = surrealdb.Query[any](ctx, sourceDB, "DEFINE TABLE products CHANGEFEED 1h", nil)
+	if err != nil {
+		t.Fatalf("Failed to enable change feed: %v", err)
+	}
+
+	// Initial data
+	initialProducts := []Product{
+		{Name: "Phone", Price: 599.99, Category: "Electronics", InStock: true, LastUpdated: time.Now()},
+		{Name: "Tablet", Price: 399.99, Category: "Electronics", InStock: true, LastUpdated: time.Now()},
+	}
+
+	for _, p := range initialProducts {
+		_, insertErr := surrealdb.Insert[Product](ctx, sourceDB, "products", p)
+		if insertErr != nil {
+			t.Fatalf("Failed to insert product: %v", insertErr)
+		}
+	}
+
+	// Perform initial full dump (current namespace/database was set by testenv.Init)
+	tempDir := t.TempDir()
+	fullDumpPath := filepath.Join(tempDir, "full.cbor")
+	dumper := surrealdump.New(sourceDB, "e2e_incr", "source_db")
+	if fullErr := dumper.Full(ctx, fullDumpPath); fullErr != nil {
+		t.Fatalf("Full dump failed: %v", fullErr)
+	}
+
+	// Check what changes are in the full dump
+	t.Logf("Full dump completed, checking for changes included in dump...")
+
+	// Get the versionstamp from full dump manifest
+	fullDumpData, err := os.ReadFile(fullDumpPath)
+	if err != nil {
+		t.Fatalf("Failed to read full dump: %v", err)
+	}
+	manifest, err := surrealdump.ReadManifest(fullDumpPath)
+	if err != nil {
+		t.Fatalf("Failed to read manifest: %v", err)
+	}
+	baseVersionstamp := manifest.EndVersionstamp
+	t.Logf("Base versionstamp from full dump: %d", baseVersionstamp)
+	t.Logf("Full dump start versionstamp: %d, end versionstamp: %d", manifest.StartVersionstamp, manifest.EndVersionstamp)
+
+	// Wait a moment to ensure change feed is ready
+	time.Sleep(100 * time.Millisecond)
+
+	// Make changes after the full dump
+	// Update a product
+	_, err = surrealdb.Query[any](ctx, sourceDB,
+		"UPDATE products SET price = 549.99 WHERE name = 'Phone'", nil)
+	if err != nil {
+		t.Fatalf("Failed to update product: %v", err)
+	}
+
+	// Add a new product
+	newProduct := Product{
+		Name: "Smartwatch", Price: 299.99, Category: "Electronics", InStock: true, LastUpdated: time.Now(),
+	}
+	_, err = surrealdb.Insert[Product](ctx, sourceDB, "products", newProduct)
+	if err != nil {
+		t.Fatalf("Failed to insert new product: %v", err)
+	}
+
+	// Delete a product
+	_, err = surrealdb.Query[any](ctx, sourceDB,
+		"DELETE products WHERE name = 'Tablet'", nil)
+	if err != nil {
+		t.Fatalf("Failed to delete product: %v", err)
+	}
+
+	// Wait to ensure changes are committed
+	time.Sleep(100 * time.Millisecond)
+
+	// Get current versionstamp after making changes
+	currentVs, _ := surrealdb.Query[[]map[string]any](ctx, sourceDB,
+		"SHOW CHANGES FOR TABLE products SINCE 0 LIMIT 1", nil)
+	if currentVs != nil && len(*currentVs) > 0 && len((*currentVs)[0].Result) > 0 {
+		if vs, ok := (*currentVs)[0].Result[0]["versionstamp"].(float64); ok {
+			t.Logf("Current versionstamp after changes: %d", uint64(vs))
+		}
+	}
+
+	// Use a slightly earlier versionstamp to ensure overlap
+	// This is safe as overlapping changes will be replayed correctly
+	incrStartVersionstamp := baseVersionstamp
+	if baseVersionstamp > 0 {
+		// Go back slightly to ensure we capture all changes
+		incrStartVersionstamp = baseVersionstamp - 1
+	}
+
+	// Create incremental dump
+	incrDumpPath := filepath.Join(tempDir, "incr.cbor")
+	t.Logf("Creating incremental dump starting from versionstamp: %d", incrStartVersionstamp)
+	if incrErr := dumper.Incremental(ctx, incrDumpPath, incrStartVersionstamp); incrErr != nil {
+		t.Fatalf("Incremental dump failed: %v", incrErr)
+	}
+
+	incrDumpData, err := os.ReadFile(incrDumpPath)
+	if err != nil {
+		t.Fatalf("Failed to read incremental dump: %v", err)
+	}
+
+	t.Logf("Full dump size: %d bytes", len(fullDumpData))
+	t.Logf("Incremental dump size: %d bytes", len(incrDumpData))
+
+	// Check what's in the incremental dump
+	t.Logf("Checking for changes in products table since versionstamp %d", incrStartVersionstamp)
+	result, err := surrealdb.Query[[]map[string]any](ctx, sourceDB,
+		fmt.Sprintf("SHOW CHANGES FOR TABLE products SINCE %d", incrStartVersionstamp), nil)
+	if err != nil {
+		t.Logf("Error getting changes: %v", err)
+	} else if result != nil && len(*result) > 0 {
+		t.Logf("Changes found in table: %d entries", len((*result)[0].Result))
+		for i, change := range (*result)[0].Result {
+			if i < 5 { // Log first 5 changes
+				t.Logf("  Change %d: %v", i, change)
+			}
+		}
+	} else {
+		t.Logf("No changes found in table")
+	}
+
+	// Create target database and restore
+	targetDB, ctx2 := setupTestDB(t)
+	defer targetDB.Close(ctx2)
+
+	targetDB, err = testenv.Init(targetDB, "e2e_incr_restored", "target_db")
+	if err != nil {
+		t.Fatalf("Failed to init target db: %v", err)
+	}
+
+	// Clean any existing data in the namespace we're about to restore
+	if useErr := targetDB.Use(ctx2, "e2e_incr", "source_db"); useErr == nil {
+		// If it exists, clean all tables
+		targetDB, _ = testenv.Init(targetDB, "e2e_incr", "source_db")
+	}
+
+	// First restore the full dump using the simplified API
+	fullRestorer := surrealrestore.New(targetDB)
+	if fullRestoreErr := fullRestorer.Full(ctx2, fullDumpPath); fullRestoreErr != nil {
+		t.Fatalf("Full restore failed: %v", fullRestoreErr)
+	}
+
+	// Then apply incremental changes using the simplified API
+	incrRestorer := surrealrestore.New(targetDB)
+	incrRestorer.Verbose = true // Enable verbose to see what's happening
+	if incrRestoreErr := incrRestorer.Incremental(ctx2, incrDumpPath); incrRestoreErr != nil {
+		t.Fatalf("Incremental restore failed: %v", incrRestoreErr)
+	}
+
+	t.Logf("Changes applied: %d", incrRestorer.Stats().ChangesApplied)
+
+	// Verify final state with SELECT queries
+	if switchErr := targetDB.Use(ctx2, "e2e_incr", "source_db"); switchErr != nil {
+		t.Fatalf("Failed to use restored db: %v", switchErr)
+	}
+
+	// Query 1: Count should be 2 (initial 2 + 1 new - 1 deleted)
+	type CountResult struct {
+		Count int `json:"count"`
+	}
+	countResult, err := surrealdb.Query[[]CountResult](ctx2, targetDB,
+		"SELECT count() as count FROM products GROUP ALL", nil)
+	if err != nil {
+		t.Fatalf("Failed to count products: %v", err)
+	}
+	if len(*countResult) > 0 && len((*countResult)[0].Result) > 0 {
+		count := (*countResult)[0].Result[0].Count
+		if count != 2 {
+			t.Errorf("Product count after incremental: expected 2, got %d", count)
+		}
+	}
+
+	// Query 2: Phone should have updated price
+	phoneResult, err := surrealdb.Query[[]Product](ctx2, targetDB,
+		"SELECT * FROM products WHERE name = 'Phone'", nil)
+	if err != nil {
+		t.Fatalf("Failed to query phone: %v", err)
+	}
+	if len(*phoneResult) > 0 {
+		t.Logf("Found %d phone records", len((*phoneResult)[0].Result))
+		for _, phone := range (*phoneResult)[0].Result {
+			t.Logf("  Phone ID: %s, Price: %.2f", phone.ID, phone.Price)
+		}
+		if len((*phoneResult)[0].Result) > 0 {
+			phone := (*phoneResult)[0].Result[0]
+			if phone.Price != 549.99 {
+				t.Errorf("Phone price not updated: expected 549.99, got %f", phone.Price)
+			}
+		}
+	}
+
+	// Query 3: Tablet should be deleted
+	tabletResult, err := surrealdb.Query[[]Product](ctx2, targetDB,
+		"SELECT * FROM products WHERE name = 'Tablet'", nil)
+	if err != nil {
+		t.Fatalf("Failed to query tablet: %v", err)
+	}
+	if len(*tabletResult) > 0 && len((*tabletResult)[0].Result) > 0 {
+		t.Error("Tablet should have been deleted")
+	}
+
+	// Query 4: Smartwatch should exist
+	watchResult, err := surrealdb.Query[[]Product](ctx2, targetDB,
+		"SELECT * FROM products WHERE name = 'Smartwatch'", nil)
+	if err != nil {
+		t.Fatalf("Failed to query smartwatch: %v", err)
+	}
+	if len(*watchResult) > 0 && len((*watchResult)[0].Result) != 1 {
+		t.Error("Smartwatch should exist after incremental restore")
+	}
+
+	// Query 5: List all products
+	allProducts, err := surrealdb.Query[[]Product](ctx2, targetDB,
+		"SELECT name, price FROM products ORDER BY name", nil)
+	if err != nil {
+		t.Fatalf("Failed to list all products: %v", err)
+	}
+	if len(*allProducts) > 0 {
+		t.Log("Final products after incremental restore:")
+		for _, p := range (*allProducts)[0].Result {
+			t.Logf("  - %s: $%.2f", p.Name, p.Price)
+		}
+	}
+}

--- a/contrib/surrealrestore/format_bytes_test.go
+++ b/contrib/surrealrestore/format_bytes_test.go
@@ -1,0 +1,165 @@
+package surrealrestore
+
+import (
+	"testing"
+)
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    int64
+		expected string
+	}{
+		{
+			name:     "Zero bytes",
+			bytes:    0,
+			expected: "0 B",
+		},
+		{
+			name:     "Less than 1KB",
+			bytes:    512,
+			expected: "512 B",
+		},
+		{
+			name:     "Exactly 1KB",
+			bytes:    1024,
+			expected: "1.0 KB",
+		},
+		{
+			name:     "1.5KB",
+			bytes:    1536,
+			expected: "1.5 KB",
+		},
+		{
+			name:     "Exactly 1MB",
+			bytes:    1024 * 1024,
+			expected: "1.0 MB",
+		},
+		{
+			name:     "2.5MB",
+			bytes:    int64(2.5 * 1024 * 1024),
+			expected: "2.5 MB",
+		},
+		{
+			name:     "Exactly 1GB",
+			bytes:    1024 * 1024 * 1024,
+			expected: "1.0 GB",
+		},
+		{
+			name:     "1.7GB",
+			bytes:    1825361101, // approximately 1.7GB
+			expected: "1.7 GB",
+		},
+		{
+			name:     "Exactly 1TB",
+			bytes:    1024 * 1024 * 1024 * 1024,
+			expected: "1.0 TB",
+		},
+		{
+			name:     "2.3TB",
+			bytes:    2528876025856, // approximately 2.3TB
+			expected: "2.3 TB",
+		},
+		{
+			name:     "Exactly 1PB",
+			bytes:    1024 * 1024 * 1024 * 1024 * 1024,
+			expected: "1.0 PB",
+		},
+		{
+			name:     "1.5PB",
+			bytes:    1688849860263936, // approximately 1.5PB
+			expected: "1.5 PB",
+		},
+		{
+			name:     "Exactly 1EB",
+			bytes:    1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+			expected: "1.0 EB",
+		},
+		{
+			name:     "999 bytes",
+			bytes:    999,
+			expected: "999 B",
+		},
+		{
+			name:     "1023 bytes",
+			bytes:    1023,
+			expected: "1023 B",
+		},
+		{
+			name:     "10.5KB",
+			bytes:    10752,
+			expected: "10.5 KB",
+		},
+		{
+			name:     "100.1MB",
+			bytes:    104962458, // approximately 100.1MB
+			expected: "100.1 MB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatBytes(tt.bytes)
+			if result != tt.expected {
+				t.Errorf("formatBytes(%d) = %s; want %s", tt.bytes, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatBytesEdgeCases(t *testing.T) {
+	// Test boundary values
+	testCases := []struct {
+		name     string
+		bytes    int64
+		expected string
+	}{
+		{
+			name:     "Just below 1KB",
+			bytes:    1023,
+			expected: "1023 B",
+		},
+		{
+			name:     "Just above 1KB",
+			bytes:    1025,
+			expected: "1.0 KB",
+		},
+		{
+			name:     "Just below 1MB",
+			bytes:    1024*1024 - 1,
+			expected: "1024.0 KB",
+		},
+		{
+			name:     "Just above 1MB",
+			bytes:    1024*1024 + 1,
+			expected: "1.0 MB",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := formatBytes(tc.bytes)
+			if result != tc.expected {
+				t.Errorf("formatBytes(%d) = %s; want %s", tc.bytes, result, tc.expected)
+			}
+		})
+	}
+}
+
+func BenchmarkFormatBytes(b *testing.B) {
+	sizes := []int64{
+		512,                       // 512 B
+		1024,                      // 1 KB
+		1024 * 1024,               // 1 MB
+		1024 * 1024 * 1024,        // 1 GB
+		1024 * 1024 * 1024 * 1024, // 1 TB
+	}
+
+	for _, size := range sizes {
+		b.Run(formatBytes(size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = formatBytes(size)
+			}
+		})
+	}
+}

--- a/contrib/surrealrestore/restore.go
+++ b/contrib/surrealrestore/restore.go
@@ -1,0 +1,561 @@
+package surrealrestore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// Alias types from surrealcbor for convenience
+type (
+	Decoder = surrealcbor.Decoder
+)
+
+// Helper functions to create decoder
+var (
+	NewDecoder = surrealcbor.NewDecoder
+)
+
+// RestoreStats tracks restoration statistics
+type RestoreStats struct {
+	RecordsRestored   int
+	TablesRestored    int
+	NamespacesCreated int
+	DatabasesCreated  int
+	ChangesApplied    int
+	StartTime         time.Time
+	EndTime           time.Time
+}
+
+// Restorer handles the database restore process
+type Restorer struct {
+	db    *surrealdb.DB
+	codec *surrealcbor.Codec
+	stats RestoreStats
+
+	Verbose bool
+	// Target namespace for restoration
+	Namespace string
+	// Target database for restoration
+	Database string
+}
+
+// New creates a new Restorer instance
+func New(db *surrealdb.DB) *Restorer {
+	return &Restorer{
+		db:    db,
+		codec: surrealcbor.New(),
+		stats: RestoreStats{
+			StartTime: time.Now(),
+		},
+	}
+}
+
+// SetNamespace sets the target namespace for restoration
+func (r *Restorer) SetNamespace(ns string) {
+	r.Namespace = ns
+}
+
+// SetDatabase sets the target database for restoration
+func (r *Restorer) SetDatabase(db string) {
+	r.Database = db
+}
+
+// SetTarget sets both namespace and database for restoration
+func (r *Restorer) SetTarget(ns, db string) {
+	r.Namespace = ns
+	r.Database = db
+}
+
+// Stats returns the restoration statistics
+func (r *Restorer) Stats() RestoreStats {
+	return r.stats
+}
+
+// fullFromReader performs a full database restore from the reader
+//
+// The dump format no longer includes metadata - it only contains:
+// 1. Magic header
+// 2. Table records (inconsistent full dump)
+// 3. Change entries (to ensure consistency)
+//
+// Namespace and database should be set via SetTarget() or use FullFromManifest()
+//
+//nolint:gocyclo,funlen // Complex restore logic for handling multiple data formats
+func (r *Restorer) fullFromReader(ctx context.Context, currentNamespace, currentDatabase string, reader io.Reader) error {
+	r.stats.StartTime = time.Now()
+
+	// Read magic header
+	magic := make([]byte, len(surrealdump.DumpFormat))
+	if _, err := io.ReadFull(reader, magic); err != nil {
+		return fmt.Errorf("failed to read magic header: %w", err)
+	}
+
+	if string(magic) != surrealdump.DumpFormat {
+		return fmt.Errorf("invalid dump format: expected %s, got %s", surrealdump.DumpFormat, string(magic))
+	}
+
+	decoder := NewDecoder(reader)
+
+	// Track which namespaces/databases we've created
+	createdNS := make(map[string]bool)
+	createdDB := make(map[string]map[string]bool)
+	restoredTables := make(map[string]bool)
+
+	// Buffer changes to apply them after all records
+	var bufferedChanges []struct {
+		Table  string
+		Change surrealdump.Change
+	}
+
+	for {
+		var item any
+		if err := decoder.Decode(&item); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("failed to decode item: %w", err)
+		}
+
+		// Check if this is a map that could be a Record or ChangeEntry
+		if itemMap, ok := item.(map[string]any); ok {
+			// Check if it's a ChangeEntry (has versionstamp and changes)
+			if _, hasVersionstamp := itemMap["versionstamp"]; hasVersionstamp {
+				if _, hasChanges := itemMap["changes"]; hasChanges {
+					// This is a change entry - buffer it to apply after all records
+					if currentNamespace != "" && currentDatabase != "" {
+						entryBytes, err := r.codec.Marshal(item)
+						if err == nil {
+							var entry surrealdump.ChangeEntry
+							if err := r.codec.Unmarshal(entryBytes, &entry); err == nil {
+								// Buffer the changes for later
+								for _, change := range entry.Changes {
+									bufferedChanges = append(bufferedChanges, struct {
+										Table  string
+										Change surrealdump.Change
+									}{
+										Table:  entry.Table,
+										Change: change,
+									})
+								}
+							}
+						}
+					}
+					continue
+				}
+			}
+
+			// Check if it has the structure of a Record
+			if _, hasTable := itemMap["table"]; hasTable {
+				if _, hasData := itemMap["data"]; hasData {
+					// This looks like a Record
+					recordBytes, err := r.codec.Marshal(item)
+					if err != nil {
+						if r.Verbose {
+							log.Printf("Failed to marshal record: %v", err)
+						}
+						continue
+					}
+
+					var record surrealdump.Record
+					if err := r.codec.Unmarshal(recordBytes, &record); err != nil {
+						if r.Verbose {
+							log.Printf("Failed to unmarshal record: %v", err)
+						}
+						continue
+					}
+
+					// Ensure we have namespace and database set
+					if currentNamespace == "" || currentDatabase == "" {
+						if r.Verbose {
+							log.Printf("Warning: No namespace/database set, skipping record")
+						}
+						continue
+					}
+
+					// Ensure namespace and database exist
+					r.ensureNamespaceDatabase(ctx, currentNamespace, currentDatabase, createdNS, createdDB)
+
+					// Switch to the correct namespace and database
+					if err := r.db.Use(ctx, currentNamespace, currentDatabase); err != nil {
+						return fmt.Errorf("failed to use ns/db: %w", err)
+					}
+
+					// Track restored tables
+					tableKey := fmt.Sprintf("%s.%s.%s", currentNamespace, currentDatabase, record.Table)
+					if !restoredTables[tableKey] {
+						restoredTables[tableKey] = true
+						r.stats.TablesRestored++
+
+						if r.Verbose {
+							log.Printf("Restoring table: %s", tableKey)
+						}
+					}
+
+					// Restore the record
+					if record.Data != nil {
+						// Always use UPSERT for records from the inconsistent dump
+						// because they might have been partially updated by changes
+						recordID := ""
+						if idVal, ok := record.Data["id"]; ok {
+							recordID = formatRecordID(idVal)
+						}
+
+						var query string
+						if recordID != "" {
+							// Use UPSERT when we have an ID to ensure we update if it exists
+							delete(record.Data, "id") // Remove id from data
+							query = fmt.Sprintf("UPSERT %s SET", recordID)
+						} else {
+							// Use CREATE for records without specific IDs
+							q := surrealql.Create(record.Table)
+							query, _ = q.Build()
+						}
+
+						// Convert map to SET clause (for both CREATE and UPSERT)
+						var setItems []string
+						vars := make(map[string]any)
+						i := 0
+						for k, v := range record.Data {
+							paramName := fmt.Sprintf("param_%d", i)
+							setItems = append(setItems, fmt.Sprintf("%s = $%s", k, paramName))
+							vars[paramName] = v
+							i++
+						}
+
+						if len(setItems) > 0 {
+							query = fmt.Sprintf("%s %s", query, strings.Join(setItems, ", "))
+						}
+
+						_, err := surrealdb.Query[any](ctx, r.db, query, vars)
+						if err != nil {
+							// Try with INSERT if CREATE/UPSERT fails
+							insertQuery := fmt.Sprintf("INSERT INTO %s $data", record.Table)
+							_, err = surrealdb.Query[any](ctx, r.db, insertQuery, map[string]any{
+								"data": record.Data,
+							})
+							if err != nil {
+								return fmt.Errorf("failed to restore record: %w", err)
+							}
+						}
+
+						r.stats.RecordsRestored++
+					}
+					continue
+				}
+			}
+
+			// Note: Dumps no longer contain metadata - namespace/database must be set via SetTarget()
+		}
+	}
+
+	// Now apply all buffered changes AFTER all records have been restored
+	// This ensures changes overwrite the inconsistent dump data
+	if currentNamespace != "" && currentDatabase != "" {
+		if err := r.db.Use(ctx, currentNamespace, currentDatabase); err != nil {
+			return fmt.Errorf("failed to use ns/db for changes: %w", err)
+		}
+
+		for i, bufferedChange := range bufferedChanges {
+			if r.Verbose {
+				if bufferedChange.Change.Update != nil {
+					if id, ok := bufferedChange.Change.Update["id"]; ok {
+						value := bufferedChange.Change.Update["value"]
+						log.Printf("Change %d: Applying UPDATE to %v with value=%v", i+1, formatRecordID(id), value)
+					}
+				} else if bufferedChange.Change.Delete != nil {
+					if id, ok := bufferedChange.Change.Delete["id"]; ok {
+						log.Printf("Change %d: Applying DELETE to %v", i+1, formatRecordID(id))
+					}
+				} else if bufferedChange.Change.DefineTable != nil {
+					log.Printf("Change %d: Defining table %s", i+1, bufferedChange.Change.DefineTable.Name)
+				}
+			}
+			if err := r.applyChange(ctx, bufferedChange.Table, bufferedChange.Change); err != nil {
+				if r.Verbose {
+					log.Printf("Warning: failed to apply buffered change: %v", err)
+				}
+			} else {
+				r.stats.ChangesApplied++
+			}
+		}
+	}
+
+	r.stats.EndTime = time.Now()
+	return nil
+}
+
+// incrementalFromReader applies incremental changes from the reader
+//
+// Namespace and database should be set via SetTarget() or use IncrementalFromManifest()
+//
+//nolint:gocyclo // Complex logic for processing incremental changes
+func (r *Restorer) incrementalFromReader(ctx context.Context, currentNamespace, currentDatabase string, reader io.Reader) error {
+	// Read magic header
+	magic := make([]byte, 8) // "SURINC01"
+	if _, err := io.ReadFull(reader, magic); err != nil {
+		return fmt.Errorf("failed to read magic header: %w", err)
+	}
+
+	if string(magic) != "SURINC01" {
+		return fmt.Errorf("invalid incremental dump format: %s", string(magic))
+	}
+
+	decoder := NewDecoder(reader)
+
+	for {
+		var item any
+		if err := decoder.Decode(&item); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("failed to decode item: %w", err)
+		}
+
+		// Try to decode as ChangeEntry
+		entryBytes, err := r.codec.Marshal(item)
+		if err != nil {
+			continue // Might be metadata
+		}
+
+		var entry surrealdump.ChangeEntry
+		if err := r.codec.Unmarshal(entryBytes, &entry); err == nil {
+			// Use namespace and database from metadata
+			if currentNamespace != "" && currentDatabase != "" {
+				// Switch to the correct namespace and database
+				if err := r.db.Use(ctx, currentNamespace, currentDatabase); err != nil {
+					return fmt.Errorf("failed to use ns/db: %w", err)
+				}
+
+				// Apply each change
+				for _, change := range entry.Changes {
+					if err := r.applyChange(ctx, entry.Table, change); err != nil {
+						if r.Verbose {
+							log.Printf("Warning: failed to apply change: %v", err)
+						}
+						// Continue with other changes even if one fails
+					} else {
+						r.stats.ChangesApplied++
+					}
+				}
+			}
+		}
+
+		// Check if this is metadata to extract namespace/database
+		if itemMap, ok := item.(map[string]any); ok {
+			if _, hasFormat := itemMap["format"]; hasFormat {
+				if _, hasVersion := itemMap["version"]; hasVersion {
+					// This is metadata - extract namespace and database
+					if ns, ok := itemMap["namespace"].(string); ok {
+						currentNamespace = ns
+					}
+					if db, ok := itemMap["database"].(string); ok {
+						currentDatabase = db
+					}
+					if r.Verbose {
+						log.Printf("Found incremental metadata: namespace=%s, database=%s", currentNamespace, currentDatabase)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Restorer) ensureNamespaceDatabase(ctx context.Context, ns, db string,
+	createdNS map[string]bool, createdDB map[string]map[string]bool) {
+	// Create namespace if not exists
+	if !createdNS[ns] {
+		query := fmt.Sprintf("DEFINE NAMESPACE IF NOT EXISTS %s", ns)
+		if _, err := surrealdb.Query[any](ctx, r.db, query, nil); err != nil {
+			// Namespace might already exist, which is fine
+			if r.Verbose {
+				log.Printf("Note: namespace %s might already exist", ns)
+			}
+		} else {
+			r.stats.NamespacesCreated++
+		}
+		createdNS[ns] = true
+		createdDB[ns] = make(map[string]bool)
+	}
+
+	// Create database if not exists
+	if !createdDB[ns][db] {
+		// First use the namespace
+		if err := r.db.Use(ctx, ns, "temp"); err != nil {
+			// Try without temp db
+			_ = r.db.Use(ctx, ns, db)
+		}
+
+		query := fmt.Sprintf("DEFINE DATABASE IF NOT EXISTS %s", db)
+		if _, err := surrealdb.Query[any](ctx, r.db, query, nil); err != nil {
+			// Database might already exist, which is fine
+			if r.Verbose {
+				log.Printf("Note: database %s.%s might already exist", ns, db)
+			}
+		} else {
+			r.stats.DatabasesCreated++
+		}
+		createdDB[ns][db] = true
+	}
+}
+
+// formatRecordID converts a record ID from various formats to the correct string format
+// e.g., from {products rwlrtb90sr1n5tslp5m8} to products:rwlrtb90sr1n5tslp5m8
+func formatRecordID(id any) string {
+	idStr := fmt.Sprintf("%v", id)
+	// Check if it's in the format {table id}
+	if strings.HasPrefix(idStr, "{") && strings.HasSuffix(idStr, "}") {
+		// Remove braces and split by space
+		idStr = strings.TrimPrefix(idStr, "{")
+		idStr = strings.TrimSuffix(idStr, "}")
+		parts := strings.Fields(idStr)
+		if len(parts) == 2 {
+			// Convert to table:id format
+			return fmt.Sprintf("%s:%s", parts[0], parts[1])
+		}
+	}
+	// If it's already in the correct format or unknown, return as is
+	return idStr
+}
+
+func (r *Restorer) applyChange(ctx context.Context, _ string, change surrealdump.Change) error {
+	if change.DefineTable != nil {
+		// Define table
+		query := fmt.Sprintf("DEFINE TABLE IF NOT EXISTS %s", change.DefineTable.Name)
+		_, err := surrealdb.Query[any](ctx, r.db, query, nil)
+		return err
+	}
+
+	if change.Update != nil {
+		// Apply update (which could be a create or update)
+		if id, ok := change.Update["id"]; ok {
+			delete(change.Update, "id") // Remove id from data
+
+			// Format the ID correctly (convert from map format to string)
+			idStr := formatRecordID(id)
+
+			// Always use UPSERT for changes to handle both create and update cases
+			// This ensures we replace all fields with the change feed data
+			query := fmt.Sprintf("UPSERT %s SET", idStr)
+
+			// Convert map to SET clause
+			var setItems []string
+			vars := make(map[string]any)
+			i := 0
+			for k, v := range change.Update {
+				paramName := fmt.Sprintf("upd_param_%d", i)
+				setItems = append(setItems, fmt.Sprintf("%s = $%s", k, paramName))
+				vars[paramName] = v
+				i++
+			}
+
+			if len(setItems) > 0 {
+				query = fmt.Sprintf("%s %s", query, strings.Join(setItems, ", "))
+			}
+
+			_, err := surrealdb.Query[any](ctx, r.db, query, vars)
+			return err
+		}
+		return fmt.Errorf("update change missing id field")
+	}
+
+	if change.Delete != nil {
+		// Apply delete
+		if id, ok := change.Delete["id"]; ok {
+			idStr := formatRecordID(id)
+			q := surrealql.Delete(idStr)
+			query, _ := q.Build()
+
+			_, err := surrealdb.Query[any](ctx, r.db, query, nil)
+			return err
+		}
+		return fmt.Errorf("delete change missing id field")
+	}
+
+	return nil
+}
+
+// Full performs a full database restore from a dump file path
+// It automatically reads the manifest and restores the data to the appropriate namespace/database
+func (r *Restorer) Full(ctx context.Context, dumpPath string) error {
+	// Read the manifest
+	manifest, err := surrealdump.ReadManifest(dumpPath)
+	if err != nil {
+		return fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	return r.fullFromManifest(ctx, dumpPath, manifest)
+}
+
+func (r *Restorer) fullFromManifest(ctx context.Context, dumpPath string, manifest *surrealdump.Manifest) error {
+	// Verify it's a full dump
+	if manifest.Type != surrealdump.ManifestTypeFull {
+		return fmt.Errorf("expected full dump but got %s", manifest.Type)
+	}
+
+	ns, db, file, err := r.initRestore(dumpPath, manifest)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return r.fullFromReader(ctx, ns, db, file)
+}
+
+// Incremental performs an incremental restore from a dump file path
+// It automatically reads the manifest and applies the changes to the appropriate namespace/database
+func (r *Restorer) Incremental(ctx context.Context, dumpPath string) error {
+	// Read the manifest
+	manifest, err := surrealdump.ReadManifest(dumpPath)
+	if err != nil {
+		return fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	return r.incrementalFromManifest(ctx, dumpPath, manifest)
+}
+
+func (r *Restorer) incrementalFromManifest(ctx context.Context, dumpPath string, manifest *surrealdump.Manifest) error {
+	// Verify it's an incremental dump
+	if manifest.Type != surrealdump.ManifestTypeIncremental {
+		return fmt.Errorf("expected incremental dump but got %s", manifest.Type)
+	}
+
+	ns, db, file, err := r.initRestore(dumpPath, manifest)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return r.incrementalFromReader(ctx, ns, db, file)
+}
+
+func (r *Restorer) initRestore(dumpPath string, manifest *surrealdump.Manifest) (ns, db string, dumpFile *os.File, err error) {
+	ns = r.Namespace
+	if ns == "" {
+		ns = manifest.Namespace
+	}
+
+	db = r.Database
+	if db == "" {
+		db = manifest.Database
+	}
+
+	// Open the dump file
+	file, err := os.Open(dumpPath)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to open dump file: %w", err)
+	}
+
+	return ns, db, file, nil
+}

--- a/contrib/surrealrestore/restore_test.go
+++ b/contrib/surrealrestore/restore_test.go
@@ -1,0 +1,173 @@
+package surrealrestore_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealdump"
+	"github.com/surrealdb/surrealdb.go/contrib/surrealrestore"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+//nolint:gocyclo // Test requires complex validation of different dump formats
+func TestRestorerFull(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup connection for source
+	conf := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
+	codec := surrealcbor.New()
+	conf.Marshaler = codec
+	conf.Unmarshaler = codec
+	conf.Logger = nil
+
+	conn := gws.New(conf)
+	sourceConn, err := surrealdb.FromConnection(ctx, conn)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer sourceConn.Close(ctx)
+
+	// Create source database with test data
+	sourceDB, err := testenv.Init(sourceConn, "simple_test", "source", "test_table")
+	if err != nil {
+		t.Fatalf("Failed to init source db: %v", err)
+	}
+
+	// Insert test data
+	type TestRecord struct {
+		ID   string `json:"id,omitempty"`
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	records := []TestRecord{
+		{Name: "Alice", Age: 30},
+		{Name: "Bob", Age: 25},
+		{Name: "Charlie", Age: 35},
+	}
+
+	for _, r := range records {
+		_, insertErr := surrealdb.Insert[TestRecord](ctx, sourceDB, "test_table", r)
+		if insertErr != nil {
+			t.Fatalf("Failed to insert record: %v", insertErr)
+		}
+	}
+
+	// Create dump (the current namespace/database was already set by testenv.Init)
+	tempDir := t.TempDir()
+	dumpPath := filepath.Join(tempDir, "dump.cbor")
+	dumper := surrealdump.New(sourceDB, "simple_test", "source")
+	if dumpErr := dumper.Full(ctx, dumpPath); dumpErr != nil {
+		t.Fatalf("Dump failed: %v", dumpErr)
+	}
+
+	// Check dump size for logging
+	if fileInfo, statErr := os.Stat(dumpPath); statErr == nil {
+		t.Logf("Dump size: %d bytes", fileInfo.Size())
+	}
+
+	// Create a new connection for target to ensure complete isolation
+	conf2 := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
+	codec2 := surrealcbor.New()
+	conf2.Marshaler = codec2
+	conf2.Unmarshaler = codec2
+	conf2.Logger = nil
+
+	conn2 := gws.New(conf2)
+	targetConn, err := surrealdb.FromConnection(ctx, conn2)
+	if err != nil {
+		t.Fatalf("Failed to connect target: %v", err)
+	}
+	defer targetConn.Close(ctx)
+
+	// Initialize target database (clean)
+	targetDB, err := testenv.Init(targetConn, "simple_restore_target", "restored")
+	if err != nil {
+		t.Fatalf("Failed to init target db: %v", err)
+	}
+
+	// Before restore, check if simple_test.source exists on target connection
+	if useErr := targetDB.Use(ctx, "simple_test", "source"); useErr == nil {
+		// The namespace/database already exists, clean it
+		preCheck, _ := surrealdb.Query[[]TestRecord](ctx, targetDB,
+			"SELECT * FROM test_table", nil)
+		if preCheck != nil && len(*preCheck) > 0 && len((*preCheck)[0].Result) > 0 {
+			t.Logf("WARNING: Found %d existing records in target before restore!", len((*preCheck)[0].Result))
+			// Clean the table
+			_, _ = surrealdb.Query[any](ctx, targetDB, "DELETE test_table", nil)
+		}
+	}
+
+	// Switch back to target namespace for restore
+	if switchErr := targetDB.Use(ctx, "simple_restore_target", "restored"); switchErr != nil {
+		t.Fatalf("Failed to switch back to target: %v", switchErr)
+	}
+
+	// Restore using the simplified API
+	restorer := surrealrestore.New(targetDB)
+	restorer.Verbose = true
+
+	if restoreErr := restorer.Full(ctx, dumpPath); restoreErr != nil {
+		t.Fatalf("Restore failed: %v", restoreErr)
+	}
+
+	stats := restorer.Stats()
+	t.Logf("Restored %d records in %d tables", stats.RecordsRestored, stats.TablesRestored)
+
+	// The restore creates the namespace/database from the dump, so we need to switch to that
+	if useRestoreErr := targetDB.Use(ctx, "simple_test", "source"); useRestoreErr != nil {
+		t.Fatalf("Failed to use restored db: %v", useRestoreErr)
+	}
+
+	// First, let's see what's actually in the test_table
+	checkResult, err := surrealdb.Query[[]TestRecord](ctx, targetDB,
+		"SELECT * FROM test_table", nil)
+	if err != nil {
+		t.Fatalf("Failed to check records: %v", err)
+	}
+
+	t.Logf("Raw check - found %d result sets", len(*checkResult))
+	for i, resultSet := range *checkResult {
+		t.Logf("  Result set %d has %d records", i, len(resultSet.Result))
+	}
+
+	// Count records
+	type CountResult struct {
+		Count int `json:"count"`
+	}
+
+	result, err := surrealdb.Query[[]CountResult](ctx, targetDB,
+		"SELECT count() as count FROM test_table GROUP ALL", nil)
+	if err != nil {
+		t.Fatalf("Failed to count: %v", err)
+	}
+
+	if len(*result) > 0 && len((*result)[0].Result) > 0 {
+		count := (*result)[0].Result[0].Count
+		if count != 3 {
+			t.Errorf("Expected 3 records, got %d", count)
+		} else {
+			t.Logf("Successfully restored %d records", count)
+		}
+	}
+
+	// Select all records
+	allRecords, err := surrealdb.Query[[]TestRecord](ctx, targetDB,
+		"SELECT * FROM test_table", nil)
+	if err != nil {
+		t.Fatalf("Failed to select records: %v", err)
+	}
+
+	if len(*allRecords) > 0 {
+		t.Logf("Found %d records", len((*allRecords)[0].Result))
+		for _, r := range (*allRecords)[0].Result {
+			t.Logf("  - %s (age %d)", r.Name, r.Age)
+		}
+	}
+}


### PR DESCRIPTION
This pull request aims to resolve issue #165, which has been open for almost a year, requesting the addition of dump & restore functionality to the SDK.

To be clear, it should NEVER be part of the SDK. However, I took it positively and leveraged it as a good chance to demonstrate how the SDK can be used to write a complex tool like this. Please feel free to fork it and use it as a basis for your own backup tool if you want to write one in Go, but that's not my goal, to be clear.

That said, this adds `contrib/surrealdump` and `contrib/surrealrestore`. Both explicitly state in their respective README files that those tools are for demo purposes and not for production backups.

The pair of tools is designed around the idea of taking a consistent dump followed by consistent incremental dumps, which enables you to establish a "dump chain" that allows you to restore the set of tables in a SurrealDB namespace/database to specific restoration points, at the granularity of incremental dumps.

A consistent full dump is created from a standard table full-scan using `SELECT`, with change feeds queried using `SHOW CHANGES FOR TABLE`. The former serves as an inconsistent full dump, and the latter serves as the "more than enough change history necessary to make the inconsistent dump consistent".

I'm unsure who would want to write a SurrealDB backup tool in Go, considering SurrealDB itself is written in Rust. For scalability, you would likely use physical backups over logical ones. But anyway, here it is for your inspiration.

Enjoy building!