### PR TITLE
Reorganize testable examples for top-level SDK functions

### DIFF
--- a/example_create_test.go
+++ b/example_create_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_insert_relation_test.go
+++ b/example_insert_relation_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_insert_test.go
+++ b/example_insert_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_bulk_insert_upsert_test.go
+++ b/example_query_bulk_insert_upsert_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_changefeed_schemaful_test.go
+++ b/example_query_changefeed_schemaful_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_changefeed_test.go
+++ b/example_query_changefeed_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_count_test.go
+++ b/example_query_count_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_embedded_struct_test.go
+++ b/example_query_embedded_struct_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_none_null_test.go
+++ b/example_query_none_null_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_return_test.go
+++ b/example_query_return_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_test.go
+++ b/example_query_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_transaction_let_return_test.go
+++ b/example_query_transaction_let_return_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_transaction_rollback_test.go
+++ b/example_query_transaction_rollback_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_transaction_test.go
+++ b/example_query_transaction_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_select_test.go
+++ b/example_select_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_update_test.go
+++ b/example_update_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_upsert_test.go
+++ b/example_upsert_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"
@@ -141,7 +141,7 @@ func ExampleUpsert_unmarshal_error_fxamackercbor() {
 	}
 
 	// Output:
-	// Error: Send: error unmarshaling result: cbor: cannot unmarshal array into Go value of type main.Person (cannot decode CBOR array to struct without toarray option)
+	// Error: Send: error unmarshaling result: cbor: cannot unmarshal array into Go value of type surrealdb_test.Person (cannot decode CBOR array to struct without toarray option)
 	// Error is RPCError: false
 }
 
@@ -180,7 +180,7 @@ func ExampleUpsert_unmarshal_error_surrealcbor() {
 	}
 
 	// Output:
-	// Error: Send: error unmarshaling result: cannot decode array into main.Person
+	// Error: Send: error unmarshaling result: cannot decode array into surrealdb_test.Person
 	// Error is RPCError: false
 }
 


### PR DESCRIPTION
so that they are visible side by side with the top-level functions at pkg.go.dev.
