### PR TITLE
rews: Restore LQ on reconnection

### DIFF
--- a/contrib/rews/integration_test.go
+++ b/contrib/rews/integration_test.go
@@ -1,0 +1,205 @@
+package rews_test
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/rews"
+	"github.com/surrealdb/surrealdb.go/internal/fakesdb"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+const testTokenSignIn = "test_token_signin"
+
+// TestIntegration tests the reconnection mechanism for live queries using fakesdb
+func TestIntegration(t *testing.T) {
+	server := fakesdb.NewServer("127.0.0.1:0")
+	server.TokenSignIn = testTokenSignIn
+
+	var liveCallCount int32
+	var queryCallCount int32
+	var selectCount int32
+	var retryRequired bool
+
+	// Track live method calls
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher: fakesdb.MatchMethodWithParams("live", func(params []any) bool {
+			count := atomic.AddInt32(&liveCallCount, 1)
+			t.Logf("Live query request #%d", count)
+			return true
+		}),
+		Result: models.UUID{UUID: uuid.Must(uuid.NewV4())},
+	})
+
+	// Track query method calls
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher: fakesdb.MatchMethodWithParams("query", func(params []any) bool {
+			if len(params) > 0 {
+				if query, ok := params[0].(string); ok {
+					if strings.Contains(strings.ToUpper(query), "LIVE SELECT") {
+						count := atomic.AddInt32(&queryCallCount, 1)
+						t.Logf("LIVE SELECT query request #%d", count)
+						return true
+					}
+				}
+			}
+			return false
+		}),
+		Result: []surrealdb.QueryResult[models.UUID]{
+			{
+				Status: "OK",
+				Time:   "1ms",
+				Result: models.UUID{UUID: uuid.Must(uuid.NewV4())},
+			},
+		},
+	})
+
+	// Drop connection on 3rd select to trigger reconnection
+	server.AddStubResponse(fakesdb.StubResponse{
+		Matcher: fakesdb.MatchMethodWithParams("select", func(params []any) bool {
+			count := atomic.AddInt32(&selectCount, 1)
+			t.Logf("Select request #%d", count)
+
+			if count == 3 && !retryRequired {
+				retryRequired = true
+				t.Log("*** Dropping connection on 3rd select request ***")
+				return true
+			}
+			return false
+		}),
+		Result: nil,
+		Failures: []fakesdb.FailureConfig{
+			{
+				Type:        fakesdb.FailureWebSocketClose,
+				Probability: 1.0,
+				CloseCode:   1001,
+				CloseReason: "Testing reconnection",
+			},
+		},
+	})
+
+	// Normal select response
+	server.AddStubResponse(fakesdb.SimpleStubResponse("select", map[string]any{
+		"id":   cbor.Tag{Number: 8, Content: []any{"test", "1"}},
+		"name": "Test Record",
+	}))
+
+	// Other necessary stubs
+	server.AddStubResponse(fakesdb.SimpleStubResponse("use", nil))
+	server.AddStubResponse(fakesdb.SimpleStubResponse("signin", map[string]any{
+		"token": testTokenSignIn,
+	}))
+	server.AddStubResponse(fakesdb.SimpleStubResponse("authenticate", nil))
+
+	// Start server
+	err := server.Start()
+	require.NoError(t, err)
+	defer func() {
+		if stopErr := server.Stop(); stopErr != nil {
+			t.Fatalf("Failed to stop server: %v", stopErr)
+		}
+	}()
+
+	wsURL := "ws://" + server.Address()
+	checkInterval := 100 * time.Millisecond
+
+	u, err := url.ParseRequestURI(wsURL)
+	require.NoError(t, err)
+	config := connection.NewConfig(u)
+
+	conn := rews.New(func(ctx context.Context) (*gorillaws.Connection, error) {
+		ws := gorillaws.New(config)
+		return ws, nil
+	}, checkInterval, config.Unmarshaler, logger.New(slog.NewTextHandler(os.Stdout, nil)))
+
+	ctx := context.Background()
+
+	// Establish initial connection
+	err = conn.Connect(ctx)
+	require.NoError(t, err, "Initial connection should succeed")
+
+	// The session would contain the following data, which will be restored on reconnection
+	// - Used namespace and database names
+	// - The token returned by the successful SignIn
+	// - The variables set via Let
+
+	err = conn.Use(ctx, "test", "test")
+	require.NoError(t, err)
+
+	token, signInErr := conn.SignIn(ctx, map[string]any{
+		"username": "root",
+		"password": "root",
+	})
+	require.NoError(t, signInErr)
+	require.Equal(t, testTokenSignIn, token)
+
+	err = conn.Authenticate(ctx, token)
+	require.NoError(t, err)
+
+	err = conn.Let(ctx, "x", 1)
+	require.NoError(t, err)
+
+	// Send live queries before disconnection
+	_, _ = conn.Send(ctx, "live", "users", false)
+	initialLiveCount := atomic.LoadInt32(&liveCallCount)
+	t.Logf("Initial live query count: %d", initialLiveCount)
+
+	_, _ = conn.Send(ctx, "query", "LIVE SELECT * FROM products", nil)
+	initialQueryCount := atomic.LoadInt32(&queryCallCount)
+	t.Logf("Initial query count: %d", initialQueryCount)
+
+	// Make selects to trigger disconnection
+	for i := 0; i < 2; i++ {
+		_, _ = conn.Send(ctx, "select", "test", "1")
+	}
+
+	// Third select will trigger disconnection
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	_, err = conn.Send(shortCtx, "select", "test", "1")
+	require.Error(t, err, "3rd select should fail due to connection drop")
+	cancel()
+
+	// Wait for reconnection
+	time.Sleep(1 * time.Second)
+
+	// Verify connection is working after reconnection
+	_, err = conn.Send(ctx, "select", "test", "1")
+	if err != nil {
+		// Try again after a bit more wait
+		time.Sleep(500 * time.Millisecond)
+		_, err = conn.Send(ctx, "select", "test", "1")
+	}
+	assert.NoError(t, err, "Connection should work after reconnection")
+
+	// After reconnection, check if more live/query calls were made
+	// This would indicate the live queries were restored
+	finalLiveCount := atomic.LoadInt32(&liveCallCount)
+	finalQueryCount := atomic.LoadInt32(&queryCallCount)
+
+	t.Logf("Final live query count: %d", finalLiveCount)
+	t.Logf("Final query count: %d", finalQueryCount)
+
+	// The counts should increase if restoration is working
+	// We can't guarantee exact numbers due to timing, but there should be attempts
+	if finalLiveCount > initialLiveCount || finalQueryCount > initialQueryCount {
+		t.Log("Live query restoration attempted (counts increased)")
+	}
+	require.Greater(t, finalLiveCount, initialLiveCount, "Live query should have been re-sent after reconnection")
+	require.Greater(t, finalQueryCount, initialQueryCount, "LIVE SELECT query should have been re-sent after reconnection")
+
+	t.Log("Test passed: Reconnection mechanism tested")
+}

--- a/contrib/rews/mock_websocket_connection_test.go
+++ b/contrib/rews/mock_websocket_connection_test.go
@@ -1,0 +1,178 @@
+package rews
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gofrs/uuid"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// mockWebSocketConnection extends the mock to return proper UUIDs
+type mockWebSocketConnection struct {
+	connection.WebSocketConnection
+	notifications map[string]chan connection.Notification
+	mu            sync.Mutex
+	sendCalled    int
+	lastMethod    string
+	lastParams    []any
+	isClosed      bool
+}
+
+func (m *mockWebSocketConnection) Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error) {
+	m.sendCalled++
+	m.lastMethod = method
+	m.lastParams = params
+
+	var result cbor.RawMessage
+
+	switch method {
+	case methodLive:
+		// Return a UUID for live queries
+		liveUUID := uuid.Must(uuid.NewV4())
+		data, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: liveUUID})
+		result = data
+
+		// Store the UUID for LiveNotifications
+		m.mu.Lock()
+		m.notifications[liveUUID.String()] = make(chan connection.Notification, 100)
+		m.mu.Unlock()
+
+	case methodQuery:
+		// Check if it's a LIVE SELECT
+		if len(params) > 0 {
+			if query, ok := params[0].(string); ok {
+				if strings.Contains(strings.ToUpper(query), "LIVE SELECT") {
+					// For LIVE SELECT, return an array of QueryResult with UUID in the Result field
+					type QueryResult struct {
+						Status string          `json:"status"`
+						Time   string          `json:"time"`
+						Result cbor.RawMessage `json:"result"`
+					}
+
+					liveUUID := uuid.Must(uuid.NewV4())
+					uuidData, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: liveUUID})
+
+					queryResults := []QueryResult{
+						{
+							Status: "OK",
+							Time:   "1ms",
+							Result: uuidData,
+						},
+					}
+
+					data, _ := cbor.Marshal(queryResults)
+					result = data
+
+					// Store the UUID for LiveNotifications
+					m.mu.Lock()
+					m.notifications[liveUUID.String()] = make(chan connection.Notification, 100)
+					m.mu.Unlock()
+				} else {
+					// Regular query result
+					result = cbor.RawMessage{}
+				}
+			}
+		}
+
+	default:
+		result = cbor.RawMessage{}
+	}
+
+	return &connection.RPCResponse[cbor.RawMessage]{
+		ID:     uuid.Must(uuid.NewV4()).String(),
+		Result: &result,
+	}, nil
+}
+
+func (m *mockWebSocketConnection) LiveNotifications(id string) (chan connection.Notification, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ch, exists := m.notifications[id]
+	if !exists {
+		return nil, fmt.Errorf("live query %s not found", id)
+	}
+	return ch, nil
+}
+
+func (m *mockWebSocketConnection) CloseLiveNotifications(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ch, exists := m.notifications[id]; exists {
+		close(ch)
+		delete(m.notifications, id)
+	}
+	return nil
+}
+
+func (m *mockWebSocketConnection) SendNotification(id string, notification connection.Notification) {
+	m.mu.Lock()
+	ch, exists := m.notifications[id]
+	m.mu.Unlock()
+
+	if exists {
+		ch <- notification
+	}
+}
+
+func (m *mockWebSocketConnection) IsClosed() bool {
+	return m.isClosed
+}
+
+func (m *mockWebSocketConnection) Connect(ctx context.Context) error {
+	m.isClosed = false
+	return nil
+}
+
+func (m *mockWebSocketConnection) Close(ctx context.Context) error {
+	m.isClosed = true
+	return nil
+}
+
+func (m *mockWebSocketConnection) Use(ctx context.Context, ns, db string) error {
+	if m.isClosed {
+		return fmt.Errorf("connection is closed")
+	}
+	return nil
+}
+
+func (m *mockWebSocketConnection) Authenticate(ctx context.Context, token string) error {
+	if m.isClosed {
+		return fmt.Errorf("connection is closed")
+	}
+	return nil
+}
+
+func (m *mockWebSocketConnection) Let(ctx context.Context, key string, val any) error {
+	if m.isClosed {
+		return fmt.Errorf("connection is closed")
+	}
+	return nil
+}
+
+func (m *mockWebSocketConnection) Unset(ctx context.Context, key string) error {
+	if m.isClosed {
+		return fmt.Errorf("connection is closed")
+	}
+	return nil
+}
+
+func (m *mockWebSocketConnection) SignIn(ctx context.Context, auth any) (string, error) {
+	if m.isClosed {
+		return "", fmt.Errorf("connection is closed")
+	}
+	return "test-token", nil
+}
+
+func (m *mockWebSocketConnection) SignUp(ctx context.Context, auth any) (string, error) {
+	if m.isClosed {
+		return "", fmt.Errorf("connection is closed")
+	}
+	return "test-token", nil
+}

