### PR TITLE
rews: Reconnection with exponential backoff

### DIFF
--- a/contrib/rews/doc.go
+++ b/contrib/rews/doc.go
@@ -1,0 +1,47 @@
+// Package rews provides a reliable, auto-reconnecting WebSocket connection for SurrealDB
+// with support for session restoration, live query persistence, and customizable retry strategies.
+//
+// The main component is Connection, which wraps a standard WebSocket connection and adds:
+//   - Automatic reconnection when the connection is lost
+//   - Session state restoration (namespace, database, authentication, variables)
+//   - Live query persistence across reconnections
+//   - Customizable retry strategies with exponential backoff
+//
+// Basic usage:
+//
+//	// Create a connection with exponential backoff retry
+//	conn := rews.New(
+//	    func(ctx context.Context) (connection.WebSocketConnection, error) {
+//	        ws := gorillaws.New(&connection.Config{
+//	            BaseURL:     "ws://localhost:8000",
+//	            Marshaler:   marshaler,
+//	            Unmarshaler: unmarshaler,
+//	        })
+//	        return ws, nil
+//	    },
+//	    5*time.Second,  // reconnection check interval
+//	    unmarshaler,
+//	    logger,
+//	)
+//
+//	// Configure retry behavior
+//	retryer := rews.NewExponentialBackoffRetryer()
+//	retryer.MaxRetries = 10
+//	conn.Retryer = retryer
+//
+//	// Connect with automatic retry on failure
+//	if err := conn.Connect(ctx); err != nil {
+//	    // Handle connection failure after all retries
+//	}
+//
+//	// Use the connection - it will automatically reconnect if disconnected
+//	conn.Use(ctx, "namespace", "database")
+//	conn.SignIn(ctx, credentials)
+//
+// The package includes several built-in retry strategies:
+//   - ExponentialBackoffRetryer: Exponential backoff with jitter
+//   - FixedDelayRetryer: Fixed delay between retries
+//   - nil: No retries (fail immediately on first error)
+//
+// Custom retry strategies can be implemented by satisfying the [Retryer] interface.
+package rews

