### PR TITLE
Reorganize FromConnection testable examples

### DIFF
--- a/example_fromconnection_fxamacker_cbor_decopts_test.go
+++ b/example_fromconnection_fxamacker_cbor_decopts_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"
@@ -16,10 +16,10 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
-// ExampleCborUnmarshaler_DecOptions_defaultLimit demonstrates that the default
+// ExampleFromConnection_cborUnmarshaler_decOptions_defaultLimit demonstrates that the default
 // CBOR decoder configuration works fine with small arrays that are well within
 // the default limit of 131,072 elements.
-func ExampleCborUnmarshaler_DecOptions_defaultLimit() {
+func ExampleFromConnection_cborUnmarshaler_decOptions_defaultLimit() {
 	// Parse the SurrealDB WebSocket URL
 	u, err := url.ParseRequestURI(testenv.GetSurrealDBWSURL())
 	if err != nil {
@@ -67,10 +67,10 @@ func ExampleCborUnmarshaler_DecOptions_defaultLimit() {
 	// Successfully retrieved record with 10 items
 }
 
-// ExampleCborUnmarshaler_DecOptions_customSmallLimit demonstrates what happens
+// ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit demonstrates what happens
 // when a custom MaxArrayElements limit is set too low and the actual data
 // exceeds that limit. The unmarshal operation fails with a clear error message.
-func ExampleCborUnmarshaler_DecOptions_customSmallLimit() {
+func ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit() {
 	// Parse the SurrealDB WebSocket URL
 	u, err := url.ParseRequestURI(testenv.GetSurrealDBWSURL())
 	if err != nil {

--- a/example_fromconnection_gws_test.go
+++ b/example_fromconnection_gws_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"
@@ -11,7 +11,9 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
 )
 
-func ExampleConnection_gws() {
+// FromConnection can take any connection.Connection implementation, including
+// gws.Connection which is based on https://github.com/lxzan/gws.
+func ExampleFromConnection_alternativeWebSocketLibrary_gws() {
 	u, err := url.ParseRequestURI(testenv.GetSurrealDBWSURL())
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse URL: %v", err))

--- a/example_fromconnection_surrealcbor_test.go
+++ b/example_fromconnection_surrealcbor_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"
@@ -13,9 +13,11 @@ import (
 	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
-// Example_surrealCBOR demonstrates how to use SurrealCBOR with SurrealDB Go SDK
-// for efficient binary serialization.
-func ExampleFromConnection_surrealCBOR() {
+// FromConnection can take any connection.Connection implementation with
+// a custom connection.Config that can be used to specify a CBOR marshaler and unmarshaler.
+// This SDK has two built-in CBOR implementations: fxamacker/cbor-based one and the newer surrealcbor.
+// surrealcbor is a more efficient and feature-rich implementation that is recommended for new projects.
+func ExampleFromConnection_alternativeCBORImpl_surrealCBOR() {
 	conf := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
 	// To enable surrealcbor, instantiate the codec
 	// and set it as the marshaler and unmarshaler.


### PR DESCRIPTION
so that they are visible alongside the top-level functions at pkg.go.dev.