--- a/contrib/rews/notification_router.go
+++ b/contrib/rews/notification_router.go
@@ -1,0 +1,176 @@
+package rews
+
+import (
+	"sync"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+)
+
+// NotificationProvider is an interface for getting live notification channels
+type NotificationProvider interface {
+	LiveNotifications(id string) (chan connection.Notification, error)
+}
+
+// NotificationRouter manages routing of notifications from external (changing) UUIDs
+// to internal (stable) UUIDs after reconnection
+type NotificationRouter struct {
+	// routes maps internal UUID -> routing info
+	routes map[string]*route
+	// routesMu protects access to routes map
+	routesMu sync.RWMutex
+
+	// logger for debugging
+	logger logger.Logger
+}
+
+// route represents a single notification routing path
+type route struct {
+	internalID string
+	externalID string
+	internalCh chan connection.Notification
+	externalCh chan connection.Notification
+	stopCh     chan struct{}
+	wg         sync.WaitGroup
+}
+
+// NewNotificationRouter creates a new NotificationRouter
+func NewNotificationRouter(log logger.Logger) *NotificationRouter {
+	return &NotificationRouter{
+		routes: make(map[string]*route),
+		logger: log,
+	}
+}
+
+// SetupRouting sets up routing from an external UUID to an internal UUID
+// It creates the internal channel if it doesn't exist and routes notifications
+// from the external channel to the internal channel.
+// This handles both cases:
+// 1. When internalID == externalID (initial setup)
+// 2. When internalID != externalID (after reconnection)
+func (nr *NotificationRouter) SetupRouting(
+	internalID, externalID string,
+	provider NotificationProvider,
+) (chan connection.Notification, error) {
+	nr.routesMu.Lock()
+	defer nr.routesMu.Unlock()
+
+	// Get or create route
+	r, exists := nr.routes[internalID]
+	if !exists {
+		// Create new route with internal channel
+		r = &route{
+			internalID: internalID,
+			internalCh: make(chan connection.Notification, 100), // buffered to avoid blocking
+			stopCh:     make(chan struct{}),
+		}
+		nr.routes[internalID] = r
+		nr.logger.Debug("Created new route", "internal_id", internalID)
+	}
+
+	// Stop old routing if it exists and external ID is changing
+	if r.externalCh != nil && r.externalID != externalID {
+		nr.logger.Debug("Stopping old routing",
+			"internal_id", internalID,
+			"old_external_id", r.externalID,
+			"new_external_id", externalID)
+		close(r.stopCh)
+		r.wg.Wait()
+		r.stopCh = make(chan struct{})
+	}
+
+	// Get external channel from provider
+	externalCh, err := provider.LiveNotifications(externalID)
+	if err != nil {
+		nr.logger.Error("Failed to get notifications for external ID",
+			"internal_id", internalID,
+			"external_id", externalID,
+			"error", err)
+		return r.internalCh, err
+	}
+
+	// Update route
+	r.externalID = externalID
+	r.externalCh = externalCh
+
+	// Start routing goroutine only if needed
+	if r.externalID != "" {
+		r.wg.Add(1)
+		go nr.routeNotifications(r)
+
+		nr.logger.Debug("Notification routing setup",
+			"internal_id", internalID,
+			"external_id", externalID)
+	}
+
+	return r.internalCh, nil
+}
+
+// routeNotifications routes notifications from external to internal channel
+func (nr *NotificationRouter) routeNotifications(r *route) {
+	defer r.wg.Done()
+
+	nr.logger.Debug("Starting notification routing",
+		"internal_id", r.internalID,
+		"external_id", r.externalID)
+
+	for {
+		select {
+		case notification, ok := <-r.externalCh:
+			if !ok {
+				nr.logger.Debug("External channel closed",
+					"internal_id", r.internalID,
+					"external_id", r.externalID)
+				return
+			}
+
+			select {
+			case r.internalCh <- notification:
+				// Successfully routed notification
+			default:
+				// Internal channel might be full or closed
+				nr.logger.Warn("Failed to route notification, channel might be full",
+					"internal_id", r.internalID)
+			}
+
+		case <-r.stopCh:
+			nr.logger.Debug("Notification routing stopped",
+				"internal_id", r.internalID,
+				"external_id", r.externalID)
+			return
+		}
+	}
+}
+
+// RemoveRoute removes a routing entry and stops its goroutine
+func (nr *NotificationRouter) RemoveRoute(internalID string) {
+	nr.routesMu.Lock()
+	defer nr.routesMu.Unlock()
+
+	if r, exists := nr.routes[internalID]; exists {
+		if r.externalCh != nil {
+			close(r.stopCh)
+			r.wg.Wait()
+		}
+		close(r.internalCh)
+		delete(nr.routes, internalID)
+
+		nr.logger.Debug("Route removed", "internal_id", internalID)
+	}
+}
+
+// Close stops all routing goroutines and closes all channels
+func (nr *NotificationRouter) Close() {
+	nr.routesMu.Lock()
+	defer nr.routesMu.Unlock()
+
+	for internalID, r := range nr.routes {
+		if r.externalCh != nil {
+			close(r.stopCh)
+			r.wg.Wait()
+		}
+		close(r.internalCh)
+		delete(nr.routes, internalID)
+		nr.logger.Debug("Route closed", "internal_id", internalID)
+	}
+}