--- a/contrib/rews/example_retry_test.go
+++ b/contrib/rews/example_retry_test.go
@@ -1,0 +1,132 @@
+package rews_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go/contrib/rews"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+func ExampleConnection_withExponentialBackoff() {
+	// Create a function that establishes the WebSocket connection
+	newConn := func(ctx context.Context) (connection.WebSocketConnection, error) {
+		// Create a gorilla/websocket-based connection
+		// ws := gorillaws.New(&connection.Config{
+		//     BaseURL:     "ws://localhost:8000",
+		//     Marshaler:   models.CborMarshaler{},
+		//     Unmarshaler: models.CborUnmarshaler{},
+		// })
+		// return ws, nil
+		return nil, fmt.Errorf("example connection creation")
+	}
+
+	// Create the auto-reconnecting connection
+	conn := rews.New(
+		newConn,
+		5*time.Second, // Check interval for reconnection
+		nil,           // unmarshaler
+		nil,           // logger
+	)
+
+	// Configure exponential backoff for both initial connections and reconnections
+	retryer := rews.NewExponentialBackoffRetryer()
+	retryer.InitialDelay = 1 * time.Second
+	retryer.MaxDelay = 30 * time.Second
+	retryer.Multiplier = 2.0
+	retryer.MaxRetries = 10 // Give up after 10 attempts for initial connection
+	// Note: For different behavior between initial and reconnect, you could
+	// implement a custom Retryer that tracks connection state
+
+	// Apply the retryer
+	conn.Retryer = retryer
+
+	// Connect with automatic retry on failure
+	ctx := context.Background()
+	err := conn.Connect(ctx)
+	if err != nil {
+		// Initial connection failed after all retry attempts
+		fmt.Printf("Failed to establish connection: %v\n", err)
+		return
+	}
+
+	// Connection established successfully
+	// The connection will now automatically reconnect with exponential backoff
+	// if the connection is lost
+
+	// Use the connection...
+	// defer conn.Close(ctx)
+}
+
+func ExampleConnection_withCustomRetryer() {
+	// Custom retryers can implement complex logic like:
+	// - Different delays based on error types
+	// - Circuit breaker patterns
+	// - Adaptive retry based on success/failure history
+	// - Integration with external monitoring systems
+	//
+	// Example structure:
+	// type CustomRetryer struct {
+	//     attempts int
+	//     maxAttempts int
+	// }
+	// Implement NextDelay and Reset methods to satisfy the Retryer interface
+
+	fmt.Println("Custom retryer can be implemented by implementing the Retryer interface")
+}
+
+func ExampleConnection_withFixedDelay() {
+	// Create a function that establishes the WebSocket connection
+	newConn := func(ctx context.Context) (connection.WebSocketConnection, error) {
+		return nil, fmt.Errorf("example connection creation")
+	}
+
+	// Create the auto-reconnecting connection
+	conn := rews.New(
+		newConn,
+		5*time.Second,
+		nil, // unmarshaler
+		nil, // logger
+	)
+
+	// Use fixed delay retryer - simple and predictable
+	fixedRetryer := rews.NewFixedDelayRetryer(
+		3*time.Second, // Wait 3 seconds between each retry
+		5,             // Try maximum 5 times
+	)
+
+	// Apply for both initial connection and reconnection
+	conn.Retryer = fixedRetryer
+
+	// Connect with fixed delay retry
+	ctx := context.Background()
+	_ = conn.Connect(ctx)
+}
+
+func ExampleConnection_withNoRetry() {
+	// Create a function that establishes the WebSocket connection
+	newConn := func(ctx context.Context) (connection.WebSocketConnection, error) {
+		return nil, fmt.Errorf("example connection creation")
+	}
+
+	// Create the auto-reconnecting connection
+	conn := rews.New(
+		newConn,
+		5*time.Second,
+		nil, // unmarshaler
+		nil, // logger
+	)
+
+	// For different retry behavior between initial and reconnect,
+	// you could implement a custom retryer that tracks state
+	// Here we use exponential backoff for all connection attempts
+	exponentialRetryer := rews.NewExponentialBackoffRetryer()
+
+	conn.Retryer = exponentialRetryer
+
+	// Connection attempts will use exponential backoff
+	// To disable retries entirely, simply leave Retryer as nil
+	ctx := context.Background()
+	_ = conn.Connect(ctx)
+}

