### PR TITLE
Fix CI and implementation to prevent data race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
             sleep 2
           done
       - name: Test ${{ matrix.connection-type }} connection
-        run: go test -v -cover ./...
+        run: go test -v -cover -race ./...
         env:
           SURREALDB_URL: ${{ matrix.surrealdb-url }}
           SURREALDB_CONNECTION_IMPL: ${{ matrix.surrealdb-connection-impl }}
@@ -148,7 +148,7 @@ jobs:
         run: |
           cd contrib/surrealnote
           # The Makefile will handle PostgreSQL start/stop automatically
-          go test -v -timeout 10m -run TestE2E_migrationFlow ./...
+          go test -v -race -timeout 10m -run TestE2E_migrationFlow ./...
         env:
           SURREALDB_URL: ws://localhost:8000/rpc
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 	$(GO) clean -modcache
 
 test:
-	$(GO) test -v -cover ./...
+	$(GO) test -v -cover -race ./...
 
 lint:
 	golangci-lint run

--- a/contrib/rews/rews_lq.go
+++ b/contrib/rews/rews_lq.go
@@ -9,24 +9,35 @@ import (
 
 // Send overrides the WebSocketConnection's Send method to intercept live queries
 func (arws *Connection[C]) Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error) {
+	// Get the current connection while holding the read lock
+	arws.connMu.RLock()
+	conn := arws.WebSocketConnection
+	arws.connMu.RUnlock()
+
 	// Let handleSend intercept and potentially handle the send
-	handled, resp, err := arws.reliableLQ.handleSend(ctx, method, params, arws.WebSocketConnection, arws.logger)
+	handled, resp, err := arws.reliableLQ.handleSend(ctx, method, params, conn, arws.logger)
 	if handled {
 		// handleSend processed this request
 		return resp, err
 	}
 
 	// Not a live query, send normally through the underlying connection
-	return arws.WebSocketConnection.Send(ctx, method, params...)
+	return conn.Send(ctx, method, params...)
 }
 
 // LiveNotifications overrides to provide UUID mapping for live queries
 func (arws *Connection[C]) LiveNotifications(id string) (chan connection.Notification, error) {
-	return arws.reliableLQ.liveNotifications(id, arws.WebSocketConnection)
+	arws.connMu.RLock()
+	conn := arws.WebSocketConnection
+	arws.connMu.RUnlock()
+	return arws.reliableLQ.liveNotifications(id, conn)
 }
 
 // CloseLiveNotifications overrides to handle UUID mapping
 func (arws *Connection[C]) CloseLiveNotifications(id string) error {
-	_, err := arws.reliableLQ.closeLiveNotifications(arws.WebSocketConnection, id)
+	arws.connMu.RLock()
+	conn := arws.WebSocketConnection
+	arws.connMu.RUnlock()
+	_, err := arws.reliableLQ.closeLiveNotifications(conn, id)
 	return err
 }

--- a/contrib/rews/rews_retry_test.go
+++ b/contrib/rews/rews_retry_test.go
@@ -19,7 +19,7 @@ type mockConnection struct {
 	connection.WebSocketConnection
 	connectCalls atomic.Int32
 	connectErr   error
-	isClosed     bool
+	isClosed     atomic.Bool
 	connectFunc  func(ctx context.Context) error // Allow overriding Connect behavior
 }
 
@@ -32,11 +32,11 @@ func (m *mockConnection) Connect(ctx context.Context) error {
 }
 
 func (m *mockConnection) IsClosed() bool {
-	return m.isClosed
+	return m.isClosed.Load()
 }
 
 func (m *mockConnection) Close(ctx context.Context) error {
-	m.isClosed = true
+	m.isClosed.Store(true)
 	return nil
 }
 
