### PR TITLE
Fix live query example test flakiness

### DIFF
--- a/example/example_livequery_test.go
+++ b/example/example_livequery_test.go
@@ -187,12 +187,12 @@ func ExampleLive() {
 		panic("Timeout waiting for all notifications")
 	}
 
+	fmt.Println("Live query being terminated")
+
 	err = surrealdb.Kill(ctx, db, live.String())
 	if err != nil {
 		panic(fmt.Sprintf("Failed to kill live query: %v", err))
 	}
-
-	fmt.Println("Live query terminated")
 
 	select {
 	case <-done:
@@ -209,7 +209,7 @@ func ExampleLive() {
 	// User updated
 	// Received notification - Action: DELETE, Result: {email=alice.updated@example.com id=users:⟨UUID⟩}
 	// User deleted
-	// Live query terminated
+	// Live query being terminated
 	// Notification channel closed
 	// Goroutine exited after channel closed
 }


### PR DESCRIPTION
This fixes the test flakiness first observed when running tests on GHA for #324, where `ExampleLive` test fail like this:

```
--- FAIL: ExampleLive (0.10s)
got:
Started live query
Received notification - Action: CREATE, Result: {email=alice@example.com id=users:⟨UUID⟩ username=alice}
New user created
Received notification - Action: UPDATE, Result: {email=alice.updated@example.com id=users:⟨UUID⟩}
User updated
Received notification - Action: DELETE, Result: {email=alice.updated@example.com id=users:⟨UUID⟩}
User deleted
Notification channel closed
Live query terminated
Goroutine exited after channel closed
want:
Started live query
Received notification - Action: CREATE, Result: {email=alice@example.com id=users:⟨UUID⟩ username=alice}
New user created
Received notification - Action: UPDATE, Result: {email=alice.updated@example.com id=users:⟨UUID⟩}
User updated
Received notification - Action: DELETE, Result: {email=alice.updated@example.com id=users:⟨UUID⟩}
User deleted
Live query terminated
Notification channel closed
Goroutine exited after channel closed
```

I believe this is due to the notification channel closure, and therefore, goroutine exit can happen before the `Kill` function call returns.