### PR TITLE
Fix LQ race between db_test and connection_test

### DIFF
--- a/pkg/connection/integration/connection_test.go
+++ b/pkg/connection/integration/connection_test.go
@@ -64,7 +64,7 @@ func (s *ConnectionTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	// set namespace, database
-	err = con.Use(context.Background(), "test", "test")
+	err = con.Use(context.Background(), "connection_integration", "connection_test")
 	s.Require().NoError(err)
 
 	// sign in


### PR DESCRIPTION
The two tests were using the overlapping ns/db, which resulted in test flakiness.
This fixes it by making the connection_test use a dedicated ns/db.