@@ -272,7 +272,7 @@ func TestConnectionRetry(t *testing.T) {
 		require.NoError(t, err)
 
 		// Simulate connection loss
-		mockConn.isClosed = true
+		mockConn.isClosed.Store(true)
 		failOnConnect.Store(true)
 
 		// Wait for reconnection attempt

--- a/contrib/rews/route.go
+++ b/contrib/rews/route.go
@@ -1,0 +1,158 @@
+package rews
+
+import (
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+)
+
+// panicIfEmpty panics with the given message if the value is empty
+func panicIfEmpty(value, message string) {
+	if value == "" {
+		panic(message)
+	}
+}
+
+// panicIfNilNotificationCh panics with the given message if the value is nil
+func panicIfNilNotificationCh(value chan connection.Notification, message string) {
+	if value == nil {
+		panic(message)
+	}
+}
+
+// route represents a single notification routing path
+type route struct {
+	// Immutable fields - set once during creation, never changed
+	internalID string                       // Stable ID that client uses
+	internalCh chan connection.Notification // Stable channel that client reads from
+
+	// Mutable fields - updated during reconnection when external UUID changes
+	// Note: These fields should only be modified by a single goroutine (no concurrent access)
+	// The routing goroutine receives copies of these values to avoid races
+	externalID string                       // Changes on reconnection (new UUID from server)
+	externalCh chan connection.Notification // Changes on reconnection (new channel from server)
+	stopCh     chan struct{}                // Signal to stop routing goroutine
+	stoppedCh  chan struct{}                // Closed by goroutine when it finishes
+}
+
+// newRoute creates a new route with the given internal ID.
+// The internal channel is buffered to avoid blocking when routing notifications.
+func newRoute(internalID string) *route {
+	panicIfEmpty(internalID, "BUG: internalID is mandatory")
+
+	return &route{
+		internalID: internalID,
+		internalCh: make(chan connection.Notification, 100), // buffered to avoid blocking
+	}
+}
+
+// stop completely stops the route by stopping any running routing goroutine and closing the internal channel.
+// This should be called when the route is being removed.
+func (r *route) stop() {
+	// First stop any running goroutine to ensure nothing is trying to send to internalCh
+	r.stopRoutingGoroutine()
+
+	// Now it's safe to close the internal channel since no goroutine is running
+	close(r.internalCh)
+}
+
+// setExternal updates the external ID and channel, managing the routing goroutine lifecycle.
+// If an existing goroutine is running with a different external ID, it stops the old one first.
+// Then it starts a new routing goroutine if the external ID is not empty.
+// This method should NOT be called concurrently - it's designed for sequential reconnection scenarios.
+func (r *route) setExternal(externalID string, externalCh chan connection.Notification, l logger.Logger) {
+	// both externalID and externalCh must be provided together
+	panicIfEmpty(externalID, "BUG: externalID is mandatory")
+	panicIfNilNotificationCh(externalCh, "BUG: externalCh is mandatory")
+
+	// Stop old routing if it exists and external ID is changing
+	if r.stopCh != nil && r.externalID != externalID {
+		if l != nil {
+			l.Debug("Stopping old routing",
+				"internal_id", r.internalID,
+				"old_external_id", r.externalID,
+				"new_external_id", externalID)
+		}
+		r.stopRoutingGoroutine()
+	}
+
+	// Update route
+	r.externalID = externalID
+	r.externalCh = externalCh
+
+	// Start the routing goroutine with the logger
+	r.startRoutingGoroutine(l)
+}
+
+// stopRoutingGoroutine stops the routing goroutine if it's running and waits for it to finish.
+// It returns true if a goroutine was stopped, false if there was no goroutine running.
+func (r *route) stopRoutingGoroutine() {
+	// If you see this panic, it means stopRoutingGoroutine was called
+	// multiple times concurrently, which is not allowed and a programming error.
+	close(r.stopCh)
+	<-r.stoppedCh // Wait for goroutine to finish
+
+	// Clear the channels after stopping
+	r.stopCh = nil
+	r.stoppedCh = nil
+	r.externalCh = nil
+}
+
+// startRoutingGoroutine starts a goroutine that routes notifications from external to internal channel.
+// It takes copies of the mutable fields to avoid race conditions during reconnection.
+// The goroutine will signal completion by closing stoppedCh.
+func (r *route) startRoutingGoroutine(l logger.Logger) {
+	// Create fresh channels for the new goroutine
+	r.stopCh = make(chan struct{})
+	r.stoppedCh = make(chan struct{})
+
+	// Create copies of all the fields we need to avoid races
+	internalID := r.internalID
+	externalID := r.externalID
+	internalCh := r.internalCh
+	externalCh := r.externalCh
+	stopCh := r.stopCh
+	stoppedCh := r.stoppedCh
+
+	go func() {
+		defer close(stoppedCh) // Signal completion when goroutine exits
+
+		if l != nil {
+			l.Debug("Starting notification routing",
+				"internal_id", internalID,
+				"external_id", externalID)
+		}
+
+		for {
+			select {
+			case notification, ok := <-externalCh:
+				if !ok {
+					if l != nil {
+						l.Debug("External channel closed",
+							"internal_id", internalID,
+							"external_id", externalID)
+					}
+					return
+				}
+
+				select {
+				case internalCh <- notification:
+					// Successfully routed notification
+				default:
+					// Internal channel might be full
+					if l != nil {
+						l.Warn("Failed to route notification, channel might be full",
+							"internal_id", internalID)
+					}
+				}
+
+			case <-stopCh:
+				if l != nil {
+					l.Debug("Notification routing stopped",
+						"internal_id", internalID,
+						"external_id", externalID)
+				}
+				return
+			}
+		}
+	}()
+}

--- a/contrib/rews/route_test.go
+++ b/contrib/rews/route_test.go
@@ -1,0 +1,219 @@
+package rews
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// createTestUUID creates a models.UUID for testing
+func createTestUUID(name string) *models.UUID {
+	// Create a deterministic UUID from string for testing
+	id := uuid.NewV5(uuid.NamespaceURL, name)
+	return &models.UUID{UUID: id}
+}
+
+// TestNewRouteValidation tests that newRoute panics with empty internalID
+func TestNewRouteValidation(t *testing.T) {
+	// Test that it panics with empty internalID
+	assert.Panics(t, func() {
+		newRoute("")
+	}, "Should panic with empty internalID")
+
+	// Test that it doesn't panic with valid internalID
+	assert.NotPanics(t, func() {
+		r := newRoute("valid-id")
+		assert.NotNil(t, r)
+		assert.Equal(t, "valid-id", r.internalID)
+		assert.NotNil(t, r.internalCh)
+	}, "Should not panic with valid internalID")
+}
+
+// TestSetExternalValidation tests that setExternal validates its parameters correctly
+func TestSetExternalValidation(t *testing.T) {
+	r := newRoute("test-route")
+
+	// Test that it panics with empty externalID
+	assert.Panics(t, func() {
+		ch := make(chan connection.Notification)
+		r.setExternal("", ch, nil)
+	}, "Should panic when externalID is empty")
+
+	// Test that it panics with nil externalCh
+	assert.Panics(t, func() {
+		r.setExternal("external-id", nil, nil)
+	}, "Should panic when externalCh is nil")
+
+	// Test that it doesn't panic when both are provided
+	assert.NotPanics(t, func() {
+		ch := make(chan connection.Notification)
+		r.setExternal("external-id", ch, nil)
+		// Clean up
+		r.stopRoutingGoroutine()
+	}, "Should not panic when both are provided")
+}
+
+// TestRouteStopRoutingGoroutine tests the stopRoutingGoroutine method
+func TestRouteStopRoutingGoroutine(t *testing.T) {
+	r := newRoute("test-route")
+
+	// Initially, no goroutine is running
+	assert.Panics(t, func() {
+		r.stopRoutingGoroutine()
+	}, "Should panic when stopping with no goroutine running")
+
+	// Set up an external channel
+	externalCh := make(chan connection.Notification, 1)
+	r.setExternal("ext-1", externalCh, nil)
+
+	// Now stopping should return true
+	assert.NotPanics(t, func() {
+		r.stopRoutingGoroutine()
+	}, "Should not panic when stopping with goroutine running")
+}
+
+// TestRouteSetExternalMultipleTimes tests setting external multiple times
+func TestRouteSetExternalMultipleTimes(t *testing.T) {
+	r := newRoute("multi-test")
+
+	// Create channels for notifications
+	sentNotifications := []connection.Notification{
+		{ID: createTestUUID("n1"), Action: connection.CreateAction},
+		{ID: createTestUUID("n2"), Action: connection.UpdateAction},
+		{ID: createTestUUID("n3"), Action: connection.DeleteAction},
+	}
+
+	// First external setup
+	ext1 := make(chan connection.Notification, 10)
+	r.setExternal("ext-1", ext1, nil)
+
+	// Send a notification through first external
+	ext1 <- sentNotifications[0]
+
+	// Wait a bit for routing
+	time.Sleep(50 * time.Millisecond)
+
+	// Switch to second external (should stop first goroutine)
+	ext2 := make(chan connection.Notification, 10)
+	r.setExternal("ext-2", ext2, nil)
+
+	// Send through second external
+	ext2 <- sentNotifications[1]
+
+	// Wait a bit for routing
+	time.Sleep(50 * time.Millisecond)
+
+	// Switch to third external
+	ext3 := make(chan connection.Notification, 10)
+	r.setExternal("ext-3", ext3, nil)
+
+	// Send through third external
+	ext3 <- sentNotifications[2]
+
+	// Collect notifications from internal channel
+	var received []connection.Notification
+	timeout := time.After(200 * time.Millisecond)
+
+	for {
+		select {
+		case notif := <-r.internalCh:
+			received = append(received, notif)
+		case <-timeout:
+			// Done collecting
+			goto done
+		}
+	}
+
+done:
+	// We should have received all notifications
+	assert.Len(t, received, 3, "Should have received all 3 notifications")
+
+	// Clean up
+	r.stop()
+}
+
+// TestRouteSequentialReconnection tests sequential reconnection scenarios
+// This simulates the real usage where setExternal is called sequentially during reconnections
+func TestRouteSequentialReconnection(t *testing.T) {
+	r := newRoute("reconnection-test")
+
+	const numReconnections = 5
+	const numMessages = 10
+
+	totalReceived := 0
+	done := make(chan struct{})
+
+	// Start a reader goroutine to consume from internal channel
+	go func() {
+		for {
+			select {
+			case notif, ok := <-r.internalCh:
+				if !ok {
+					close(done)
+					return
+				}
+				totalReceived++
+				assert.NotNil(t, notif)
+			case <-time.After(2 * time.Second):
+				close(done)
+				return
+			}
+		}
+	}()
+
+	// Simulate sequential reconnections
+	for reconnect := 0; reconnect < numReconnections; reconnect++ {
+		// Create a new external channel for this "connection"
+		extCh := make(chan connection.Notification, numMessages)
+		extID := fmt.Sprintf("connection-%d", reconnect)
+
+		// Set this as the new external channel (simulating reconnection with new UUID)
+		r.setExternal(extID, extCh, nil)
+
+		// Send messages through this connection
+		go func(connID int, ch chan connection.Notification) {
+			for m := 0; m < numMessages; m++ {
+				notification := connection.Notification{
+					ID:     createTestUUID(fmt.Sprintf("c%d-m%d", connID, m)),
+					Action: connection.CreateAction,
+				}
+
+				select {
+				case ch <- notification:
+					// Sent successfully
+				case <-time.After(10 * time.Millisecond):
+					// Timeout - connection might have changed
+					return
+				}
+
+				// Small delay between messages
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(reconnect, extCh)
+
+		// Simulate connection duration before next reconnection
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Give final messages time to be routed
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop the route
+	r.stop()
+
+	// Wait for reader to finish
+	<-done
+
+	t.Logf("Received %d notifications from %d sequential reconnections", totalReceived, numReconnections)
+	assert.Greater(t, totalReceived, 0, "Should have received at least some notifications")
+
+	// We expect to receive most messages, though some from earlier connections might be lost
+	// when reconnection happens (this is realistic behavior)
+	expectedMin := numMessages * (numReconnections - 1) // At least messages from completed connections
+	assert.GreaterOrEqual(t, totalReceived, expectedMin/2, "Should receive a reasonable number of messages")
+}


### PR DESCRIPTION
This pull request introduces improvements to thread safety in the `gorillaws` and `rews` packages, along with additional refactoring, tests, and tweaks to CI to ensure no data races are introduced into the implementation in the future.
