### PR TITLE
Fix datetime marshal to allow extreme values

### DIFF
--- a/pkg/models/datetime.go
+++ b/pkg/models/datetime.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
-	"github.com/surrealdb/surrealdb.go/pkg/constants"
 )
 
 // CustomDateTime embeds time.Time
@@ -17,7 +16,7 @@ func (d *CustomDateTime) MarshalCBOR() ([]byte, error) {
 	if d.IsZero() {
 		return cbor.Marshal(cbor.Tag{Number: TagNone})
 	}
-	
+
 	s := d.Unix()
 	ns := int64(d.Nanosecond())
 

--- a/pkg/models/datetime_test.go
+++ b/pkg/models/datetime_test.go
@@ -129,6 +129,27 @@ func TestDateTime_cbor_local_time(t *testing.T) {
 	assert.Equal(t, CustomDateTime{Time: localTime.UTC()}, decoded, "unmarshaled CustomDateTime does not match original converted to UTC")
 }
 
+func TestDateTime_cbor_extreme_values(t *testing.T) {
+	t.Parallel()
+
+	extremeTimes := []CustomDateTime{
+		{Time: time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)}, // Minimum representable time
+		// 62135596801 is the number of seconds from year 1 to 1970
+		{time.Unix(1<<63-62135596801, 999999999)}, // Maximum representable time
+	}
+
+	for _, original := range extremeTimes {
+		data, err := original.MarshalCBOR()
+		require.NoError(t, err)
+
+		var decoded CustomDateTime
+		err = decoded.UnmarshalCBOR(data)
+		require.NoError(t, err)
+
+		assert.Equal(t, toUTC(original), decoded, "unmarshaled CustomDateTime does not match original")
+	}
+}
+
 func toUTC(dt CustomDateTime) CustomDateTime {
 	return CustomDateTime{Time: dt.In(time.UTC)}
 }


### PR DESCRIPTION
previous mechanism was trimming values at the extremes. This doesn't and is simpler as it just extracts the seconds and nanoseconsd directly from the time.Time