### PR TITLE
surrealql: Streamline continued change feed reading

### DIFF
--- a/contrib/surrealdump/dump.go
+++ b/contrib/surrealdump/dump.go
@@ -317,11 +317,7 @@ func (d *Dumper) getTableChanges(ctx context.Context, table string, sinceVersion
 	Versionstamp uint64
 	Changes      []Change
 }, maxVs uint64, err error) {
-	// SurrealDB versionstamps include extra bytes for FoundationDB ordering
-	// When using SINCE, we need to shift right by 16 bits to get the logical version
-	// See: https://surrealdb.com/docs/surrealql/statements/show
-	adjustedVs := sinceVersionstamp >> 16
-	q := surrealql.ShowChangesForTable(table).SinceVersionstamp(adjustedVs)
+	q := surrealql.ShowChangesForTable(table).SinceVersionstamp(sinceVersionstamp)
 	query, _ := q.Build()
 
 	type ChangeSet struct {

--- a/contrib/surrealql/example_show_changes_test.go
+++ b/contrib/surrealql/example_show_changes_test.go
@@ -46,8 +46,11 @@ func ExampleShowChangesForTable_sinceRawVersionstamp() {
 
 func ExampleShowChangesForTable_sinceVersionstamp() {
 	// Show changes since a specific versionstamp
+	// Note: If you pass a versionstamp from a previous SHOW CHANGES result (e.g., 6553600),
+	// this method automatically adjusts it by shifting right 16 bits (to 100 in this case)
+	// to get the logical version for the SINCE clause
 	q := surrealql.ShowChangesForTable("events").
-		SinceVersionstamp(100).
+		SinceVersionstamp(6553600). // This will be automatically adjusted to 100
 		Limit(50)
 
 	sql, _ := q.Build()


### PR DESCRIPTION
This enhances the surrealql library added in #289 by improving the `SinceVersionstamp` helper to automatically right-shift the provided full versionstamp, so that you don't need to worry about the implementation detail when continuing to read change feed entries from where you left off.