### PR TITLE
cbor: Fix UUID marshaling/unmarshaling

### DIFF
--- a/contrib/rews/mock_websocket_connection_test.go
+++ b/contrib/rews/mock_websocket_connection_test.go
@@ -36,7 +36,8 @@ func (m *mockWebSocketConnection) Send(ctx context.Context, method string, param
 	case methodLive:
 		// Return a UUID for live queries
 		liveUUID := uuid.Must(uuid.NewV4())
-		data, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: liveUUID})
+		modelUUID := models.UUID{UUID: liveUUID}
+		data, _ := cbor.Marshal(modelUUID)
 		result = data
 
 		// Store the UUID for LiveNotifications
@@ -57,7 +58,8 @@ func (m *mockWebSocketConnection) Send(ctx context.Context, method string, param
 					}
 
 					liveUUID := uuid.Must(uuid.NewV4())
-					uuidData, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: liveUUID})
+					modelUUID := models.UUID{UUID: liveUUID}
+					uuidData, _ := cbor.Marshal(modelUUID)
 
 					queryResults := []QueryResult{
 						{

--- a/contrib/rews/reliable_lq_test.go
+++ b/contrib/rews/reliable_lq_test.go
@@ -139,10 +139,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 		mock := &mockRPCSender{
 			mockResult: func(method string) cbor.RawMessage {
 				uuid := models.UUID{UUID: newExternalUUID}
-				data, _ := cbor.Marshal(cbor.Tag{
-					Number:  models.TagSpecBinaryUUID,
-					Content: uuid,
-				})
+				data, _ := cbor.Marshal(uuid)
 				return data
 			},
 		}
@@ -214,10 +211,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 						Result cbor.RawMessage `json:"result"`
 					}
 
-					uuidData, _ := cbor.Marshal(cbor.Tag{
-						Number:  models.TagSpecBinaryUUID,
-						Content: uuid,
-					})
+					uuidData, _ := cbor.Marshal(uuid)
 					queryResults := []QueryResult{
 						{
 							Status: "OK",
@@ -229,10 +223,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 					data, _ := cbor.Marshal(queryResults)
 					return data
 				} else {
-					data, _ := cbor.Marshal(cbor.Tag{
-						Number:  models.TagSpecBinaryUUID,
-						Content: uuid,
-					})
+					data, _ := cbor.Marshal(uuid)
 					return data
 				}
 			},
@@ -264,20 +255,14 @@ func TestReliableLQ_handleSend(t *testing.T) {
 
 	// Create response for live method (direct UUID)
 	liveUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
-	liveData, _ := cbor.Marshal(cbor.Tag{
-		Number:  models.TagSpecBinaryUUID,
-		Content: liveUUID,
-	})
+	liveData, _ := cbor.Marshal(liveUUID)
 	liveResp := &connection.RPCResponse[cbor.RawMessage]{
 		Result: (*cbor.RawMessage)(&liveData),
 	}
 
 	// Create response for query method (array of QueryResult with UUID)
 	queryUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
-	queryUUIDData, _ := cbor.Marshal(cbor.Tag{
-		Number:  models.TagSpecBinaryUUID,
-		Content: queryUUID,
-	})
+	queryUUIDData, _ := cbor.Marshal(queryUUID)
 	queryResults := []QueryResult{
 		{
 			Status: "OK",
@@ -427,7 +412,7 @@ func TestReliableLQ_handleSend_tracking(t *testing.T) {
 		mockResult: func(method string) cbor.RawMessage {
 			// Return a mock UUID response as models.UUID
 			uuid := models.UUID{UUID: testUUID}
-			data, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: uuid})
+			data, _ := cbor.Marshal(uuid)
 			return data
 		},
 	}
@@ -469,7 +454,8 @@ func TestReliableLQ_handleSend_tracking(t *testing.T) {
 				Result cbor.RawMessage `json:"result"`
 			}
 
-			uuidData, _ := cbor.Marshal(cbor.Tag{Number: models.TagSpecBinaryUUID, Content: liveSelectTestUUID})
+			liveSelectUUID := models.UUID{UUID: liveSelectTestUUID}
+			uuidData, _ := cbor.Marshal(liveSelectUUID)
 			queryResults := []QueryResult{
 				{
 					Status: "OK",

--- a/example_create_test.go
+++ b/example_create_test.go
@@ -155,7 +155,6 @@ func ExampleCreate_recordID_withUUID() {
 	// Create a UUIDv7 using gofrs/uuid
 	u, _ := uuid.NewV7()
 	u2 := models.UUID{UUID: u}
-	_ = u2.Parse(u.String())
 
 	// Create the record with UUIDv7 ID
 	record := Person{

--- a/pkg/models/uuid.go
+++ b/pkg/models/uuid.go
@@ -1,9 +1,62 @@
 package models
 
-import "github.com/gofrs/uuid"
+import (
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gofrs/uuid"
+)
 
 type UUIDString string
 
+// UUID represents a UUID v4 or v7 value.
+//
+// It implements cbor.Marshaler and cbor.Unmarshaler to handle
+// CBOR encoding/decoding with tag 37 as specified by SurrealDB.
+//
+// Please see the [data type documentation] and the [CBOR tag documentation] for details.
+//
+// [data type documentation]: https://surrealdb.com/docs/surrealql/datamodel/uuid
+// [CBOR tag documentation]: https://surrealdb.com/docs/surrealdb/integration/cbor#tag-37
 type UUID struct {
 	uuid.UUID
+}
+
+// MarshalCBOR implements cbor.Marshaler interface for UUID
+func (u UUID) MarshalCBOR() ([]byte, error) {
+	// Tag 37 is for UUID
+	return cbor.Marshal(cbor.Tag{
+		Number:  TagSpecBinaryUUID,
+		Content: u.Bytes(),
+	})
+}
+
+// UnmarshalCBOR implements cbor.Unmarshaler interface for UUID
+func (u *UUID) UnmarshalCBOR(data []byte) error {
+	var tag cbor.Tag
+	if err := cbor.Unmarshal(data, &tag); err != nil {
+		return err
+	}
+
+	if tag.Number != TagSpecBinaryUUID {
+		return fmt.Errorf("unexpected tag number for UUID: got %d, want %d", tag.Number, TagSpecBinaryUUID)
+	}
+
+	bytes, ok := tag.Content.([]byte)
+	if !ok {
+		return fmt.Errorf("UUID tag content must be byte string, got %T", tag.Content)
+	}
+
+	// Both UUID v4 and v7 are 16 bytes
+	if len(bytes) != 16 {
+		return fmt.Errorf("UUID must be exactly 16 bytes, got %d", len(bytes))
+	}
+
+	parsed, err := uuid.FromBytes(bytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse UUID bytes: %w", err)
+	}
+
+	u.UUID = parsed
+	return nil
 }

--- a/surrealcbor/encode_tag_uuid_test.go
+++ b/surrealcbor/encode_tag_uuid_test.go
@@ -1,0 +1,197 @@
+package surrealcbor
+
+import (
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// TestEncode_uuid tests encoding of Tag 37 (UUID)
+func TestEncode_uuid(t *testing.T) {
+	t.Run("encode models.UUID", func(t *testing.T) {
+		// Create UUID from bytes
+		uuidBytes := []byte{
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		}
+		u, err := uuid.FromBytes(uuidBytes)
+		require.NoError(t, err)
+		modelUUID := models.UUID{UUID: u}
+
+		enc, err := Marshal(modelUUID)
+		require.NoError(t, err)
+
+		// Decode the raw CBOR to check the tag
+		var tag cbor.Tag
+		err = cbor.Unmarshal(enc, &tag)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(37), tag.Number)
+
+		// Verify the content is byte string
+		bytes, ok := tag.Content.([]byte)
+		require.True(t, ok, "expected byte string, got %T", tag.Content)
+		assert.Len(t, bytes, 16)
+
+		// Decode back to verify round-trip
+		var decoded models.UUID
+		err = Unmarshal(enc, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, modelUUID, decoded)
+	})
+
+	t.Run("round-trip zero UUID", func(t *testing.T) {
+		modelUUID := models.UUID{UUID: uuid.Nil} // All zeros
+
+		enc, err := Marshal(modelUUID)
+		require.NoError(t, err)
+
+		// Verify tag structure
+		var tag cbor.Tag
+		err = cbor.Unmarshal(enc, &tag)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(37), tag.Number)
+
+		bytes, ok := tag.Content.([]byte)
+		require.True(t, ok, "expected byte string, got %T", tag.Content)
+		assert.Len(t, bytes, 16)
+		for i, b := range bytes {
+			assert.Equal(t, byte(0), b, "byte at index %d should be 0", i)
+		}
+
+		// Decode back
+		var decoded models.UUID
+		err = Unmarshal(enc, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, modelUUID, decoded)
+	})
+
+	t.Run("encode UUID with all bytes set", func(t *testing.T) {
+		// Create UUID with all bytes set to 0xff
+		uuidBytes := []byte{
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		}
+		u, err := uuid.FromBytes(uuidBytes)
+		require.NoError(t, err)
+		modelUUID := models.UUID{UUID: u}
+
+		enc, err := Marshal(modelUUID)
+		require.NoError(t, err)
+
+		// Verify tag structure
+		var tag cbor.Tag
+		err = cbor.Unmarshal(enc, &tag)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(37), tag.Number)
+
+		bytes, ok := tag.Content.([]byte)
+		require.True(t, ok, "expected byte string, got %T", tag.Content)
+		assert.Len(t, bytes, 16)
+		for i, b := range bytes {
+			assert.Equal(t, byte(0xff), b, "byte at index %d should be 0xff", i)
+		}
+
+		// Decode back
+		var decoded models.UUID
+		err = Unmarshal(enc, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, modelUUID, decoded)
+	})
+
+	t.Run("encode various UUIDs", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			uuid models.UUID
+		}{
+			{
+				name: "sequential bytes",
+				uuid: func() models.UUID {
+					b := []byte{
+						0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+						0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+					}
+					u, _ := uuid.FromBytes(b)
+					return models.UUID{UUID: u}
+				}(),
+			},
+			{
+				name: "version 4 UUID pattern",
+				uuid: func() models.UUID {
+					b := []byte{
+						0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0x4d, 0xef,
+						0x81, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+					}
+					u, _ := uuid.FromBytes(b)
+					return models.UUID{UUID: u}
+				}(),
+			},
+			{
+				name: "alternating pattern",
+				uuid: func() models.UUID {
+					b := []byte{
+						0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55,
+						0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55,
+					}
+					u, _ := uuid.FromBytes(b)
+					return models.UUID{UUID: u}
+				}(),
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				enc, err := Marshal(tc.uuid)
+				require.NoError(t, err)
+
+				// Verify tag structure
+				var tag cbor.Tag
+				err = cbor.Unmarshal(enc, &tag)
+				require.NoError(t, err)
+				assert.Equal(t, uint64(37), tag.Number)
+
+				bytes, ok := tag.Content.([]byte)
+				require.True(t, ok, "expected byte string, got %T", tag.Content)
+				assert.Len(t, bytes, 16)
+
+				// Verify round-trip
+				var decoded models.UUID
+				err = Unmarshal(enc, &decoded)
+				require.NoError(t, err)
+				assert.Equal(t, tc.uuid, decoded)
+			})
+		}
+	})
+
+	t.Run("encode UUID matches expected CBOR structure", func(t *testing.T) {
+		// Create UUID from specific bytes
+		uuidBytes := []byte{
+			0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+			0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
+		}
+		u, err := uuid.FromBytes(uuidBytes)
+		require.NoError(t, err)
+		modelUUID := models.UUID{UUID: u}
+
+		enc, err := Marshal(modelUUID)
+		require.NoError(t, err)
+
+		// The CBOR encoding should be:
+		// 0xD8, 0x25 (Tag 37)
+		// 0x50 (16-byte byte string)
+		// followed by the 16 UUID bytes
+		assert.Greater(t, len(enc), 18) // At least tag + length + 16 bytes
+		assert.Equal(t, byte(0xD8), enc[0])
+		assert.Equal(t, byte(0x25), enc[1])
+		assert.Equal(t, byte(0x50), enc[2])
+
+		// Verify the UUID bytes match
+		uBytes := modelUUID.Bytes()
+		for i := 0; i < 16; i++ {
+			assert.Equal(t, uBytes[i], enc[3+i], "UUID byte at index %d mismatch", i)
+		}
+	})
+}


### PR DESCRIPTION
Interestingly, I've realized that the UUID embedded in RecordID does not work(the response times out, because SurrealDB responds without the response ID due to CBOR-related RPC error), and it worked only when you manually encode it using `cbor.Tag` struct like this:


```golang
u, _ := uuid.NewV7()
recordID := models.NewRecordID("mytable", cbor.Tag{Number: 37, Content:  u.Bytes()})
```

With this fix, the below should just work:

```golang
u, _ := uuid.NewV7()
u2 := models.UUID{UUID: u}
recordID := models.NewRecordID("mytable", u2)
```

Discord: https://discordapp.com/channels/902568124350599239/1413548789448314880