--- a/contrib/rews/notification_router_test.go
+++ b/contrib/rews/notification_router_test.go
@@ -1,0 +1,446 @@
+package rews
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+const (
+	testInternalID = "internal-123"
+	testExternalID = "external-456"
+)
+
+// testUUID creates a models.UUID for testing
+func testUUID(name string) *models.UUID {
+	// Create a deterministic UUID from string for testing
+	id := uuid.NewV5(uuid.NamespaceURL, name)
+	return &models.UUID{UUID: id}
+}
+
+// mockNotificationProvider is a mock implementation of NotificationProvider
+type mockNotificationProvider struct {
+	channels map[string]chan connection.Notification
+	mu       sync.Mutex
+	errors   map[string]error
+}
+
+func newMockNotificationProvider() *mockNotificationProvider {
+	return &mockNotificationProvider{
+		channels: make(map[string]chan connection.Notification),
+		errors:   make(map[string]error),
+	}
+}
+
+func (m *mockNotificationProvider) LiveNotifications(id string) (chan connection.Notification, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err, exists := m.errors[id]; exists {
+		return nil, err
+	}
+
+	if ch, exists := m.channels[id]; exists {
+		return ch, nil
+	}
+
+	// Create a new channel for this ID
+	ch := make(chan connection.Notification, 10)
+	m.channels[id] = ch
+	return ch, nil
+}
+
+func (m *mockNotificationProvider) SendNotification(id string, notification connection.Notification) error {
+	m.mu.Lock()
+	ch, exists := m.channels[id]
+	m.mu.Unlock()
+
+	if !exists {
+		return fmt.Errorf("no channel for id: %s", id)
+	}
+
+	select {
+	case ch <- notification:
+		return nil
+	case <-time.After(100 * time.Millisecond):
+		return fmt.Errorf("timeout sending notification")
+	}
+}
+
+func (m *mockNotificationProvider) CloseChannel(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ch, exists := m.channels[id]; exists {
+		close(ch)
+		delete(m.channels, id)
+	}
+}
+
+func (m *mockNotificationProvider) SetError(id string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.errors[id] = err
+}
+
+// TestNotificationRouter_BasicRouting tests basic routing functionality
+func TestNotificationRouter_BasicRouting(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	internalID := testInternalID
+	externalID := testExternalID
+
+	// Setup routing - this will create the channel and return it
+	ch, err := router.SetupRouting(internalID, externalID, provider)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	// Send a notification through the external channel
+	notification := connection.Notification{
+		ID:     testUUID("test-notification"),
+		Action: connection.CreateAction,
+		Result: map[string]interface{}{"test": "data"},
+	}
+
+	err = provider.SendNotification(externalID, notification)
+	require.NoError(t, err)
+
+	// Receive the notification on the internal channel
+	select {
+	case received := <-ch:
+		assert.Equal(t, notification.ID, received.ID)
+		assert.Equal(t, notification.Action, received.Action)
+		assert.Equal(t, notification.Result, received.Result)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Timeout waiting for notification")
+	}
+
+	// Clean up
+	router.RemoveRoute(internalID)
+}
+
+// TestNotificationRouter_UpdateRouting tests updating an existing route
+func TestNotificationRouter_UpdateRouting(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	internalID := "internal-123"
+	externalID1 := "external-456"
+	externalID2 := "external-789"
+
+	// Setup initial routing
+	ch, err := router.SetupRouting(internalID, externalID1, provider)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	// Send notification through first external channel
+	notification1 := connection.Notification{
+		ID:     testUUID("notification-1"),
+		Action: connection.CreateAction,
+	}
+	err = provider.SendNotification(externalID1, notification1)
+	require.NoError(t, err)
+
+	// Receive first notification
+	select {
+	case received := <-ch:
+		assert.Equal(t, notification1.ID, received.ID)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Timeout waiting for first notification")
+	}
+
+	// Update routing to new external ID - should return the same channel
+	ch2, err := router.SetupRouting(internalID, externalID2, provider)
+	require.NoError(t, err)
+	require.Equal(t, ch, ch2, "Should return the same internal channel")
+
+	// Allow time for old routing to stop
+	time.Sleep(100 * time.Millisecond)
+
+	// Send notification through second external channel
+	notification2 := connection.Notification{
+		ID:     testUUID("notification-2"),
+		Action: connection.UpdateAction,
+	}
+	err = provider.SendNotification(externalID2, notification2)
+	require.NoError(t, err)
+
+	// Should receive notification from new external ID on same internal channel
+	select {
+	case received := <-ch:
+		assert.Equal(t, notification2.ID, received.ID)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Timeout waiting for second notification")
+	}
+
+	// Notifications to old external ID should not be routed
+	notification3 := connection.Notification{
+		ID:     testUUID("notification-3"),
+		Action: connection.DeleteAction,
+	}
+	err = provider.SendNotification(externalID1, notification3)
+	require.NoError(t, err)
+
+	// Should not receive notification from old external ID
+	select {
+	case <-ch:
+		t.Fatal("Should not receive notification from old external ID")
+	case <-time.After(200 * time.Millisecond):
+		// Expected timeout
+	}
+
+	// Clean up
+	router.RemoveRoute(internalID)
+}
+
+// TestNotificationRouter_ChannelReuse tests that SetupRouting reuses channels
+func TestNotificationRouter_ChannelReuse(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	internalID := "internal-123"
+	externalID := "external-456"
+
+	// First call should create channel
+	ch1, err := router.SetupRouting(internalID, externalID, provider)
+	require.NoError(t, err)
+	require.NotNil(t, ch1)
+
+	// Second call with same internal ID should return same channel
+	ch2, err := router.SetupRouting(internalID, externalID, provider)
+	require.NoError(t, err)
+	require.NotNil(t, ch2)
+	assert.Equal(t, ch1, ch2, "Should return the same channel")
+
+	// Call with different external ID should still return same internal channel
+	ch3, err := router.SetupRouting(internalID, "external-789", provider)
+	require.NoError(t, err)
+	assert.Equal(t, ch1, ch3, "Should return the same internal channel")
+
+	// Clean up
+	router.RemoveRoute(internalID)
+}
+
+// TestNotificationRouter_MultipleRoutes tests managing multiple routes
+func TestNotificationRouter_MultipleRoutes(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	routes := []struct {
+		internalID string
+		externalID string
+	}{
+		{"internal-1", "external-1"},
+		{"internal-2", "external-2"},
+		{"internal-3", "external-3"},
+	}
+
+	// Setup multiple routes
+	channels := make(map[string]chan connection.Notification)
+	for _, route := range routes {
+		ch, err := router.SetupRouting(route.internalID, route.externalID, provider)
+		require.NoError(t, err)
+		require.NotNil(t, ch)
+		channels[route.internalID] = ch
+	}
+
+	// Send notifications to each external ID
+	for i, route := range routes {
+		notification := connection.Notification{
+			ID:     testUUID(fmt.Sprintf("notification-%d", i)),
+			Action: connection.CreateAction,
+		}
+		err := provider.SendNotification(route.externalID, notification)
+		require.NoError(t, err)
+	}
+
+	// Verify each internal channel receives its notification
+	for i, route := range routes {
+		ch := channels[route.internalID]
+		select {
+		case received := <-ch:
+			assert.Equal(t, testUUID(fmt.Sprintf("notification-%d", i)), received.ID)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("Timeout waiting for notification on %s", route.internalID)
+		}
+	}
+
+	// Clean up all routes
+	for _, route := range routes {
+		router.RemoveRoute(route.internalID)
+	}
+}
+
+// TestNotificationRouter_ProviderError tests handling of provider errors
+func TestNotificationRouter_ProviderError(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	internalID := testInternalID
+	externalID := testExternalID
+
+	// Set an error for the external ID
+	provider.SetError(externalID, fmt.Errorf("connection failed"))
+
+	// Setup routing should fail but still return the channel
+	ch, err := router.SetupRouting(internalID, externalID, provider)
+	assert.NotNil(t, ch) // Channel is created even if provider fails
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "connection failed")
+}
+
+// TestNotificationRouter_ExternalChannelClose tests handling when external channel closes
+func TestNotificationRouter_ExternalChannelClose(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	internalID := testInternalID
+	externalID := testExternalID
+
+	// Setup routing
+	ch, err := router.SetupRouting(internalID, externalID, provider)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	// Verify we get the same channel when setting up routing again with same IDs
+	ch2, err := router.SetupRouting(internalID, externalID, provider)
+	require.NoError(t, err)
+	require.Equal(t, ch, ch2)
+
+	// Send a notification to verify it's working
+	notification := connection.Notification{
+		ID:     testUUID("test-notification"),
+		Action: connection.CreateAction,
+	}
+	err = provider.SendNotification(externalID, notification)
+	require.NoError(t, err)
+
+	// Receive it
+	select {
+	case <-ch:
+		// Good
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Timeout waiting for notification")
+	}
+
+	// Close the external channel
+	provider.CloseChannel(externalID)
+
+	// Wait a bit for the routing goroutine to notice
+	time.Sleep(100 * time.Millisecond)
+
+	// Internal channel should still exist but not receive new notifications
+	// We can verify this by trying to setup routing again - should return same channel
+	ch3, err := router.SetupRouting(internalID, externalID, provider)
+	assert.NoError(t, err)
+	assert.Equal(t, ch, ch3)
+
+	// Clean up
+	router.RemoveRoute(internalID)
+}
+
+// TestNotificationRouter_Close tests closing the router
+func TestNotificationRouter_Close(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	// Setup multiple routes and keep track of channels
+	channels := make(map[string]chan connection.Notification)
+	for i := 0; i < 3; i++ {
+		internalID := fmt.Sprintf("internal-%d", i)
+		externalID := fmt.Sprintf("external-%d", i)
+		ch, err := router.SetupRouting(internalID, externalID, provider)
+		require.NoError(t, err)
+		channels[internalID] = ch
+	}
+
+	// Close the router
+	router.Close()
+
+	// All channels should be closed
+	for internalID, ch := range channels {
+		select {
+		case _, ok := <-ch:
+			assert.False(t, ok, "Channel for %s should be closed", internalID)
+		default:
+			// Channel might be blocked, try with timeout
+			select {
+			case _, ok := <-ch:
+				assert.False(t, ok, "Channel for %s should be closed", internalID)
+			case <-time.After(100 * time.Millisecond):
+				t.Errorf("Channel for %s appears to be still open", internalID)
+			}
+		}
+	}
+}
+
+// TestNotificationRouter_ConcurrentAccess tests concurrent operations
+func TestNotificationRouter_ConcurrentAccess(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	router := NewNotificationRouter(log)
+	provider := newMockNotificationProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Start multiple goroutines doing various operations
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			for j := 0; j < 10; j++ {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				internalID := fmt.Sprintf("internal-%d", id)
+				externalID := fmt.Sprintf("external-%d-%d", id, j)
+
+				// Setup routing
+				ch, err := router.SetupRouting(internalID, externalID, provider)
+				assert.NoError(t, err)
+				assert.NotNil(t, ch)
+
+				// Verify we get the same channel back when setting up again
+				ch2, err := router.SetupRouting(internalID, externalID, provider)
+				assert.NoError(t, err)
+				assert.Equal(t, ch, ch2)
+
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			// Clean up
+			router.RemoveRoute(fmt.Sprintf("internal-%d", id))
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Close router
+	router.Close()
+}

--- a/contrib/rews/reliable_lq.go
+++ b/contrib/rews/reliable_lq.go
@@ -1,0 +1,352 @@
+package rews
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/surrealdb/surrealdb.go/internal/codec"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+const (
+	// methodLive is the RPC method name for live queries
+	methodLive = "live"
+	// methodQuery is the RPC method name for query operations
+	methodQuery = "query"
+)
+
+// NotificationCloser is an interface for closing live notifications
+type NotificationCloser interface {
+	CloseLiveNotifications(id string) error
+}
+
+// RPCSender is an interface for sending RPC requests
+type RPCSender interface {
+	Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error)
+}
+
+// reliableLQ encapsulates all the state and functionality for reliable live query management
+// across reconnections. It maintains mappings between stable internal UUIDs and changing
+// external UUIDs, and handles the restoration of live queries after reconnection.
+type reliableLQ struct {
+	// liveQueries stores information about active live queries
+	// Maps internal (stable) UUID -> LiveQueryInfo
+	liveQueries map[string]*LiveQueryInfo
+
+	// liveQueriesMu protects access to liveQueries map
+	liveQueriesMu sync.RWMutex
+
+	// router handles notification routing between external and internal UUIDs
+	router *NotificationRouter
+
+	// unmarshaler is used to unmarshal CBOR data
+	unmarshaler codec.Unmarshaler
+}
+
+// newReliableLQ creates and initializes a new reliableLQ instance
+func newReliableLQ(log logger.Logger, unmarshaler codec.Unmarshaler) *reliableLQ {
+	if unmarshaler == nil {
+		panic("reliableLQ requires a valid unmarshaler")
+	}
+
+	return &reliableLQ{
+		liveQueries: make(map[string]*LiveQueryInfo),
+		router:      NewNotificationRouter(log),
+		unmarshaler: unmarshaler,
+	}
+}
+
+// LiveQueryInfo stores information about a live query for restoration after reconnection
+type LiveQueryInfo struct {
+	// InternalID is the stable UUID that the consumer uses
+	InternalID string
+	// ExternalID is the current UUID from the server (changes on reconnect)
+	ExternalID string
+	// Method is the RPC method used to create the live query ("live" or "query")
+	Method string
+	// Params are the parameters used to create the live query
+	Params []any
+}
+
+// isLiveSelectQuery checks if a query string is a LIVE SELECT statement
+func (rlq *reliableLQ) isLiveSelectQuery(query string) bool {
+	// Simple check for LIVE SELECT queries
+	// This is a basic implementation - could be made more robust
+	trimmed := strings.TrimSpace(strings.ToUpper(query))
+	return strings.HasPrefix(trimmed, "LIVE SELECT")
+}
+
+// recordLiveQueryFromResponse extracts the UUID from a response and records the live query.
+func (rlq *reliableLQ) recordLiveQueryFromResponse(result *cbor.RawMessage, method string, params []any, log logger.Logger) error {
+	// Try to extract the UUID from the result
+	var liveID string
+
+	// Special handling for query method with LIVE SELECT
+	// The response structure might be different
+	if method == methodQuery {
+		// For LIVE SELECT through query method, the result is an array of QueryResult
+		// We need to extract the UUID from the first QueryResult's Result field
+		type QueryResult struct {
+			Status string          `json:"status"`
+			Time   string          `json:"time"`
+			Result cbor.RawMessage `json:"result"`
+		}
+
+		var queryResults []QueryResult
+		if err := rlq.unmarshaler.Unmarshal(*result, &queryResults); err != nil {
+			return fmt.Errorf("failed to decode query results array: %w", err)
+		}
+
+		if len(queryResults) == 0 {
+			return fmt.Errorf("query returned no results")
+		}
+
+		// Extract UUID from the first result
+		var uuid models.UUID
+		if err := rlq.unmarshaler.Unmarshal(queryResults[0].Result, &uuid); err != nil {
+			return fmt.Errorf("failed to decode live query UUID from first query result: %w", err)
+		}
+		liveID = uuid.String()
+		log.Debug("Extracted UUID from query result", "liveID", liveID, "method", method)
+	} else {
+		// For regular live method, unmarshal directly as UUID
+		var uuid models.UUID
+		if err := rlq.unmarshaler.Unmarshal(*result, &uuid); err != nil {
+			return fmt.Errorf("failed to decode live query UUID: %w", err)
+		}
+		liveID = uuid.String()
+		log.Debug("Extracted UUID from live result", "liveID", liveID, "method", method)
+	}
+
+	if liveID == "" {
+		// This shouldn't happen - we expect a valid UUID to be extracted
+		return fmt.Errorf("extracted UUID is empty for %s method", method)
+	}
+
+	rlq.recordLiveQuery(liveID, method, params, log)
+	return nil
+}
+
+// recordLiveQuery records a live query for restoration after reconnection
+func (rlq *reliableLQ) recordLiveQuery(liveID, method string, params []any, log logger.Logger) {
+	rlq.liveQueriesMu.Lock()
+	defer rlq.liveQueriesMu.Unlock()
+
+	info := &LiveQueryInfo{
+		InternalID: liveID, // Initially, internal and external are the same
+		ExternalID: liveID,
+		Method:     method,
+		Params:     params,
+	}
+
+	rlq.liveQueries[liveID] = info
+
+	log.Debug("Recorded live query", "id", liveID, "method", method)
+}
+
+// send performs the actual send operation and tracks live queries
+func (rlq *reliableLQ) send(
+	ctx context.Context,
+	method string,
+	params []any,
+	sender RPCSender,
+	log logger.Logger,
+) (*connection.RPCResponse[cbor.RawMessage], error) {
+	// Send the request through the sender
+	resp, err := sender.Send(ctx, method, params...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only process successful responses with results
+	if resp != nil && resp.Error == nil && resp.Result != nil {
+		// Record the live query for restoration
+		if err := rlq.recordLiveQueryFromResponse(resp.Result, method, params, log); err != nil {
+			// Log the error but don't fail the send operation
+			// The query was successful, we just couldn't track it for restoration
+			log.Error("Failed to record live query for restoration", "method", method, "error", err)
+		}
+	}
+
+	return resp, nil
+}
+
+// handleSend intercepts and handles live query sends, tracking them for restoration
+// Returns true if the send was handled, false if it should be passed through
+func (rlq *reliableLQ) handleSend(
+	ctx context.Context,
+	method string,
+	params []any,
+	sender RPCSender,
+	log logger.Logger,
+) (bool, *connection.RPCResponse[cbor.RawMessage], error) {
+	// Check if this is a live query that needs to be tracked
+	shouldHandle := false
+	if method == methodLive {
+		shouldHandle = true
+		log.Debug("Handling live method", "params", params)
+	} else if method == methodQuery && len(params) > 0 {
+		// Check if this is a LIVE SELECT query
+		if query, ok := params[0].(string); ok {
+			log.Debug("Checking query for LIVE SELECT")
+			if rlq.isLiveSelectQuery(query) {
+				shouldHandle = true
+				log.Debug("Handling LIVE SELECT query")
+			}
+		}
+	}
+
+	// If it's not a live query, don't handle it
+	if !shouldHandle {
+		log.Debug("Not handling method", "method", method, "params", params)
+		return false, nil, nil
+	}
+
+	// Use our send method that handles live query tracking
+	log.Debug("Sending and tracking live query", "method", method)
+	resp, err := rlq.send(ctx, method, params, sender, log)
+	return true, resp, err
+}
+
+// liveNotifications handles getting live notifications with UUID mapping
+func (rlq *reliableLQ) liveNotifications(
+	id string,
+	provider NotificationProvider,
+) (chan connection.Notification, error) {
+	// Check if this is an internal ID that needs mapping
+	rlq.liveQueriesMu.RLock()
+	info, exists := rlq.liveQueries[id]
+	if !exists {
+		rlq.liveQueriesMu.RUnlock()
+		// This should not happen in normal usage - LiveNotifications should only be called
+		// after a successful Live() or Query() with LIVE SELECT, which records the query
+		return nil, fmt.Errorf("live query with ID %s not found - was Live() or LIVE SELECT query called first?", id)
+	}
+
+	externalID := info.ExternalID
+	rlq.liveQueriesMu.RUnlock()
+
+	// Use setupNotificationRouting which will handle the routing setup and return the channel
+	return rlq.router.SetupRouting(id, externalID, provider)
+}
+
+// closeLiveNotifications handles closing live notifications with UUID mapping
+func (rlq *reliableLQ) closeLiveNotifications(closer NotificationCloser, id string) (string, error) {
+	// Check if this is an internal ID that needs mapping
+	rlq.liveQueriesMu.RLock()
+	info, exists := rlq.liveQueries[id]
+	if !exists {
+		rlq.liveQueriesMu.RUnlock()
+		// This should not happen in normal usage - CloseLiveNotifications should only be called
+		// for live queries that were previously created and tracked
+		return "", fmt.Errorf("live query with ID %s not found - was this live query previously created?", id)
+	}
+
+	externalID := info.ExternalID
+	rlq.liveQueriesMu.RUnlock()
+
+	// Close notifications on the underlying connection
+	err := closer.CloseLiveNotifications(externalID)
+
+	// Remove route from router
+	rlq.router.RemoveRoute(id)
+
+	// Remove from live queries tracking
+	rlq.liveQueriesMu.Lock()
+	delete(rlq.liveQueries, id)
+	rlq.liveQueriesMu.Unlock()
+
+	return externalID, err
+}
+
+// restoreLiveQueries re-establishes live queries after reconnection.
+//
+// This function does not fail-fast when a live query cannot be restored due to
+// server errors (e.g., permission issues, query errors). However, it WILL return
+// an error if we cannot extract UUIDs from successful responses, as this indicates
+// a bug in either the SDK or SurrealDB.
+func (rlq *reliableLQ) restoreLiveQueries(ctx context.Context, sender RPCSender, provider NotificationProvider, log logger.Logger) error {
+	rlq.liveQueriesMu.RLock()
+	queries := make([]*LiveQueryInfo, 0, len(rlq.liveQueries))
+	for _, info := range rlq.liveQueries {
+		queries = append(queries, info)
+	}
+	rlq.liveQueriesMu.RUnlock()
+
+	for _, info := range queries {
+		log.Debug("Restoring live query", "internal_id", info.InternalID, "method", info.Method)
+
+		// Send the query to get a new external ID
+		resp, err := sender.Send(ctx, info.Method, info.Params...)
+		if err != nil {
+			log.Error("Failed to restore live query", "internal_id", info.InternalID, "error", err)
+			continue
+		}
+
+		if resp.Error != nil {
+			log.Error("Live query restoration returned error", "internal_id", info.InternalID, "error", resp.Error)
+			continue
+		}
+
+		// Extract the new external ID from the response
+		var newExternalID string
+		if resp.Result != nil {
+			switch info.Method {
+			case methodLive:
+				var uuid models.UUID
+				if err := rlq.unmarshaler.Unmarshal(*resp.Result, &uuid); err == nil {
+					newExternalID = uuid.String()
+				}
+			case methodQuery:
+				type QueryResult struct {
+					Status string          `json:"status"`
+					Time   string          `json:"time"`
+					Result cbor.RawMessage `json:"result"`
+				}
+
+				var queryResults []QueryResult
+				if err := rlq.unmarshaler.Unmarshal(*resp.Result, &queryResults); err == nil {
+					if len(queryResults) > 0 {
+						var uuid models.UUID
+						if err := rlq.unmarshaler.Unmarshal(queryResults[0].Result, &uuid); err == nil {
+							newExternalID = uuid.String()
+						}
+					}
+				}
+			}
+		}
+
+		if newExternalID == "" {
+			return fmt.Errorf("failed to extract UUID from restored live query response for %s (method: %s)",
+				info.InternalID, info.Method)
+		}
+
+		// Update the mapping with the new external ID
+		rlq.liveQueriesMu.Lock()
+		if oldInfo, exists := rlq.liveQueries[info.InternalID]; exists {
+			// Update with new external ID
+			oldInfo.ExternalID = newExternalID
+
+			log.Debug("Live query restored with new external ID",
+				"internal_id", info.InternalID,
+				"old_external", info.ExternalID,
+				"new_external", newExternalID)
+		}
+		rlq.liveQueriesMu.Unlock()
+
+		// Setup notification routing for the restored query
+		if _, err := rlq.router.SetupRouting(info.InternalID, newExternalID, provider); err != nil {
+			log.Error("Failed to setup notification routing for restored query",
+				"internal_id", info.InternalID,
+				"external_id", newExternalID,
+				"error", err)
+		}
+	}
+
+	return nil
+}

--- a/contrib/rews/reliable_lq_test.go
+++ b/contrib/rews/reliable_lq_test.go
@@ -1,0 +1,570 @@
+package rews
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// testUnmarshaler is a test implementation of codec.Unmarshaler
+
+// TestReliableLQ_requiresUnmarshaler tests that newReliableLQ panics with nil unmarshaler
+func TestReliableLQ_requiresUnmarshaler(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+
+	assert.Panics(t, func() {
+		newReliableLQ(log, nil)
+	}, "newReliableLQ should panic when unmarshaler is nil")
+}
+
+// TestReliableLQ_restoreLiveQueries tests that live queries are restored after reconnection
+func TestReliableLQ_restoreLiveQueries(t *testing.T) {
+	t.Run("restores live RPC query", func(t *testing.T) {
+		mock := &mockRPCSender{}
+		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+
+		// Manually add a live query to simulate one that needs restoration
+		rlq.liveQueries["test-id"] = &LiveQueryInfo{
+			InternalID: "test-id",
+			ExternalID: "test-id",
+			Method:     "live",
+			Params:     []any{"users", false},
+		}
+
+		// Restore live queries
+		ctx := context.Background()
+		// Create a mock provider (we won't actually use the channel for this test)
+		mockProvider := newMockNotificationProvider()
+		mockProvider.errors["test-id"] = fmt.Errorf("expected error - live query not accessible during test")
+		err := rlq.restoreLiveQueries(ctx, mock, mockProvider, log)
+		assert.Error(t, err) // We expect an error because mock doesn't return a valid UUID
+
+		// Verify the live query was resent
+		assert.Equal(t, 1, mock.sendCalled)
+		assert.Equal(t, "live", mock.lastMethod)
+		assert.Equal(t, []any{"users", false}, mock.lastParams)
+	})
+
+	t.Run("restores query RPC with LIVE SELECT", func(t *testing.T) {
+		mock := &mockRPCSender{}
+		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+
+		// Manually add a LIVE SELECT query to simulate one that needs restoration
+		liveSelectQuery := "LIVE SELECT * FROM products WHERE active = true"
+		rlq.liveQueries["live-select-id"] = &LiveQueryInfo{
+			InternalID: "live-select-id",
+			ExternalID: "live-select-id",
+			Method:     "query",
+			Params:     []any{liveSelectQuery, nil},
+		}
+
+		// Restore live queries
+		ctx := context.Background()
+		mockProvider := newMockNotificationProvider()
+		mockProvider.errors["live-select-id"] = fmt.Errorf("expected error - live query not accessible during test")
+		err := rlq.restoreLiveQueries(ctx, mock, mockProvider, log)
+		assert.Error(t, err) // We expect an error because mock doesn't return a valid UUID
+
+		// Verify the LIVE SELECT query was resent
+		assert.Equal(t, 1, mock.sendCalled)
+		assert.Equal(t, "query", mock.lastMethod)
+		assert.Equal(t, []any{liveSelectQuery, nil}, mock.lastParams)
+	})
+
+	t.Run("restores multiple queries of different types", func(t *testing.T) {
+		mock := &mockRPCSender{}
+		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+
+		// Add both types of live queries
+		rlq.liveQueries["live-1"] = &LiveQueryInfo{
+			InternalID: "live-1",
+			ExternalID: "live-1",
+			Method:     "live",
+			Params:     []any{"users", true},
+		}
+		rlq.liveQueries["live-select-1"] = &LiveQueryInfo{
+			InternalID: "live-select-1",
+			ExternalID: "live-select-1",
+			Method:     "query",
+			Params:     []any{"LIVE SELECT * FROM orders", map[string]any{"limit": 10}},
+		}
+		rlq.liveQueries["live-2"] = &LiveQueryInfo{
+			InternalID: "live-2",
+			ExternalID: "live-2",
+			Method:     "live",
+			Params:     []any{"products"},
+		}
+
+		// Restore live queries
+		ctx := context.Background()
+		mockProvider := newMockNotificationProvider()
+		err := rlq.restoreLiveQueries(ctx, mock, mockProvider, log)
+		assert.Error(t, err) // We expect an error because mock doesn't return a valid UUID
+
+		// Since restoreLiveQueries now returns an error immediately when UUID extraction fails,
+		// it will only make one Send call before returning the error
+		assert.Equal(t, 1, mock.sendCalled)
+	})
+	t.Run("updates existing live query mappings", func(t *testing.T) {
+		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+		ctx := context.Background()
+
+		// Setup initial state with existing mappings
+		oldExternalID := "old-external-uuid"
+		internalID := "stable-internal-uuid"
+
+		rlq.liveQueries[internalID] = &LiveQueryInfo{
+			InternalID: internalID,
+			ExternalID: oldExternalID,
+			Method:     "live",
+			Params:     []any{"users", false},
+		}
+
+		// Create mock that returns a new UUID
+		newExternalUUID := uuid.Must(uuid.NewV4())
+		newExternalID := newExternalUUID.String()
+		mock := &mockRPCSender{
+			mockResult: func(method string) cbor.RawMessage {
+				uuid := models.UUID{UUID: newExternalUUID}
+				data, _ := cbor.Marshal(cbor.Tag{
+					Number:  models.TagSpecBinaryUUID,
+					Content: uuid,
+				})
+				return data
+			},
+		}
+
+		mockProvider := newMockNotificationProvider()
+
+		// Restore live queries
+		err := rlq.restoreLiveQueries(ctx, mock, mockProvider, log)
+		assert.NoError(t, err)
+
+		// Verify the LiveQueryInfo was updated with new external ID
+		assert.Equal(t, newExternalID, rlq.liveQueries[internalID].ExternalID)
+		assert.Equal(t, internalID, rlq.liveQueries[internalID].InternalID)
+	})
+
+	t.Run("restores multiple queries with existing mappings", func(t *testing.T) {
+		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+		ctx := context.Background()
+
+		// Setup initial state with multiple existing mappings
+		queries := map[string]*LiveQueryInfo{
+			"internal-1": {
+				InternalID: "internal-1",
+				ExternalID: "old-external-1",
+				Method:     "live",
+				Params:     []any{"users"},
+			},
+			"internal-2": {
+				InternalID: "internal-2",
+				ExternalID: "old-external-2",
+				Method:     "query",
+				Params:     []any{"LIVE SELECT * FROM products"},
+			},
+		}
+
+		for id, info := range queries {
+			rlq.liveQueries[id] = info
+		}
+
+		// Track which methods were called
+		var callCount int
+		methodCalls := make(map[string]int)
+
+		queries["internal-1"].ExternalID = uuid.Must(uuid.NewV4()).String()
+		queries["internal-2"].ExternalID = uuid.Must(uuid.NewV4()).String()
+
+		// Create mock that returns different UUIDs for each call
+		mock := &mockRPCSender{
+			mockResult: func(method string) cbor.RawMessage {
+				callCount++
+				methodCalls[method]++
+
+				var info *LiveQueryInfo
+				for _, v := range rlq.liveQueries {
+					if v.Method == method {
+						info = v
+						break
+					}
+				}
+
+				uuid := models.UUID{UUID: uuid.Must(uuid.FromString(info.ExternalID))}
+
+				// Return proper format based on method
+				if method == "query" {
+					type QueryResult struct {
+						Status string          `json:"status"`
+						Time   string          `json:"time"`
+						Result cbor.RawMessage `json:"result"`
+					}
+
+					uuidData, _ := cbor.Marshal(cbor.Tag{
+						Number:  models.TagSpecBinaryUUID,
+						Content: uuid,
+					})
+					queryResults := []QueryResult{
+						{
+							Status: "OK",
+							Time:   "1ms",
+							Result: uuidData,
+						},
+					}
+
+					data, _ := cbor.Marshal(queryResults)
+					return data
+				} else {
+					data, _ := cbor.Marshal(cbor.Tag{
+						Number:  models.TagSpecBinaryUUID,
+						Content: uuid,
+					})
+					return data
+				}
+			},
+		}
+
+		mockProvider := newMockNotificationProvider()
+
+		// Restore live queries
+		err := rlq.restoreLiveQueries(ctx, mock, mockProvider, log)
+		assert.NoError(t, err)
+
+		// Verify all queries were restored
+		assert.Equal(t, 2, callCount)
+		assert.Equal(t, 1, methodCalls["live"])
+		assert.Equal(t, 1, methodCalls["query"])
+
+		assert.Equal(t, queries, rlq.liveQueries)
+	})
+}
+
+// TestReliableLQ_handleSend tests the handleSend method's behavior
+func TestReliableLQ_handleSend(t *testing.T) {
+	// QueryResult represents the response from a query method
+	type QueryResult struct {
+		Status string          `json:"status"`
+		Time   string          `json:"time"`
+		Result cbor.RawMessage `json:"result"`
+	}
+
+	// Create response for live method (direct UUID)
+	liveUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+	liveData, _ := cbor.Marshal(cbor.Tag{
+		Number:  models.TagSpecBinaryUUID,
+		Content: liveUUID,
+	})
+	liveResp := &connection.RPCResponse[cbor.RawMessage]{
+		Result: (*cbor.RawMessage)(&liveData),
+	}
+
+	// Create response for query method (array of QueryResult with UUID)
+	queryUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+	queryUUIDData, _ := cbor.Marshal(cbor.Tag{
+		Number:  models.TagSpecBinaryUUID,
+		Content: queryUUID,
+	})
+	queryResults := []QueryResult{
+		{
+			Status: "OK",
+			Time:   "1ms",
+			Result: queryUUIDData,
+		},
+	}
+	queryData, _ := cbor.Marshal(queryResults)
+	queryResp := &connection.RPCResponse[cbor.RawMessage]{
+		Result: (*cbor.RawMessage)(&queryData),
+	}
+
+	tests := []struct {
+		name        string
+		method      string
+		params      []any
+		resp        *connection.RPCResponse[cbor.RawMessage]
+		handled     bool
+		sendCalled  int
+		lastMethod  string
+		lastParams  []any
+		description string
+	}{
+		{
+			name:        "handles live RPC",
+			method:      "live",
+			params:      []any{"users"},
+			handled:     true,
+			sendCalled:  1,
+			lastMethod:  "live",
+			lastParams:  []any{"users"},
+			resp:        liveResp,
+			description: "Should handle 'live' method calls",
+		},
+		{
+			name:        "handles query RPC with LIVE SELECT",
+			method:      "query",
+			params:      []any{"LIVE SELECT * FROM products WHERE active = true"},
+			handled:     true,
+			sendCalled:  1,
+			lastMethod:  "query",
+			lastParams:  []any{"LIVE SELECT * FROM products WHERE active = true"},
+			resp:        queryResp,
+			description: "Should handle 'query' method with LIVE SELECT statement",
+		},
+		{
+			name:        "does not handle query RPC with regular SELECT",
+			method:      "query",
+			params:      []any{"SELECT * FROM products WHERE active = true"},
+			handled:     false,
+			sendCalled:  0,
+			description: "Should not handle 'query' method with regular SELECT statement",
+		},
+		{
+			name:        "does not handle select RPC",
+			method:      "select",
+			params:      []any{"users", "123"},
+			handled:     false,
+			sendCalled:  0,
+			description: "Should not handle 'select' method calls",
+		},
+		{
+			name:        "handles case-insensitive LIVE SELECT",
+			method:      "query",
+			params:      []any{"live select * from users"},
+			handled:     true,
+			sendCalled:  1,
+			lastMethod:  "query",
+			lastParams:  []any{"live select * from users"},
+			resp:        queryResp,
+			description: "Should handle LIVE SELECT in lowercase",
+		},
+		{
+			name:        "handles LIVE SELECT with whitespace",
+			method:      "query",
+			params:      []any{"  LIVE SELECT  * FROM users  "},
+			handled:     true,
+			sendCalled:  1,
+			lastMethod:  "query",
+			lastParams:  []any{"  LIVE SELECT  * FROM users  "},
+			resp:        queryResp,
+			description: "Should handle LIVE SELECT with extra whitespace",
+		},
+		{
+			name:        "does not handle empty query params",
+			method:      "query",
+			params:      []any{},
+			handled:     false,
+			sendCalled:  0,
+			description: "Should not handle query with empty params",
+		},
+		{
+			name:        "does not handle create RPC",
+			method:      "create",
+			params:      []any{"users", map[string]any{"name": "test"}},
+			handled:     false,
+			sendCalled:  0,
+			description: "Should not handle 'create' method calls",
+		},
+		{
+			name:        "does not handle update RPC",
+			method:      "update",
+			params:      []any{"users:123", map[string]any{"name": "test"}},
+			handled:     false,
+			sendCalled:  0,
+			description: "Should not handle 'update' method calls",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockRPCSender{
+				mockResult: func(method string) cbor.RawMessage {
+					if tt.resp != nil && tt.resp.Result != nil {
+						return *tt.resp.Result
+					}
+					return cbor.RawMessage{}
+				},
+			}
+			log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+			rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+			ctx := context.Background()
+
+			handled, resp, err := rlq.handleSend(ctx, tt.method, tt.params, mock, log)
+
+			assert.NoError(t, err, tt.description)
+			assert.Equal(t, tt.handled, handled, tt.description+" - handled flag")
+			assert.Equal(t, tt.sendCalled, mock.sendCalled, tt.description+" - sendCalled")
+			assert.Equal(t, tt.lastMethod, mock.lastMethod, tt.description+" - method")
+			assert.Equal(t, tt.lastParams, mock.lastParams, tt.description+" - params")
+			assert.Equal(t, tt.resp, resp, tt.description+" - response")
+		})
+	}
+}
+
+// TestReliableLQ_handleSend_tracking tests that handleSend properly tracks live queries
+func TestReliableLQ_handleSend_tracking(t *testing.T) {
+	// Setup
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+	ctx := context.Background()
+
+	// Create a mock that returns a UUID in the response
+	testUUID := uuid.Must(uuid.NewV4())
+	uuidStr := testUUID.String()
+	mock := &mockRPCSender{
+		mockResult: func(method string) cbor.RawMessage {
+			// Return a mock UUID response as models.UUID
+			uuid := models.UUID{UUID: testUUID}
+			data, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: uuid})
+			return data
+		},
+	}
+
+	// Test live method tracking
+	t.Run("tracks live query", func(t *testing.T) {
+		params := []any{"users", false}
+		handled, resp, err := rlq.handleSend(ctx, "live", params, mock, log)
+
+		assert.True(t, handled)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify the live query was tracked
+		assert.Len(t, rlq.liveQueries, 1)
+		assert.Contains(t, rlq.liveQueries, uuidStr)
+		info := rlq.liveQueries[uuidStr]
+		assert.NotNil(t, info)
+		assert.Equal(t, "live", info.Method)
+		assert.Equal(t, params, info.Params)
+	})
+
+	// Clear tracked queries
+	rlq.liveQueries = make(map[string]*LiveQueryInfo)
+
+	// Test LIVE SELECT tracking
+	t.Run("tracks LIVE SELECT query", func(t *testing.T) {
+		query := "LIVE SELECT * FROM products"
+		params := []any{query, nil}
+		liveSelectTestUUID := uuid.Must(uuid.NewV4())
+		liveSelectUUIDStr := liveSelectTestUUID.String()
+
+		// For LIVE SELECT, the response is an array of QueryResult objects
+		mock.mockResult = func(method string) cbor.RawMessage {
+			// Create a QueryResult array with the UUID in the Result field
+			type QueryResult struct {
+				Status string          `json:"status"`
+				Time   string          `json:"time"`
+				Result cbor.RawMessage `json:"result"`
+			}
+
+			uuidData, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: liveSelectTestUUID})
+			queryResults := []QueryResult{
+				{
+					Status: "OK",
+					Time:   "1ms",
+					Result: uuidData,
+				},
+			}
+
+			data, _ := cbor.Marshal(queryResults)
+			return data
+		}
+
+		handled, resp, err := rlq.handleSend(ctx, "query", params, mock, log)
+
+		assert.True(t, handled)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify the LIVE SELECT was tracked
+		assert.Len(t, rlq.liveQueries, 1)
+		assert.Contains(t, rlq.liveQueries, liveSelectUUIDStr)
+		info := rlq.liveQueries[liveSelectUUIDStr]
+		assert.NotNil(t, info)
+		assert.Equal(t, "query", info.Method)
+		assert.Equal(t, params, info.Params)
+	})
+}
+
+// TestReliableLQ_recordLiveQueryFromResponse_errors tests error handling
+func TestReliableLQ_recordLiveQueryFromResponse_errors(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+	rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+
+	tests := []struct {
+		name        string
+		method      string
+		params      []any
+		result      cbor.RawMessage
+		expectError string
+	}{
+		{
+			name:        "returns error for invalid UUID in live method",
+			method:      "live",
+			params:      []any{"users"},
+			result:      cbor.RawMessage([]byte{0x01, 0x02}), // Invalid CBOR
+			expectError: "failed to decode live query UUID",
+		},
+		{
+			name:        "returns error for invalid CBOR in query method",
+			method:      "query",
+			params:      []any{"LIVE SELECT * FROM users"},
+			result:      cbor.RawMessage([]byte{0x01, 0x02}), // Invalid CBOR
+			expectError: "failed to decode query results array",
+		},
+		{
+			name:        "returns error for empty result in query method",
+			method:      "query",
+			params:      []any{"LIVE SELECT * FROM users"},
+			result:      cbor.RawMessage{},
+			expectError: "failed to decode query results array",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rlq.recordLiveQueryFromResponse(&tt.result, tt.method, tt.params, log)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+// mockRPCSender is used for testing send operations
+type mockRPCSender struct {
+	sendCalled int
+	lastMethod string
+	lastParams []any
+	mockResult func(method string) cbor.RawMessage
+}
+
+func (m *mockRPCSender) Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error) {
+	m.sendCalled++
+	m.lastMethod = method
+	m.lastParams = params
+
+	// Return a mock response
+	var result cbor.RawMessage
+	if m.mockResult != nil {
+		result = m.mockResult(method)
+	} else {
+		// Default empty response
+		result = cbor.RawMessage{}
+	}
+
+	return &connection.RPCResponse[cbor.RawMessage]{
+		Result: &result,
+	}, nil
+}

--- a/contrib/rews/rews_lq.go
+++ b/contrib/rews/rews_lq.go
@@ -1,0 +1,32 @@
+package rews
+
+import (
+	"context"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+// Send overrides the WebSocketConnection's Send method to intercept live queries
+func (arws *Connection[C]) Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error) {
+	// Let handleSend intercept and potentially handle the send
+	handled, resp, err := arws.reliableLQ.handleSend(ctx, method, params, arws.WebSocketConnection, arws.logger)
+	if handled {
+		// handleSend processed this request
+		return resp, err
+	}
+
+	// Not a live query, send normally through the underlying connection
+	return arws.WebSocketConnection.Send(ctx, method, params...)
+}
+
+// LiveNotifications overrides to provide UUID mapping for live queries
+func (arws *Connection[C]) LiveNotifications(id string) (chan connection.Notification, error) {
+	return arws.reliableLQ.liveNotifications(id, arws.WebSocketConnection)
+}
+
+// CloseLiveNotifications overrides to handle UUID mapping
+func (arws *Connection[C]) CloseLiveNotifications(id string) error {
+	_, err := arws.reliableLQ.closeLiveNotifications(arws.WebSocketConnection, id)
+	return err
+}

--- a/contrib/rews/rews_lq_test.go
+++ b/contrib/rews/rews_lq_test.go
@@ -1,0 +1,211 @@
+package rews
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// TestLiveQueryLifecycle tests the lifecycle of live queries
+// including LiveNotifications and CloseLiveNotifications calls.
+// This primarily ensure that the LQ-related features work correctly with rews,
+// when no reconnection is involved.
+func TestLiveQueryLifecycle(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Create a mock that returns proper UUIDs for live queries
+	mock := &mockWebSocketConnection{
+		notifications: make(map[string]chan connection.Notification),
+	}
+
+	conn := &Connection[*mockWebSocketConnection]{
+		WebSocketConnection: mock,
+		reliableLQ:          newReliableLQ(log, &models.CborUnmarshaler{}),
+		logger:              log,
+		sessionVars:         make(map[string]any),
+	}
+
+	ctx := context.Background()
+
+	t.Run("live RPC with notifications", func(t *testing.T) {
+		// Call live RPC
+		resp, err := conn.Send(ctx, methodLive, "users", false)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Result)
+
+		// Extract the UUID from the response
+		var liveID models.UUID
+		err = cbor.Unmarshal(*resp.Result, &liveID)
+		require.NoError(t, err)
+		liveIDStr := liveID.String()
+		require.NotEmpty(t, liveIDStr)
+
+		// Get live notifications channel
+		ch, err := conn.LiveNotifications(liveIDStr)
+		require.NoError(t, err)
+		require.NotNil(t, ch)
+
+		// Send a test notification through the mock
+		notificationID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+		testNotification := connection.Notification{
+			ID:     &notificationID,
+			Action: connection.CreateAction,
+			Result: map[string]any{"test": "data"},
+		}
+
+		// Send notification to the channel
+		go func() {
+			mock.SendNotification(liveIDStr, testNotification)
+		}()
+
+		// Receive the notification
+		select {
+		case received := <-ch:
+			assert.Equal(t, testNotification.ID, received.ID)
+			assert.Equal(t, testNotification.Action, received.Action)
+		case <-time.After(1 * time.Second):
+			t.Fatal("Timeout waiting for notification")
+		}
+
+		// Close live notifications
+		err = conn.CloseLiveNotifications(liveIDStr)
+		require.NoError(t, err)
+
+		// Verify the channel is closed
+		select {
+		case _, ok := <-ch:
+			assert.False(t, ok, "Channel should be closed")
+		case <-time.After(100 * time.Millisecond):
+			// Channel might be blocked, but that's ok as long as CloseLiveNotifications didn't error
+		}
+	})
+
+	t.Run("LIVE SELECT query with notifications", func(t *testing.T) {
+		// Call query RPC with LIVE SELECT
+		resp, err := conn.Send(ctx, methodQuery, "LIVE SELECT * FROM products WHERE active = true", nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Result)
+
+		// For LIVE SELECT, the response is an array of QueryResult
+		type QueryResult struct {
+			Status string          `json:"status"`
+			Time   string          `json:"time"`
+			Result cbor.RawMessage `json:"result"`
+		}
+
+		var queryResults []QueryResult
+		err = cbor.Unmarshal(*resp.Result, &queryResults)
+		require.NoError(t, err)
+		require.Len(t, queryResults, 1)
+
+		var liveID models.UUID
+		err = cbor.Unmarshal(queryResults[0].Result, &liveID)
+		require.NoError(t, err)
+		liveIDStr := liveID.String()
+		require.NotEmpty(t, liveIDStr)
+
+		// Get live notifications channel
+		ch, err := conn.LiveNotifications(liveIDStr)
+		require.NoError(t, err)
+		require.NotNil(t, ch)
+
+		// Send a test notification
+		notificationID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+		testNotification := connection.Notification{
+			ID:     &notificationID,
+			Action: connection.UpdateAction,
+			Result: map[string]any{"product": "updated"},
+		}
+
+		go func() {
+			mock.SendNotification(liveIDStr, testNotification)
+		}()
+
+		// Receive the notification
+		select {
+		case received := <-ch:
+			assert.Equal(t, testNotification.ID, received.ID)
+			assert.Equal(t, testNotification.Action, received.Action)
+		case <-time.After(1 * time.Second):
+			t.Fatal("Timeout waiting for notification")
+		}
+
+		// Close live notifications
+		err = conn.CloseLiveNotifications(liveIDStr)
+		require.NoError(t, err)
+
+		// Verify the internal tracking was cleaned up
+		conn.reliableLQ.liveQueriesMu.RLock()
+		_, exists := conn.reliableLQ.liveQueries[liveIDStr]
+		conn.reliableLQ.liveQueriesMu.RUnlock()
+		assert.False(t, exists, "Live query should be removed from tracking")
+	})
+
+	t.Run("multiple live queries with proper cleanup", func(t *testing.T) {
+		var liveIDs []string
+
+		// Create multiple live queries
+		for i := 0; i < 3; i++ {
+			table := fmt.Sprintf("table_%d", i)
+			resp, err := conn.Send(ctx, methodLive, table, false)
+			require.NoError(t, err)
+
+			var liveID models.UUID
+			err = cbor.Unmarshal(*resp.Result, &liveID)
+			require.NoError(t, err)
+			liveIDs = append(liveIDs, liveID.String())
+		}
+
+		// Get notification channels for all
+		channels := make(map[string]chan connection.Notification)
+		for _, id := range liveIDs {
+			ch, err := conn.LiveNotifications(id)
+			require.NoError(t, err)
+			channels[id] = ch
+		}
+
+		// Verify all channels work
+		for id, ch := range channels {
+			notificationID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+			notification := connection.Notification{
+				ID:     &notificationID,
+				Action: connection.CreateAction,
+			}
+
+			go func(id string, n connection.Notification) {
+				mock.SendNotification(id, n)
+			}(id, notification)
+
+			select {
+			case received := <-ch:
+				assert.Equal(t, notification.ID, received.ID)
+			case <-time.After(1 * time.Second):
+				t.Fatalf("Timeout waiting for notification on %s", id)
+			}
+		}
+
+		// Close all live queries
+		for _, id := range liveIDs {
+			err := conn.CloseLiveNotifications(id)
+			require.NoError(t, err)
+		}
+
+		// Verify all are cleaned up
+		conn.reliableLQ.liveQueriesMu.RLock()
+		assert.Len(t, conn.reliableLQ.liveQueries, 0, "All live queries should be removed")
+		conn.reliableLQ.liveQueriesMu.RUnlock()
+	})
+}

--- a/contrib/rews/rews_test.go
+++ b/contrib/rews/rews_test.go
@@ -1,0 +1,412 @@
+package rews
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// TestConnection tests all public methods of the Connection struct
+func TestConnection(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Helper function to create a new Connection with a mock
+	createConnection := func() (*Connection[*mockWebSocketConnection], *mockWebSocketConnection) {
+		mock := &mockWebSocketConnection{
+			notifications: make(map[string]chan connection.Notification),
+		}
+
+		conn := &Connection[*mockWebSocketConnection]{
+			WebSocketConnection: mock,
+			reliableLQ:          newReliableLQ(log, &models.CborUnmarshaler{}),
+			logger:              log,
+			sessionVars:         make(map[string]any),
+			state:               StateConnected, // Start in connected state for most tests
+			CheckInterval:       100 * time.Millisecond,
+		}
+
+		return conn, mock
+	}
+
+	ctx := context.Background()
+
+	t.Run("IsClosed", func(t *testing.T) {
+		conn, _ := createConnection()
+
+		// Initially not closed
+		assert.False(t, conn.IsClosed())
+
+		// After transitioning to closed state
+		conn.state = StateClosed
+		assert.True(t, conn.IsClosed())
+
+		// Test other states
+		states := []State{
+			StateDisconnected,
+			StateConnecting,
+			StateConnected,
+			StateClosing,
+		}
+
+		for _, state := range states {
+			conn.state = state
+			assert.False(t, conn.IsClosed(), "Should not be closed in state: %v", state)
+		}
+	})
+
+	t.Run("Use", func(t *testing.T) {
+		conn, mock := createConnection()
+
+		// Test setting namespace and database
+		err := conn.Use(ctx, "test_ns", "test_db")
+		require.NoError(t, err)
+
+		// Verify session state was updated
+		assert.Equal(t, "test_ns", conn.sessionNS)
+		assert.Equal(t, "test_db", conn.sessionDB)
+
+		// Test with empty values
+		err = conn.Use(ctx, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "", conn.sessionNS)
+		assert.Equal(t, "", conn.sessionDB)
+
+		// Test with special characters
+		err = conn.Use(ctx, "ns-with-dash", "db_with_underscore")
+		require.NoError(t, err)
+		assert.Equal(t, "ns-with-dash", conn.sessionNS)
+		assert.Equal(t, "db_with_underscore", conn.sessionDB)
+
+		// Test when connection is closed
+		conn.state = StateClosed
+		mock.isClosed = true
+		err = conn.Use(ctx, "should", "fail")
+		assert.Error(t, err, "Should fail when connection is closed")
+	})
+
+	t.Run("Let", func(t *testing.T) {
+		conn, mock := createConnection()
+
+		// Test setting various types of variables
+		testCases := []struct {
+			key   string
+			value any
+		}{
+			{"string_var", "test_value"},
+			{"int_var", 42},
+			{"float_var", 3.14},
+			{"bool_var", true},
+			{"nil_var", nil},
+			{"map_var", map[string]any{"nested": "value"}},
+			{"slice_var", []int{1, 2, 3}},
+		}
+
+		for _, tc := range testCases {
+			err := conn.Let(ctx, tc.key, tc.value)
+			require.NoError(t, err, "Failed to set variable %s", tc.key)
+			assert.Equal(t, tc.value, conn.sessionVars[tc.key], "Variable %s not stored correctly", tc.key)
+		}
+
+		// Test overwriting existing variable
+		err := conn.Let(ctx, "string_var", "new_value")
+		require.NoError(t, err)
+		assert.Equal(t, "new_value", conn.sessionVars["string_var"])
+
+		// Test when connection is closed
+		conn.state = StateClosed
+		mock.isClosed = true
+		err = conn.Let(ctx, "should_fail", "value")
+		assert.Error(t, err, "Should fail when connection is closed")
+	})
+
+	t.Run("Unset", func(t *testing.T) {
+		conn, mock := createConnection()
+
+		// Set some variables first
+		conn.sessionVars["var1"] = "value1"
+		conn.sessionVars["var2"] = "value2"
+		conn.sessionVars["var3"] = "value3"
+
+		// Test unsetting a variable
+		err := conn.Unset(ctx, "var1")
+		require.NoError(t, err)
+		_, exists := conn.sessionVars["var1"]
+		assert.False(t, exists, "Variable should be removed")
+
+		// Verify other variables are untouched
+		assert.Equal(t, "value2", conn.sessionVars["var2"])
+		assert.Equal(t, "value3", conn.sessionVars["var3"])
+
+		// Test unsetting non-existent variable (should not error)
+		err = conn.Unset(ctx, "non_existent")
+		require.NoError(t, err)
+
+		// Test unsetting all remaining variables
+		err = conn.Unset(ctx, "var2")
+		require.NoError(t, err)
+		err = conn.Unset(ctx, "var3")
+		require.NoError(t, err)
+		assert.Len(t, conn.sessionVars, 0, "All variables should be removed")
+
+		// Test when connection is closed
+		conn.state = StateClosed
+		mock.isClosed = true
+		err = conn.Unset(ctx, "should_fail")
+		assert.Error(t, err, "Should fail when connection is closed")
+	})
+
+	t.Run("SignIn", func(t *testing.T) {
+		conn, mock := createConnection()
+
+		// Test successful sign in
+		authData := map[string]any{
+			"user": "testuser",
+			"pass": "testpass",
+		}
+
+		token, err := conn.SignIn(ctx, authData)
+		require.NoError(t, err)
+		assert.Equal(t, "test-token", token)
+		assert.Equal(t, "test-token", conn.sessionToken, "Token should be stored in session")
+
+		// Test with different auth structures
+		authDataWithNS := map[string]any{
+			"ns":   "test",
+			"db":   "test",
+			"user": "admin",
+			"pass": "admin",
+		}
+
+		token, err = conn.SignIn(ctx, authDataWithNS)
+		require.NoError(t, err)
+		assert.Equal(t, "test-token", token)
+
+		// Test with struct auth data
+		type AuthStruct struct {
+			Username string `json:"user"`
+			Password string `json:"pass"`
+		}
+
+		authStruct := AuthStruct{
+			Username: "structuser",
+			Password: "structpass",
+		}
+
+		token, err = conn.SignIn(ctx, authStruct)
+		require.NoError(t, err)
+		assert.Equal(t, "test-token", token)
+
+		// Test when connection is closed
+		conn.state = StateClosed
+		mock.isClosed = true
+		_, err = conn.SignIn(ctx, authData)
+		assert.Error(t, err, "Should fail when connection is closed")
+	})
+
+	t.Run("SignUp", func(t *testing.T) {
+		conn, mock := createConnection()
+
+		// Test successful sign up
+		authData := map[string]any{
+			"user":  "newuser",
+			"pass":  "newpass",
+			"email": "test@example.com",
+		}
+
+		token, err := conn.SignUp(ctx, authData)
+		require.NoError(t, err)
+		assert.Equal(t, "test-token", token)
+		assert.Equal(t, "test-token", conn.sessionToken, "Token should be stored in session")
+
+		// Test with minimal auth data
+		minimalAuth := map[string]any{
+			"user": "minimal",
+			"pass": "minimal",
+		}
+
+		token, err = conn.SignUp(ctx, minimalAuth)
+		require.NoError(t, err)
+		assert.Equal(t, "test-token", token)
+
+		// Test with additional fields
+		extendedAuth := map[string]any{
+			"user":      "extended",
+			"pass":      "extended",
+			"email":     "extended@example.com",
+			"firstName": "Test",
+			"lastName":  "User",
+			"age":       25,
+		}
+
+		token, err = conn.SignUp(ctx, extendedAuth)
+		require.NoError(t, err)
+		assert.Equal(t, "test-token", token)
+
+		// Test when connection is closed
+		conn.state = StateClosed
+		mock.isClosed = true
+		_, err = conn.SignUp(ctx, authData)
+		assert.Error(t, err, "Should fail when connection is closed")
+	})
+
+	t.Run("Authenticate", func(t *testing.T) {
+		conn, mock := createConnection()
+
+		// Test successful authentication
+		testToken := "myexampletoken.test.signature"
+		err := conn.Authenticate(ctx, testToken)
+		require.NoError(t, err)
+		assert.Equal(t, testToken, conn.sessionToken, "Token should be stored in session")
+
+		// Test with different token format
+		anotherToken := "Bearer token123456"
+		err = conn.Authenticate(ctx, anotherToken)
+		require.NoError(t, err)
+		assert.Equal(t, anotherToken, conn.sessionToken, "New token should replace old one")
+
+		// Test with empty token (should clear authentication)
+		err = conn.Authenticate(ctx, "")
+		require.NoError(t, err)
+		assert.Equal(t, "", conn.sessionToken, "Empty token should clear session")
+
+		// Test when connection is closed
+		conn.state = StateClosed
+		mock.isClosed = true
+		err = conn.Authenticate(ctx, "should_fail")
+		assert.Error(t, err, "Should fail when connection is closed")
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		conn, mock := createConnection()
+
+		// Initialize channels as they would be in Connect
+		conn.connCloseCh = make(chan int, 1)
+		conn.reconnLoopCloseCh = make(chan int, 1)
+
+		// Start a minimal reconnection loop to avoid blocking
+		go func() {
+			<-conn.connCloseCh
+			close(conn.reconnLoopCloseCh)
+		}()
+
+		// Setup some session state
+		conn.sessionNS = "test_ns"
+		conn.sessionDB = "test_db"
+		conn.sessionToken = "test_token"
+		conn.sessionVars["var1"] = "value1"
+
+		// Close the connection
+		err := conn.Close(ctx)
+		require.NoError(t, err)
+		assert.True(t, mock.isClosed, "Mock should be marked as closed")
+		assert.Equal(t, StateClosed, conn.state, "Connection state should be closed")
+
+		// Verify session state is preserved (for potential reconnection logic)
+		assert.Equal(t, "test_ns", conn.sessionNS, "Session NS should be preserved")
+		assert.Equal(t, "test_db", conn.sessionDB, "Session DB should be preserved")
+		assert.Equal(t, "test_token", conn.sessionToken, "Session token should be preserved")
+		assert.Equal(t, "value1", conn.sessionVars["var1"], "Session vars should be preserved")
+
+		// Test closing already closed connection
+		err = conn.Close(ctx)
+		assert.Error(t, err, "Should error when closing already closed connection")
+	})
+}
+
+// TestConnectionStateTransitions tests the state machine transitions
+func TestConnectionStateTransitions(t *testing.T) {
+	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("Valid transitions", func(t *testing.T) {
+		conn := &Connection[*mockWebSocketConnection]{
+			logger: log,
+			state:  StateDisconnected,
+		}
+
+		// Disconnected -> Connecting
+		err := conn.transitionTo(StateConnecting)
+		assert.NoError(t, err)
+		assert.Equal(t, StateConnecting, conn.state)
+
+		// Connecting -> Connected
+		err = conn.transitionTo(StateConnected)
+		assert.NoError(t, err)
+		assert.Equal(t, StateConnected, conn.state)
+
+		// Connected -> Disconnected (connection lost)
+		err = conn.transitionTo(StateDisconnected)
+		assert.NoError(t, err)
+		assert.Equal(t, StateDisconnected, conn.state)
+
+		// Disconnected -> Connecting (reconnect)
+		err = conn.transitionTo(StateConnecting)
+		assert.NoError(t, err)
+		assert.Equal(t, StateConnecting, conn.state)
+
+		// Connecting -> Connected
+		err = conn.transitionTo(StateConnected)
+		assert.NoError(t, err)
+		assert.Equal(t, StateConnected, conn.state)
+
+		// Connected -> Closing
+		err = conn.transitionTo(StateClosing)
+		assert.NoError(t, err)
+		assert.Equal(t, StateClosing, conn.state)
+
+		// Closing -> Closed
+		err = conn.transitionTo(StateClosed)
+		assert.NoError(t, err)
+		assert.Equal(t, StateClosed, conn.state)
+	})
+
+	t.Run("Invalid transitions", func(t *testing.T) {
+		testCases := []struct {
+			from State
+			to   State
+			desc string
+		}{
+			{StateDisconnected, StateConnected, "Cannot transition from Disconnected to Connected"},
+			{StateDisconnected, StateClosed, "Cannot transition from Disconnected to Closed"},
+			{StateConnecting, StateClosing, "Cannot transition from Connecting to Closing"},
+			{StateConnected, StateClosed, "Cannot transition from Connected to Closed"},
+			{StateClosing, StateConnecting, "Cannot transition from Closing to Connecting"},
+			{StateClosing, StateConnected, "Cannot transition from Closing to Connected"},
+			{StateClosing, StateDisconnected, "Cannot transition from Closing to Disconnected"},
+			{StateClosed, StateConnecting, "Cannot reconnect from Closed state"},
+			{StateClosed, StateConnected, "Cannot reconnect from Closed state"},
+			{StateClosed, StateDisconnected, "Cannot disconnect from Closed state"},
+		}
+
+		for _, tc := range testCases {
+			conn := &Connection[*mockWebSocketConnection]{
+				logger: log,
+				state:  tc.from,
+			}
+
+			err := conn.transitionTo(tc.to)
+			assert.Error(t, err, tc.desc)
+			assert.Equal(t, tc.from, conn.state, "State should not change on invalid transition")
+		}
+	})
+
+	t.Run("Self transitions", func(t *testing.T) {
+		// Some states allow self-transitions
+		conn := &Connection[*mockWebSocketConnection]{
+			logger: log,
+			state:  StateDisconnected,
+		}
+
+		// Disconnected -> Disconnected (allowed)
+		err := conn.transitionTo(StateDisconnected)
+		assert.NoError(t, err)
+		assert.Equal(t, StateDisconnected, conn.state)
+	})
+}

--- a/contrib/testenv/connection.go
+++ b/contrib/testenv/connection.go
@@ -198,6 +198,7 @@ func (c *Config) New() (*surrealdb.DB, error) {
 						return gws.New(conf), nil
 					},
 					c.ReconnectDuration,
+					conf.Unmarshaler,
 					conf.Logger,
 				)
 			} else {
@@ -206,6 +207,7 @@ func (c *Config) New() (*surrealdb.DB, error) {
 						return gorillaws.New(conf), nil
 					},
 					c.ReconnectDuration,
+					conf.Unmarshaler,
 					conf.Logger,
 				)
 			}

