### PR TITLE
Documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img width=120 src="https://raw.githubusercontent.com/surrealdb/icons/main/golang.svg" />
 </p>
 
-<h3 align="center">The official SurrealDB SDK for Golang.</h3>
+<h3 align="center">The official SurrealDB SDK for Go</h3>
 
 <br>
 
@@ -30,281 +30,19 @@
     <a href="https://www.youtube.com/channel/UCjf2teVEuYVvvVC-gFZNq6w"><img src="https://img.shields.io/badge/youtube-subscribe-fc1c1c.svg?style=flat-square"></a>
 </p>
 
-# surrealdb.go
-
-The official SurrealDB SDK for Go.
-
-## Documentation
-
-View the SDK documentation on [pkg.go.dev](https://pkg.go.dev/github.com/surrealdb/surrealdb.go) or [here](https://surrealdb.com/docs/integration/libraries/golang).
-
 ## How to install
 
 ```sh
 go get github.com/surrealdb/surrealdb.go
 ```
 
-## Getting started
+## "Getting started" example
 
-To connect to SurrealDB and perform data operations, please refer to the complete example in [./example/main.go](./example/main.go).
+To connect to SurrealDB and perform data operations, please refer to [example](https://pkg.go.dev/github.com/surrealdb/surrealdb.go/example#section-readme).
 
-> This example requires SurrealDB to be [installed](https://surrealdb.com/install) and running on port 8000.
+## Using the SDK
 
-### Running the Example
-
-The easiest way to get started is to run the example directly:
-
-```sh
-# Clone the repository
-git clone https://github.com/surrealdb/surrealdb.go.git
-cd surrealdb.go
-
-# Run the example
-go run ./example
-```
-
-The `./example` directory contains a complete working example demonstrating basic CRUD operations.
-
-### Testable Examples
-
-Testable example files (`example*_test.go`) demonstrate various SDK features including:
-- Query operations and transactions
-- Relations and graph traversal
-- Bulk operations (insert, upsert)
-- Authentication methods
-- Custom CBOR configuration
-- And many more use cases
-
-You can run any of the example tests with:
-```sh
-go test -v ./ -run ExampleName
-```
-
-If you're viewing this documentation at `pkg.go.dev`, you can view the examples alongside corresponding SDK functions.
-
-## Executing SurrealQL
-
-### Using Query
-
-For most use cases, you can use the `Query` function to execute SurrealQL statements. This is the recommended approach for complex queries, transactions, and when you need full control over your database operations:
-
-```go
-// Execute a SurrealQL query with typed results
-results, err := surrealdb.Query[[]Person](
-    context.Background(),
-    db,
-    "SELECT * FROM persons WHERE age > $minAge",
-    map[string]any{
-        "minAge": 18,
-    },
-)
-
-// You can also use Query for transactions with variables
-transactionResults, err := surrealdb.Query[[]any](
-    context.Background(),
-    db,
-    `
-    BEGIN TRANSACTION;
-    CREATE person:$johnId SET name = $johnName, age = $johnAge;
-    CREATE person:$janeId SET name = $janeName, age = $janeAge;
-    COMMIT TRANSACTION;
-    `,
-    map[string]any{
-        "johnId": "john",
-        "johnName": "John",
-        "johnAge": 30,
-        "janeId": "jane",
-        "janeName": "Jane",
-        "janeAge": 25,
-    },
-)
-
-// Or use a single CREATE with content variable
-createResult, err := surrealdb.Query[[]Person](
-    context.Background(),
-    db,
-    "CREATE person:$id CONTENT $content",
-    map[string]any{
-        "id": "alice",
-        "content": map[string]any{
-            "name": "Alice",
-            "age": 28,
-            "city": "New York",
-        },
-    },
-)
-```
-
-The `Query` function supports:
-- Full SurrealQL syntax including transactions
-- Parameterized queries for security
-- Typed results with generics
-- Multiple statements in a single call
-
-### Using Send for low-level control
-
-All data manipulation methods are handled by an underlying `send` function. This function is
-exposed via `db.Send` function if you want to create requests yourself but limited to a selected set of methods. These
-methods are:
-
--   select
--   create
--   insert
--   upsert
--   update
--   patch
--   delete
--   query
-
-```go
-type UserSelectResult struct {
-	Result []Users
-}
-
-var res UserSelectResult
-// or var res surrealdb.Result[[]Users]
-
-err := db.Send(context.Background(), &res, "select", user.ID)
-if err != nil {
-	panic(err)
-}
-```
-
-## Connection Engines
-
-There are 2 different connection engines you can use to connect to SurrealDb backend. You can do so via Websocket or through HTTP
-connections
-
-### Via Websocket
-
-```go
-db, err := surrealdb.FromEndpointURLString(ctx, "ws://localhost:8000")
-```
-
-or for a secure connection
-
-```go
-db, err := surrealdb.FromEndpointURLString(ctx, "wss://localhost:8000")
-```
-
-### Via HTTP
-
-There are some functions that are not available on RPC when using HTTP but on Websocket. All these except
-the "live" endpoint are effectively implemented in the HTTP library and provides the same result as though
-it is natively available on HTTP. While using the HTTP connection engine, note that live queries will still
-use a websocket connection if the backend supports it
-
-```go
-db, err := surrealdb.FromEndpointURLString(ctx, "http://localhost:8000")
-```
-
-or for a secure connection
-
-```go
-db, err := surrealdb.FromEndpointURLString(ctx, "https://localhost:8000")
-```
-
-### Using SurrealKV and Memory
-
-SurrealKV and Memory also do not support live notifications at this time. This would be updated in the next
-release.
-
-> ⚠️ **Note**
-> Although the examples below reference `surrealkv://` and `memory://`, **these modes are currently not supported in the Go SDK**.
-> Support for embedded databases (like SurrealKV and in-memory) is pending future development and is being tracked in [issue #197](https://github.com/surrealdb/surrealdb.go/issues/197).
->
-> Until then, please use `http://` or `ws://` endpoints to connect to a running SurrealDB server instance.
-
-For Surreal KV
-
-```go
-db, err := surrealdb.New("surrealkv://path/to/dbfile.kv")
-```
-
-For Memory
-
-```go
-db, err := surrealdb.New("mem://")
-db, err := surrealdb.New("memory://")
-```
-
-## Data Models
-
-This package facilitates communication between client and the backend service using the Concise
-Binary Object Representation (CBOR) format. It streamlines data serialization and deserialization
-while ensuring efficient and lightweight communication. The library also provides custom models
-tailored to specific Data models recognised by SurrealDb, which cannot be covered by idiomatic go, enabling seamless interaction between
-the client and the backend.
-
-See the [documetation on data models](https://surrealdb.com/docs/surrealql/datamodel) on support data types
-
-| CBOR Type                        | Go Representation                                                                                           | Example                                                                                |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Null                             | `nil`                                                                                                       | `var x any = nil`                                                                      |
-| None                             | `surrealdb.None`                                                                                            | `map[string]any{"customer": surrealdb.None}`                                           |
-| Boolean                          | `bool`                                                                                                      | `true`, `false`                                                                        |
-| Array                            | `[]any`                                                                                                     | `[]MyStruct{item1, item2}`                                                             |
-| Date/Time                        | `time.Time`                                                                                                 | `time.Now()`                                                                           |
-| Duration                         | `time.Duration`                                                                                             | `time.Duration(8821356)`                                                               |
-| UUID (string representation)     | `surrealdb.UUID(string)`                                                                                    | `surrealdb.UUID("123e4567-e89b-12d3-a456-426614174000")`                               |
-| UUID (binary representation)     | `surrealdb.UUIDBin([]bytes)`                                                                                | `surrealdb.UUIDBin([]byte{0x01, 0x02, ...}`)`                                          |
-| Integer                          | `uint`, `uint64`, `int`, `int64`                                                                            | `42`, `uint64(100000)`, `-42`, `int64(-100000)`                                        |
-| Floating Point                   | `float32`, `float64`                                                                                        | `3.14`, `float64(2.71828)`                                                             |
-| Byte String, Binary Encoded Data | `[]byte`                                                                                                    | `[]byte{0x01, 0x02}`                                                                   |
-| Text String                      | `string`                                                                                                    | `"Hello, World!"`                                                                      |
-| Map                              | `map[any]any`                                                                                               | `map[string]float64{"one": 1.0}`                                                       |
-| Table name                       | `surrealdb.Table(name)`                                                                                     | `surrealdb.Table("users")`                                                             |
-| Record ID                        | `surrealdb.RecordID{Table: string, ID: any}`                                                                | `surrealdb.RecordID{Table: "customers", ID: 1}, surrealdb.NewRecordID("customers", 1)` |
-| Geometry Point                   | `surrealdb.GeometryPoint{Latitude: float64, Longitude: float64}`                                            | `surrealdb.GeometryPoint{Latitude: 11.11, Longitude: 22.22`                            |
-| Geometry Line                    | `surrealdb.GeometryLine{GeometricPoint1, GeometricPoint2,... }`                                             |                                                                                        |
-| Geometry Polygon                 | `surrealdb.GeometryPolygon{GeometryLine1, GeometryLine2,... }`                                              |                                                                                        |
-| Geometry Multipoint              | `surrealdb.GeometryMultiPoint{GeometryPoint1, GeometryPoint2,... }`                                         |                                                                                        |
-| Geometry MultiLine               | `surrealdb.GeometryMultiLine{GeometryLine1, GeometryLine2,... }`                                            |                                                                                        |
-| Geometry MultiPolygon            | `surrealdb.GeometryMultiPolygon{GeometryPolygon1, GeometryPolygon2,... }`                                   |                                                                                        |
-| Geometry Collection              | `surrealdb.GeometryMultiPolygon{GeometryPolygon1, GeometryLine2, GeometryPoint3, GeometryMultiPoint4,... }` |                                                                                        |
-
-## Helper Types
-
-### surrealdb.O
-
-For some methods like create, insert, update, you can pass a map instead of an struct value. An example:
-
-```go
-person, err := surrealdb.Create[Person](context.Background(), db, models.Table("persons"), map[any]any{
-	"Name":     "John",
-	"Surname":  "Doe",
-	"Location": models.NewGeometryPoint(-0.11, 22.00),
-})
-```
-
-This can be simplified to:
-
-```go
-person, err := surrealdb.Create[Person](context.Background(), db, models.Table("persons"), surrealdb.O{
-	"Name":     "John",
-	"Surname":  "Doe",
-	"Location": models.NewGeometryPoint(-0.11, 22.00),
-})
-```
-
-Where surrealdb.O is defined below. There is no special advantage in using this other than simplicity/legibility.
-
-```go
-type surrealdb.O map[any]any
-```
-
-### surrealdb.Result[T]
-
-This is useful for the `Send` function where `T` is the expected response type for a request. An example:
-
-```go
-var res surrealdb.Result[[]Users]
-err := db.Send(context.Background(), &res, "select", model.Table("users"))
-if err != nil {
-	panic(err)
-}
-fmt.Printf("users: %+v\n", users.R)
-```
+To use the SDK, please refer to the [documentation](https://pkg.go.dev/github.com/surrealdb/surrealdb.go#section-documentation).
 
 ## Contributing
 
@@ -316,3 +54,15 @@ make lint test
 
 You also need to be running SurrealDB alongside the tests.
 We recommend using the nightly build, as development may rely on the latest functionality.
+
+## Links
+
+<!--
+This section is intentionally named "Links" so that the links
+are displayed in the right sidecbar.
+
+https://github.com/golang/go/issues/42968
+-->
+
+- [The SDK documentation on pkg.go.dev](https://pkg.go.dev/github.com/surrealdb/surrealdb.go)
+- [The SDK documentation on surrealdb.com](https://surrealdb.com/docs/integration/libraries/golang)

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,32 @@
+// The [surrealdb] package implements [SurrealDB RPC Protocol] in the Go way.
+//
+// # Connection Engines
+//
+// There are 2 different connection engines, WebSocket and HTTP, you can use to connect to SurrealDB backend.
+//
+// Provide a proper SurrealDB endpoint URL to [FromEndpointURLString] so that it chooses the right backend for you.
+//
+// # Data Models
+//
+// The [surrealdb] package facilitates communication between client and the backend service using the Concise
+// Binary Object Representation (CBOR) format.
+//
+// For more information on CBOR and how it relates to SurrealDB's
+// data models, please refer to the [github.com/surrealdb/surrealdb.go/pkg/models] package.
+//
+// # Use Query for most use cases
+//
+// For most use cases, you can use the [Query] function to execute SurrealQL statements.
+//
+// [Query] is recommended for both simple and complex queries, transactions, and when you need full control over your database operations.
+//
+// To ease writing queries for [Query] with more type-safety, you can use the [github.com/surrealdb/surrealdb.go/contrib/surrealql] package.
+//
+// # Use Send for low-level control
+//
+// [Send] is used internally by all data manipulation methods.
+//
+// Use it directly when you want to create requests yourself.
+//
+// [SurrealDB RPC Protcol]: https://surrealdb.com/docs/surrealdb/integration/rpc
+package surrealdb

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,43 @@
+
+## Getting started with SurrealDB SDK for Go
+
+To connect to SurrealDB and perform data operations, please refer to the complete example in [main.go](cmd/main.go).
+
+> This example requires SurrealDB to be [installed](https://surrealdb.com/install) and running on port 8000.
+
+### Running the Example
+
+The easiest way to get started is to run the example directly:
+
+```sh
+# Clone the repository
+git clone https://github.com/surrealdb/surrealdb.go.git
+cd surrealdb.go
+
+# Run the example
+go run ./example/cmd
+```
+
+The `example` directory contains a complete working example demonstrating basic CRUD operations.
+
+### Testable Examples
+
+The testable example files [`example*_test.go`](..) demonstrate various SDK features including:
+- Query operations and transactions
+- Relations and graph traversal
+- Bulk operations (insert, upsert)
+- Authentication methods
+- Custom CBOR configuration
+- And many more use cases
+
+You can run any of the example tests with:
+```sh
+# Clone the repository
+git clone https://github.com/surrealdb/surrealdb.go.git
+cd surrealdb.go
+
+# Run the testable example
+go test -v ./ -run ExampleName
+```
+
+If you're viewing this documentation at `pkg.go.dev`, you can view the examples alongside corresponding SDK functions.

--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/example"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
@@ -48,7 +49,7 @@ func main() {
 	}(token)
 
 	// Create an entry
-	person1, err := surrealdb.Create[Person](context.Background(), db, models.Table("persons"), map[interface{}]interface{}{
+	person1, err := surrealdb.Create[example.Person](context.Background(), db, models.Table("persons"), map[interface{}]interface{}{
 		"Name":     "John",
 		"Surname":  "Doe",
 		"Location": models.NewGeometryPoint(-0.11, 22.00),
@@ -59,7 +60,7 @@ func main() {
 	fmt.Printf("Created person with a map: %+v\n", person1)
 
 	// Or use structs
-	person2, err := surrealdb.Create[Person](context.Background(), db, models.Table("persons"), Person{
+	person2, err := surrealdb.Create[example.Person](context.Background(), db, models.Table("persons"), example.Person{
 		Name:     "John",
 		Surname:  "Doe",
 		Location: models.NewGeometryPoint(-0.11, 22.00),
@@ -70,7 +71,7 @@ func main() {
 	fmt.Printf("Created person with a struvt: %+v\n", person2)
 
 	// Get entry by Record ID
-	person, err := surrealdb.Select[PersonWithCustomID, models.RecordID](context.Background(), db, *person1.ID)
+	person, err := surrealdb.Select[example.PersonWithCustomID, models.RecordID](context.Background(), db, *person1.ID)
 	if err != nil {
 		panic(err)
 	}
@@ -82,24 +83,24 @@ func main() {
 	fmt.Printf("Selected a person by record id (in JSON with custom ID JSON encoder): %s\n", string(personInJSON))
 
 	// Or retrieve the entire table
-	persons, err := surrealdb.Select[[]Person, models.Table](context.Background(), db, models.Table("persons"))
+	persons, err := surrealdb.Select[[]example.Person, models.Table](context.Background(), db, models.Table("persons"))
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Selected all in persons table: %+v\n", persons)
 
 	// Delete an entry by ID
-	if _, err = surrealdb.Delete[Person](context.Background(), db, *person2.ID); err != nil {
+	if _, err = surrealdb.Delete[example.Person](context.Background(), db, *person2.ID); err != nil {
 		panic(err)
 	}
 
 	// Delete all entries
-	if _, err = surrealdb.Delete[[]Person](context.Background(), db, models.Table("persons")); err != nil {
+	if _, err = surrealdb.Delete[[]example.Person](context.Background(), db, models.Table("persons")); err != nil {
 		panic(err)
 	}
 
 	// Confirm empty table
-	persons, err = surrealdb.Select[[]Person](context.Background(), db, models.Table("persons"))
+	persons, err = surrealdb.Select[[]example.Person](context.Background(), db, models.Table("persons"))
 	if err != nil {
 		panic(err)
 	}

--- a/example/person.go
+++ b/example/person.go
@@ -1,4 +1,4 @@
-package main
+package example
 
 import (
 	"encoding/json"
@@ -7,10 +7,32 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
+// Person is a Go struct that represents an example
+// database record for a person.
+//
+// Note that this SDK uses CBOR for serialization, although
+// struct fields (can) have `json` tags.
+// If you want to be more specific, you should use `cbor` tags instead.
+// `json` tags work only because the our CBOR implementation supports
+// both types of tags for your convenience.
 type Person struct {
-	ID       *models.RecordID     `json:"id,omitempty"`
-	Name     string               `json:"name"`
-	Surname  string               `json:"surname"`
+	// ID is the unique identifier for the person record.
+	//
+	// Any SurrealDB record has ID.
+	// The SurrealDB Go SDK uses models.RecordID to represent record IDs.
+	ID *models.RecordID `json:"id,omitempty"`
+
+	// Name is the person's name.
+	//
+	// Many Go primitive types that can be serialized using CBOR
+	// are supported.
+	Name    string `json:"name"`
+	Surname string `json:"surname"`
+
+	// Location is the person's location.
+	//
+	// Some SurrealDB-specific data types require custom structs
+	// provided by this SDK.
 	Location models.GeometryPoint `json:"location"`
 }
 

--- a/pkg/models/README.md
+++ b/pkg/models/README.md
@@ -1,0 +1,41 @@
+
+## Data Models
+
+The [surrealdb] package facilitates communication between client and the backend service using the Concise
+Binary Object Representation (CBOR) format.
+
+It streamlines data serialization and deserialization
+while ensuring efficient and lightweight communication.
+
+The library also provides custom models
+tailored to specific Data models recognised by SurrealDb, which cannot be covered by idiomatic Go, enabling seamless interaction between
+the client and the backend.
+
+See the [documetation on data models](https://surrealdb.com/docs/surrealql/datamodel) on data types supported in SurrealQL, and the below for ones supported in the [surrealdb] package.
+
+[surrealdb]: https://pkg.go.dev/github.com/surrealdb/surrealdb.go
+
+| CBOR Type                        | Go Representation                                                                                           | Example                                                                                |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Null                             | `nil`                                                                                                       | `var x any = nil`                                                                      |
+| None                             | `surrealdb.None`                                                                                            | `map[string]any{"customer": surrealdb.None}`                                           |
+| Boolean                          | `bool`                                                                                                      | `true`, `false`                                                                        |
+| Array                            | `[]any`                                                                                                     | `[]MyStruct{item1, item2}`                                                             |
+| Date/Time                        | `time.Time`                                                                                                 | `time.Now()`                                                                           |
+| Duration                         | `time.Duration`                                                                                             | `time.Duration(8821356)`                                                               |
+| UUID (string representation)     | `surrealdb.UUID(string)`                                                                                    | `surrealdb.UUID("123e4567-e89b-12d3-a456-426614174000")`                               |
+| UUID (binary representation)     | `surrealdb.UUIDBin([]bytes)`                                                                                | `surrealdb.UUIDBin([]byte{0x01, 0x02, ...}`)`                                          |
+| Integer                          | `uint`, `uint64`, `int`, `int64`                                                                            | `42`, `uint64(100000)`, `-42`, `int64(-100000)`                                        |
+| Floating Point                   | `float32`, `float64`                                                                                        | `3.14`, `float64(2.71828)`                                                             |
+| Byte String, Binary Encoded Data | `[]byte`                                                                                                    | `[]byte{0x01, 0x02}`                                                                   |
+| Text String                      | `string`                                                                                                    | `"Hello, World!"`                                                                      |
+| Map                              | `map[any]any`                                                                                               | `map[string]float64{"one": 1.0}`                                                       |
+| Table name                       | `surrealdb.Table(name)`                                                                                     | `surrealdb.Table("users")`                                                             |
+| Record ID                        | `surrealdb.RecordID{Table: string, ID: any}`                                                                | `surrealdb.RecordID{Table: "customers", ID: 1}, surrealdb.NewRecordID("customers", 1)` |
+| Geometry Point                   | `surrealdb.GeometryPoint{Latitude: float64, Longitude: float64}`                                            | `surrealdb.GeometryPoint{Latitude: 11.11, Longitude: 22.22`                            |
+| Geometry Line                    | `surrealdb.GeometryLine{GeometricPoint1, GeometricPoint2,... }`                                             |                                                                                        |
+| Geometry Polygon                 | `surrealdb.GeometryPolygon{GeometryLine1, GeometryLine2,... }`                                              |                                                                                        |
+| Geometry Multipoint              | `surrealdb.GeometryMultiPoint{GeometryPoint1, GeometryPoint2,... }`                                         |                                                                                        |
+| Geometry MultiLine               | `surrealdb.GeometryMultiLine{GeometryLine1, GeometryLine2,... }`                                            |                                                                                        |
+| Geometry MultiPolygon            | `surrealdb.GeometryMultiPolygon{GeometryPolygon1, GeometryPolygon2,... }`                                   |                                                                                        |
+| Geometry Collection              | `surrealdb.GeometryMultiPolygon{GeometryPolygon1, GeometryLine2, GeometryPoint3, GeometryMultiPoint4,... }` |                                                                                        |

--- a/types.go
+++ b/types.go
@@ -17,6 +17,8 @@ type PatchData struct {
 	Value any    `json:"value"`
 }
 
+// QueryResult is a struct that represents one of the results
+// of a SurrealDB query RPC method call, made via [Query], for example.
 type QueryResult[T any] struct {
 	Status string      `json:"status"`
 	Time   string      `json:"time"`
@@ -81,8 +83,10 @@ type Auth struct {
 	Password  string `json:"pass,omitempty"`
 }
 
+// Deprecated: Use map[string]any instead
 type Obj map[any]any
 
+// Deprecated: Use [RPCResponse] instead.
 type Result[T any] struct {
 	T any
 }


### PR DESCRIPTION
Since the next minor release of this SDK (v0.10.0), I'd like to use pkg.go.dev as the most up-to-date, easy-to-browse, and comprehensive documentation for any released versions of this SDK.

Today, you can see that it lacks examples associated with each top-level symbol:

https://pkg.go.dev/github.com/surrealdb/surrealdb.go

However, you can see function docs and testable examples side by side since #329, #330, and #331.

Now the remaining part is that our current README lacks proper links to each top-level symbol and its Go doc comment.
In this pull request, I changed that by moving most of the detailed documentation to go doc comments, allowing you to do everything in a more structured way on pkg.go.dev.

Once the v0.10.0 gets published, you will be able to compare the enhancements by browsing v0.9.0 version of our pkg.go.dev page (https://pkg.go.dev/github.com/surrealdb/surrealdb.go@v0.9.0) vs one for v010.0 (https://pkg.go.dev/github.com/surrealdb/surrealdb.go@v0.10.0, not available just now because we cut v0.10.0 after this pull request).

> Note that you still need to read the README.md files and go through the doc comments in the code if you want to use unreleased versions. That's unchanged.
>
> I believe it's less common though.
>
> I believe most of the folks contacted me for a lack of documentation/confusing documentation
> referred to the one on surrealdb.com. It will be overhauled via https://github.com/surrealdb/docs.surrealdb.com/pull/1422 separately.
> But in the future, we could derive docs on surrealdb.com from the one published at pkg.go.dev if it's easier overall.
