### PR TITLE
Add make target `pkgsite`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,5 @@ test:
 lint:
 	golangci-lint run
 
+pkgsite:
+	$(GO) run golang.org/x/pkgsite/cmd/pkgsite@latest


### PR DESCRIPTION
for viewing the pkg.go.dev style doc locally.