### PR TITLE
Reorganize remaining testable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,24 @@ cd surrealdb.go
 go run ./example
 ```
 
-The `./example` directory contains:
-- `main.go` - A complete working example demonstrating basic CRUD operations
-- Multiple test files (`*_test.go`) - Examples demonstrating various SDK features including:
-  - Query operations and transactions
-  - Relations and graph traversal
-  - Bulk operations (insert, upsert)
-  - Authentication methods
-  - Custom CBOR configuration
-  - And many more use cases
+The `./example` directory contains a complete working example demonstrating basic CRUD operations.
+
+### Testable Examples
+
+Testable example files (`example*_test.go`) demonstrate various SDK features including:
+- Query operations and transactions
+- Relations and graph traversal
+- Bulk operations (insert, upsert)
+- Authentication methods
+- Custom CBOR configuration
+- And many more use cases
 
 You can run any of the example tests with:
 ```sh
-go test -v ./example -run ExampleName
+go test -v ./ -run ExampleName
 ```
+
+If you're viewing this documentation at `pkg.go.dev`, you can view the examples alongside corresponding SDK functions.
 
 ## Executing SurrealQL
 

--- a/example_db_recorduser_test.go
+++ b/example_db_recorduser_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_db_signin_test.go
+++ b/example_db_signin_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_db_version_test.go
+++ b/example_db_version_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_livequery_test.go
+++ b/example_livequery_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_issue291_test.go
+++ b/example_query_issue291_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_query_issue292_test.go
+++ b/example_query_issue292_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_relate_test.go
+++ b/example_relate_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"

--- a/example_send_test.go
+++ b/example_send_test.go
@@ -1,4 +1,4 @@
-package main
+package surrealdb_test
 
 import (
 	"context"
@@ -10,7 +10,8 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
-func ExampleDB_send_select() {
+// Send can be used to any SurrealDB RPC method including "select".
+func ExampleSend_select() {
 	db := testenv.MustNew("surrealdbexamples", "update", "person")
 
 	type Person struct {


### PR DESCRIPTION
so that they are visible alongside the top-level functions doc at pkg.go.dev.

Follow-up to #329 and #330