--- a/pkg/connection/integration/rews_test.go
+++ b/pkg/connection/integration/rews_test.go
@@ -115,8 +115,11 @@ func testDoReconnect[C connection.WebSocketConnection](t *testing.T, newConnFunc
 	// Short reconnection check interval for testing
 	checkInterval := 100 * time.Millisecond
 
-	// Create auto-reconnecting connection
-	conn := rews.New(newConnFunc(wsURL), checkInterval, logger.New(slog.NewTextHandler(os.Stdout, nil)))
+	// Create auto-reconnecting connection with proper unmarshaler
+	u, err := url.ParseRequestURI(wsURL)
+	require.NoError(t, err)
+	config := connection.NewConfig(u)
+	conn := rews.New(newConnFunc(wsURL), checkInterval, config.Unmarshaler, logger.New(slog.NewTextHandler(os.Stdout, nil)))
 
 	// Create DB instance
 	db, err := surrealdb.FromConnection(context.Background(), conn)


### PR DESCRIPTION
This enhances the `rews` feature (#267 and #279) to additionally support restoring live queries on reconnection.
Previously, the Go channel for receiving live notifications stopped working after the first automatic reconnection done by `rews`, which made it very difficult for users to use `rews` with live queries.
Since this change, users can expect that the channel will work across reconnections.

This is done by `rews` replaying the `live` RPCs or the `query` RPCs with `LIVE SELECT` statements on reconnection, while tracking live notification UUID changes for routing the live notifications sent from SurrealDB to the original channel that is created when the user initially called the `LiveNotifications` function before reconnection.

A theoretical gotcha is that it isn't perfect due to how SurrealDB works. You can prevent a live query from being replayed externally by changing the user's permissions. In this case, the replayed live query will fail upon reconnection, and you need to adjust the permission so that the live query can be successfully replayed upon subsequent reconnection.

Ref #110
Ref #280