--- a/contrib/rews/mock_websocket_connection_test.go
+++ b/contrib/rews/mock_websocket_connection_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
+const testToken = "test-token"
+
 // mockWebSocketConnection extends the mock to return proper UUIDs
 type mockWebSocketConnection struct {
 	connection.WebSocketConnection
@@ -167,12 +169,12 @@ func (m *mockWebSocketConnection) SignIn(ctx context.Context, auth any) (string,
 	if m.isClosed {
 		return "", fmt.Errorf("connection is closed")
 	}
-	return "test-token", nil
+	return testToken, nil
 }
 
 func (m *mockWebSocketConnection) SignUp(ctx context.Context, auth any) (string, error) {
 	if m.isClosed {
 		return "", fmt.Errorf("connection is closed")
 	}
-	return "test-token", nil
+	return testToken, nil
 }

--- a/contrib/rews/retry.go
+++ b/contrib/rews/retry.go
@@ -1,0 +1,115 @@
+package rews
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Retryer defines the interface for implementing retry strategies
+type Retryer interface {
+	// NextDelay returns the delay before the next retry attempt
+	// attempt is 0-based (0 for first retry, 1 for second, etc.)
+	// Returns the delay duration and whether to continue retrying
+	NextDelay(attempt int, lastErr error) (time.Duration, bool)
+
+	// Reset resets the retry strategy state (called on successful connection)
+	Reset()
+}
+
+// ExponentialBackoffRetryer implements exponential backoff with jitter
+type ExponentialBackoffRetryer struct {
+	// InitialDelay is the initial retry delay
+	InitialDelay time.Duration
+
+	// MaxDelay is the maximum retry delay
+	MaxDelay time.Duration
+
+	// Multiplier is the exponential backoff multiplier
+	Multiplier float64
+
+	// MaxRetries is the maximum number of retry attempts (0 for infinite)
+	MaxRetries int
+
+	// Jitter adds randomness to the delay to avoid thundering herd
+	Jitter bool
+
+	// JitterFactor is the maximum jitter as a fraction of the delay (0.0 to 1.0)
+	JitterFactor float64
+}
+
+// NewExponentialBackoffRetryer creates a new exponential backoff retryer with defaults
+func NewExponentialBackoffRetryer() *ExponentialBackoffRetryer {
+	return &ExponentialBackoffRetryer{
+		InitialDelay: 1 * time.Second,
+		MaxDelay:     30 * time.Second,
+		Multiplier:   2.0,
+		MaxRetries:   0, // infinite retries by default
+		Jitter:       true,
+		JitterFactor: 0.3,
+	}
+}
+
+// NextDelay implements Retryer
+func (r *ExponentialBackoffRetryer) NextDelay(attempt int, lastErr error) (time.Duration, bool) {
+	// Check if we've exceeded max retries
+	if r.MaxRetries > 0 && attempt >= r.MaxRetries {
+		return 0, false
+	}
+
+	// Calculate exponential delay
+	delay := float64(r.InitialDelay) * math.Pow(r.Multiplier, float64(attempt))
+
+	// Cap at max delay
+	if delay > float64(r.MaxDelay) {
+		delay = float64(r.MaxDelay)
+	}
+
+	// Add jitter if enabled
+	if r.Jitter && r.JitterFactor > 0 {
+		// Using math/rand is acceptable for jitter in retry delays (non-cryptographic use)
+		//nolint:gosec // math/rand is fine for jitter, not security-critical
+		jitter := delay * r.JitterFactor * (2*rand.Float64() - 1) // -jitterFactor to +jitterFactor
+		delay += jitter
+		if delay < 0 {
+			delay = float64(r.InitialDelay)
+		}
+	}
+
+	return time.Duration(delay), true
+}
+
+// Reset implements Retryer
+func (r *ExponentialBackoffRetryer) Reset() {
+	// No state to reset for exponential backoff
+}
+
+// FixedDelayRetryer implements a simple fixed delay retry retryer
+type FixedDelayRetryer struct {
+	// Delay is the fixed delay between retries
+	Delay time.Duration
+
+	// MaxRetries is the maximum number of retry attempts (0 for infinite)
+	MaxRetries int
+}
+
+// NewFixedDelayRetryer creates a new fixed delay retryer
+func NewFixedDelayRetryer(delay time.Duration, maxRetries int) *FixedDelayRetryer {
+	return &FixedDelayRetryer{
+		Delay:      delay,
+		MaxRetries: maxRetries,
+	}
+}
+
+// NextDelay implements Retryer
+func (r *FixedDelayRetryer) NextDelay(attempt int, lastErr error) (time.Duration, bool) {
+	if r.MaxRetries > 0 && attempt >= r.MaxRetries {
+		return 0, false
+	}
+	return r.Delay, true
+}
+
+// Reset implements Retryer
+func (r *FixedDelayRetryer) Reset() {
+	// No state to reset for fixed delay
+}

--- a/contrib/rews/retry_test.go
+++ b/contrib/rews/retry_test.go
@@ -1,0 +1,135 @@
+package rews
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExponentialBackoffRetryer(t *testing.T) {
+	t.Run("default configuration", func(t *testing.T) {
+		retryer := NewExponentialBackoffRetryer()
+
+		// First retry (attempt 0)
+		delay, shouldRetry := retryer.NextDelay(0, nil)
+		assert.True(t, shouldRetry)
+		assert.GreaterOrEqual(t, delay, 700*time.Millisecond) // 1s - 30% jitter
+		assert.LessOrEqual(t, delay, 1300*time.Millisecond)   // 1s + 30% jitter
+
+		// Second retry (attempt 1)
+		delay, shouldRetry = retryer.NextDelay(1, nil)
+		assert.True(t, shouldRetry)
+		assert.GreaterOrEqual(t, delay, 1400*time.Millisecond) // 2s - 30% jitter
+		assert.LessOrEqual(t, delay, 2600*time.Millisecond)    // 2s + 30% jitter
+
+		// Third retry (attempt 2)
+		delay, shouldRetry = retryer.NextDelay(2, nil)
+		assert.True(t, shouldRetry)
+		assert.GreaterOrEqual(t, delay, 2800*time.Millisecond) // 4s - 30% jitter
+		assert.LessOrEqual(t, delay, 5200*time.Millisecond)    // 4s + 30% jitter
+	})
+
+	t.Run("without jitter", func(t *testing.T) {
+		retryer := &ExponentialBackoffRetryer{
+			InitialDelay: 100 * time.Millisecond,
+			MaxDelay:     1 * time.Second,
+			Multiplier:   2.0,
+			Jitter:       false,
+		}
+
+		// First retry
+		delay, shouldRetry := retryer.NextDelay(0, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 100*time.Millisecond, delay)
+
+		// Second retry
+		delay, shouldRetry = retryer.NextDelay(1, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 200*time.Millisecond, delay)
+
+		// Third retry
+		delay, shouldRetry = retryer.NextDelay(2, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 400*time.Millisecond, delay)
+
+		// Fourth retry
+		delay, shouldRetry = retryer.NextDelay(3, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 800*time.Millisecond, delay)
+
+		// Fifth retry - should hit max delay
+		delay, shouldRetry = retryer.NextDelay(4, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 1*time.Second, delay)
+
+		// Sixth retry - should still be at max delay
+		delay, shouldRetry = retryer.NextDelay(5, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 1*time.Second, delay)
+	})
+
+	t.Run("with max retries", func(t *testing.T) {
+		retryer := &ExponentialBackoffRetryer{
+			InitialDelay: 100 * time.Millisecond,
+			MaxDelay:     10 * time.Second,
+			Multiplier:   2.0,
+			MaxRetries:   3,
+			Jitter:       false,
+		}
+
+		// First three retries should succeed
+		for i := 0; i < 3; i++ {
+			delay, shouldRetry := retryer.NextDelay(i, nil)
+			assert.True(t, shouldRetry, "attempt %d should retry", i)
+			assert.Greater(t, delay, time.Duration(0))
+		}
+
+		// Fourth retry should fail
+		delay, shouldRetry := retryer.NextDelay(3, nil)
+		assert.False(t, shouldRetry)
+		assert.Equal(t, time.Duration(0), delay)
+	})
+
+	t.Run("reset does not affect stateless retryer", func(t *testing.T) {
+		retryer := NewExponentialBackoffRetryer()
+		retryer.Jitter = false // Disable jitter for consistent results
+
+		delay1, _ := retryer.NextDelay(2, nil)
+		retryer.Reset()
+		delay2, _ := retryer.NextDelay(2, nil)
+
+		assert.Equal(t, delay1, delay2)
+	})
+}
+
+func TestFixedDelayRetryer(t *testing.T) {
+	t.Run("basic operation", func(t *testing.T) {
+		retryer := NewFixedDelayRetryer(500*time.Millisecond, 0)
+
+		// All retries should have the same delay
+		for i := 0; i < 10; i++ {
+			delay, shouldRetry := retryer.NextDelay(i, nil)
+			assert.True(t, shouldRetry)
+			assert.Equal(t, 500*time.Millisecond, delay)
+		}
+	})
+
+	t.Run("with max retries", func(t *testing.T) {
+		retryer := NewFixedDelayRetryer(100*time.Millisecond, 2)
+
+		// First two retries should succeed
+		delay, shouldRetry := retryer.NextDelay(0, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 100*time.Millisecond, delay)
+
+		delay, shouldRetry = retryer.NextDelay(1, nil)
+		assert.True(t, shouldRetry)
+		assert.Equal(t, 100*time.Millisecond, delay)
+
+		// Third retry should fail
+		delay, shouldRetry = retryer.NextDelay(2, nil)
+		assert.False(t, shouldRetry)
+		assert.Equal(t, time.Duration(0), delay)
+	})
+}

--- a/contrib/rews/rews_retry_test.go
+++ b/contrib/rews/rews_retry_test.go
@@ -1,0 +1,294 @@
+package rews
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/internal/codec"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+// mockConnection implements a basic WebSocketConnection for testing
+type mockConnection struct {
+	connection.WebSocketConnection
+	connectCalls atomic.Int32
+	connectErr   error
+	isClosed     bool
+	connectFunc  func(ctx context.Context) error // Allow overriding Connect behavior
+}
+
+func (m *mockConnection) Connect(ctx context.Context) error {
+	m.connectCalls.Add(1)
+	if m.connectFunc != nil {
+		return m.connectFunc(ctx)
+	}
+	return m.connectErr
+}
+
+func (m *mockConnection) IsClosed() bool {
+	return m.isClosed
+}
+
+func (m *mockConnection) Close(ctx context.Context) error {
+	m.isClosed = true
+	return nil
+}
+
+func (m *mockConnection) Use(ctx context.Context, namespace, database string) error {
+	return nil
+}
+
+func (m *mockConnection) Let(ctx context.Context, key string, value any) error {
+	return nil
+}
+
+func (m *mockConnection) Unset(ctx context.Context, key string) error {
+	return nil
+}
+
+func (m *mockConnection) Authenticate(ctx context.Context, token string) error {
+	return nil
+}
+
+func (m *mockConnection) SignUp(ctx context.Context, authData any) (string, error) {
+	return testToken, nil
+}
+
+func (m *mockConnection) SignIn(ctx context.Context, authData any) (string, error) {
+	return testToken, nil
+}
+
+// mockUnmarshaler implements a basic Unmarshaler for testing
+type mockUnmarshaler struct{}
+
+func (m mockUnmarshaler) Unmarshal(data []byte, v any) error {
+	return cbor.Unmarshal(data, v)
+}
+
+// Ensure mockUnmarshaler implements codec.Unmarshaler
+var _ codec.Unmarshaler = mockUnmarshaler{}
+
+func TestConnectionRetry(t *testing.T) {
+	t.Run("initial connect with exponential backoff", func(t *testing.T) {
+		var attemptCount atomic.Int32
+		failCount := 3
+
+		mockConn := &mockConnection{}
+
+		newFunc := func(ctx context.Context) (connection.WebSocketConnection, error) {
+			attempt := int(attemptCount.Add(1))
+			if attempt <= failCount {
+				return nil, errors.New("connection failed")
+			}
+			return mockConn, nil
+		}
+
+		// Create connection with exponential backoff retryer
+		conn := New(
+			newFunc,
+			5*time.Second,
+			mockUnmarshaler{}, // unmarshaler required for reliableLQ
+			nil,               // logger not needed for this test
+		)
+
+		// Configure exponential backoff with short delays for testing
+		retryer := &ExponentialBackoffRetryer{
+			InitialDelay: 10 * time.Millisecond,
+			MaxDelay:     100 * time.Millisecond,
+			Multiplier:   2.0,
+			MaxRetries:   5,
+			Jitter:       false,
+		}
+		conn.Retryer = retryer
+
+		// Connect should retry and eventually succeed
+		ctx := context.Background()
+		err := conn.Connect(ctx)
+		require.NoError(t, err)
+
+		// Should have attempted 4 times (3 failures + 1 success)
+		assert.Equal(t, int32(4), attemptCount.Load())
+
+		// Clean up
+		err = conn.Close(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("initial connect with max retries exceeded", func(t *testing.T) {
+		var attemptCount atomic.Int32
+
+		newFunc := func(ctx context.Context) (connection.WebSocketConnection, error) {
+			attemptCount.Add(1)
+			return nil, errors.New("connection failed")
+		}
+
+		conn := New(
+			newFunc,
+			5*time.Second,
+			mockUnmarshaler{}, // unmarshaler required for reliableLQ
+			nil,               // logger not needed for this test
+		)
+
+		// Configure retryer with limited retries
+		retryer := &ExponentialBackoffRetryer{
+			InitialDelay: 10 * time.Millisecond,
+			MaxDelay:     50 * time.Millisecond,
+			Multiplier:   2.0,
+			MaxRetries:   3,
+			Jitter:       false,
+		}
+		conn.Retryer = retryer
+
+		// Connect should fail after max retries
+		ctx := context.Background()
+		err := conn.Connect(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "after 4 attempts")
+
+		// Should have attempted exactly 4 times (initial + 3 retries)
+		assert.Equal(t, int32(4), attemptCount.Load())
+	})
+
+	t.Run("no retry retryer falls back to single attempt", func(t *testing.T) {
+		var attemptCount atomic.Int32
+
+		newFunc := func(ctx context.Context) (connection.WebSocketConnection, error) {
+			attemptCount.Add(1)
+			return nil, errors.New("connection failed")
+		}
+
+		conn := New(
+			newFunc,
+			5*time.Second,
+			mockUnmarshaler{}, // unmarshaler required for reliableLQ
+			nil,               // logger not needed for this test
+		)
+
+		// No retry retryer configured
+
+		ctx := context.Background()
+		err := conn.Connect(ctx)
+		require.Error(t, err)
+
+		// Should have attempted only once
+		assert.Equal(t, int32(1), attemptCount.Load())
+	})
+
+	t.Run("context cancellation during retry", func(t *testing.T) {
+		var attemptCount atomic.Int32
+
+		newFunc := func(ctx context.Context) (connection.WebSocketConnection, error) {
+			attemptCount.Add(1)
+			return nil, errors.New("connection failed")
+		}
+
+		conn := New(
+			newFunc,
+			5*time.Second,
+			mockUnmarshaler{}, // unmarshaler required for reliableLQ
+			nil,               // logger not needed for this test
+		)
+
+		// Configure retryer with longer delays
+		retryer := &ExponentialBackoffRetryer{
+			InitialDelay: 100 * time.Millisecond,
+			MaxDelay:     1 * time.Second,
+			Multiplier:   2.0,
+			MaxRetries:   10,
+			Jitter:       false,
+		}
+		conn.Retryer = retryer
+
+		// Create cancellable context
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Cancel after a short delay
+		go func() {
+			time.Sleep(150 * time.Millisecond)
+			cancel()
+		}()
+
+		err := conn.Connect(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "connection canceled")
+
+		// Should have attempted at least once but not too many times
+		attempts := attemptCount.Load()
+		assert.GreaterOrEqual(t, attempts, int32(1))
+		assert.LessOrEqual(t, attempts, int32(3))
+	})
+
+	t.Run("reconnect with retry retryer", func(t *testing.T) {
+		var createCount atomic.Int32
+		var connectCount atomic.Int32
+		failOnConnect := atomic.Bool{}
+
+		mockConn := &mockConnection{}
+
+		newFunc := func(ctx context.Context) (connection.WebSocketConnection, error) {
+			createCount.Add(1)
+			if failOnConnect.Load() {
+				return nil, errors.New("create failed")
+			}
+			return mockConn, nil
+		}
+
+		// Override Connect to track calls
+		mockConn.connectErr = nil
+		mockConn.connectFunc = func(ctx context.Context) error {
+			connectCount.Add(1)
+			if failOnConnect.Load() && connectCount.Load() <= 2 {
+				return errors.New("connect failed")
+			}
+			return nil
+		}
+
+		conn := New(
+			newFunc,
+			100*time.Millisecond, // Short check interval for testing
+			mockUnmarshaler{},    // unmarshaler required for reliableLQ
+			nil,                  // logger not needed for this test
+		)
+
+		// Configure reconnect retry retryer
+		reconnectRetryer := &ExponentialBackoffRetryer{
+			InitialDelay: 10 * time.Millisecond,
+			MaxDelay:     50 * time.Millisecond,
+			Multiplier:   2.0,
+			MaxRetries:   5,
+			Jitter:       false,
+		}
+		conn.Retryer = reconnectRetryer
+
+		// Initial connect should succeed
+		ctx := context.Background()
+		err := conn.Connect(ctx)
+		require.NoError(t, err)
+
+		// Simulate connection loss
+		mockConn.isClosed = true
+		failOnConnect.Store(true)
+
+		// Wait for reconnection attempt
+		time.Sleep(200 * time.Millisecond)
+
+		// Allow reconnection to succeed on third attempt
+		failOnConnect.Store(false)
+
+		// Wait for successful reconnection
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify reconnection occurred with retries
+		assert.Greater(t, connectCount.Load(), int32(1))
+
+		// Clean up
+		err = conn.Close(ctx)
+		assert.NoError(t, err)
+	})
+}

--- a/contrib/rews/rews_test.go
+++ b/contrib/rews/rews_test.go
@@ -174,8 +174,8 @@ func TestConnection(t *testing.T) {
 
 		token, err := conn.SignIn(ctx, authData)
 		require.NoError(t, err)
-		assert.Equal(t, "test-token", token)
-		assert.Equal(t, "test-token", conn.sessionToken, "Token should be stored in session")
+		assert.Equal(t, testToken, token)
+		assert.Equal(t, testToken, conn.sessionToken, "Token should be stored in session")
 
 		// Test with different auth structures
 		authDataWithNS := map[string]any{
@@ -187,7 +187,7 @@ func TestConnection(t *testing.T) {
 
 		token, err = conn.SignIn(ctx, authDataWithNS)
 		require.NoError(t, err)
-		assert.Equal(t, "test-token", token)
+		assert.Equal(t, testToken, token)
 
 		// Test with struct auth data
 		type AuthStruct struct {
@@ -202,7 +202,7 @@ func TestConnection(t *testing.T) {
 
 		token, err = conn.SignIn(ctx, authStruct)
 		require.NoError(t, err)
-		assert.Equal(t, "test-token", token)
+		assert.Equal(t, testToken, token)
 
 		// Test when connection is closed
 		conn.state = StateClosed
@@ -223,8 +223,8 @@ func TestConnection(t *testing.T) {
 
 		token, err := conn.SignUp(ctx, authData)
 		require.NoError(t, err)
-		assert.Equal(t, "test-token", token)
-		assert.Equal(t, "test-token", conn.sessionToken, "Token should be stored in session")
+		assert.Equal(t, testToken, token)
+		assert.Equal(t, testToken, conn.sessionToken, "Token should be stored in session")
 
 		// Test with minimal auth data
 		minimalAuth := map[string]any{
@@ -234,7 +234,7 @@ func TestConnection(t *testing.T) {
 
 		token, err = conn.SignUp(ctx, minimalAuth)
 		require.NoError(t, err)
-		assert.Equal(t, "test-token", token)
+		assert.Equal(t, testToken, token)
 
 		// Test with additional fields
 		extendedAuth := map[string]any{
@@ -248,7 +248,7 @@ func TestConnection(t *testing.T) {
 
 		token, err = conn.SignUp(ctx, extendedAuth)
 		require.NoError(t, err)
-		assert.Equal(t, "test-token", token)
+		assert.Equal(t, testToken, token)
 
 		// Test when connection is closed
 		conn.state = StateClosed

--- a/doc.go
+++ b/doc.go
@@ -6,6 +6,11 @@
 //
 // Provide a proper SurrealDB endpoint URL to [FromEndpointURLString] so that it chooses the right backend for you.
 //
+// For WebSocket connections that require reliability, consider using [github.com/surrealdb/surrealdb.go/contrib/rews],
+// which provides automatic reconnection with session restoration. This is particularly important because SurrealDB's
+// RPC Protocol over WebSocket is stateful - authentication, namespace/database selection, and live queries must be
+// restored after reconnection.
+//
 // # Data Models
 //
 // The [surrealdb] package facilitates communication between client and the backend service using the Concise


### PR DESCRIPTION
This pull request enhances the `rews` package to support reconnection with exponential backoff.

I've also enhanced the documentation so that `rews` is discoverable via the top-level package doc, which will be found at:

https://pkg.go.dev/github.com/surrealdb/surrealdb.go#hdr-Connection_Engines

-once we cut v0.11.0.

Relates to #280
