### PR TITLE
Make surrealcbor the default CBOR implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,23 +30,23 @@ jobs:
             go-version: '1.25.0'
             connection-type: 'http'
             surrealdb-url: 'http://localhost:8000'
-          # v2.3.7 with Go 1.25.0, http, surrealcbor
+          # v2.3.7 with Go 1.25.0, http, fxamackercbor (legacy)
           - surrealdb-version: 'v2.3.7'
             go-version: '1.25.0'
             connection-type: 'http'
             surrealdb-url: 'http://localhost:8000'
-            surrealdb-cbor-impl: 'surrealcbor'
+            surrealdb-cbor-impl: 'fxamackercbor'
           # v2.3.7 with Go 1.25.0, gorilla/websocket
           - surrealdb-version: 'v2.3.7'
             go-version: '1.25.0'
             connection-type: 'ws'
             surrealdb-url: 'ws://localhost:8000/rpc'
-          # v2.3.7 with Go 1.25.0, gorilla/websocket, surrealcbor
+          # v2.3.7 with Go 1.25.0, gorilla/websocket, fxamackercbor (legacy)
           - surrealdb-version: 'v2.3.7'
             go-version: '1.25.0'
             connection-type: 'ws'
             surrealdb-url: 'ws://localhost:8000/rpc'
-            surrealdb-cbor-impl: 'surrealcbor'
+            surrealdb-cbor-impl: 'fxamackercbor'
           # v2.3.7 with Go 1.25.0, gorilla/websocket, reconnection
           - surrealdb-version: 'v2.3.7'
             go-version: '1.25.0'
@@ -66,6 +66,12 @@ jobs:
             surrealdb-url: 'ws://localhost:8000/rpc'
             surrealdb-connection-impl: 'gws'
             surrealdb-reconnection-check-interval: '1s'
+          # v2.3.7 with Go 1.25.0, explicit surrealcbor
+          - surrealdb-version: 'v2.3.7'
+            go-version: '1.25.0'
+            connection-type: 'ws'
+            surrealdb-url: 'ws://localhost:8000/rpc'
+            surrealdb-cbor-impl: 'surrealcbor'
           # v2.3.7 with Go 1.24.6
           - surrealdb-version: 'v2.3.7'
             go-version: '1.24.6'

--- a/contrib/rews/reliable_lq_test.go
+++ b/contrib/rews/reliable_lq_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 // testUnmarshaler is a test implementation of codec.Unmarshaler
@@ -31,7 +32,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 	t.Run("restores live RPC query", func(t *testing.T) {
 		mock := &mockRPCSender{}
 		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+		rlq := newReliableLQ(log, surrealcbor.New())
 
 		// Manually add a live query to simulate one that needs restoration
 		rlq.liveQueries["test-id"] = &LiveQueryInfo{
@@ -58,7 +59,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 	t.Run("restores query RPC with LIVE SELECT", func(t *testing.T) {
 		mock := &mockRPCSender{}
 		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+		rlq := newReliableLQ(log, surrealcbor.New())
 
 		// Manually add a LIVE SELECT query to simulate one that needs restoration
 		liveSelectQuery := "LIVE SELECT * FROM products WHERE active = true"
@@ -85,7 +86,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 	t.Run("restores multiple queries of different types", func(t *testing.T) {
 		mock := &mockRPCSender{}
 		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+		rlq := newReliableLQ(log, surrealcbor.New())
 
 		// Add both types of live queries
 		rlq.liveQueries["live-1"] = &LiveQueryInfo{
@@ -119,7 +120,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 	})
 	t.Run("updates existing live query mappings", func(t *testing.T) {
 		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+		rlq := newReliableLQ(log, surrealcbor.New())
 		ctx := context.Background()
 
 		// Setup initial state with existing mappings
@@ -157,7 +158,7 @@ func TestReliableLQ_restoreLiveQueries(t *testing.T) {
 
 	t.Run("restores multiple queries with existing mappings", func(t *testing.T) {
 		log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-		rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+		rlq := newReliableLQ(log, surrealcbor.New())
 		ctx := context.Background()
 
 		// Setup initial state with multiple existing mappings
@@ -383,7 +384,7 @@ func TestReliableLQ_handleSend(t *testing.T) {
 				},
 			}
 			log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-			rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+			rlq := newReliableLQ(log, surrealcbor.New())
 			ctx := context.Background()
 
 			handled, resp, err := rlq.handleSend(ctx, tt.method, tt.params, mock, log)
@@ -402,7 +403,7 @@ func TestReliableLQ_handleSend(t *testing.T) {
 func TestReliableLQ_handleSend_tracking(t *testing.T) {
 	// Setup
 	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-	rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+	rlq := newReliableLQ(log, surrealcbor.New())
 	ctx := context.Background()
 
 	// Create a mock that returns a UUID in the response
@@ -487,7 +488,7 @@ func TestReliableLQ_handleSend_tracking(t *testing.T) {
 // TestReliableLQ_recordLiveQueryFromResponse_errors tests error handling
 func TestReliableLQ_recordLiveQueryFromResponse_errors(t *testing.T) {
 	log := logger.New(slog.NewTextHandler(os.Stdout, nil))
-	rlq := newReliableLQ(log, &models.CborUnmarshaler{})
+	rlq := newReliableLQ(log, surrealcbor.New())
 
 	tests := []struct {
 		name        string

--- a/contrib/rews/rews_lq_test.go
+++ b/contrib/rews/rews_lq_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 // TestLiveQueryLifecycle tests the lifecycle of live queries
@@ -31,7 +32,7 @@ func TestLiveQueryLifecycle(t *testing.T) {
 
 	conn := &Connection[*mockWebSocketConnection]{
 		WebSocketConnection: mock,
-		reliableLQ:          newReliableLQ(log, &models.CborUnmarshaler{}),
+		reliableLQ:          newReliableLQ(log, surrealcbor.New()),
 		logger:              log,
 		sessionVars:         make(map[string]any),
 	}

--- a/contrib/rews/rews_test.go
+++ b/contrib/rews/rews_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
-	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 // TestConnection tests all public methods of the Connection struct
@@ -26,7 +26,7 @@ func TestConnection(t *testing.T) {
 
 		conn := &Connection[*mockWebSocketConnection]{
 			WebSocketConnection: mock,
-			reliableLQ:          newReliableLQ(log, &models.CborUnmarshaler{}),
+			reliableLQ:          newReliableLQ(log, surrealcbor.New()),
 			logger:              log,
 			sessionVars:         make(map[string]any),
 			state:               StateConnected, // Start in connected state for most tests

--- a/db_test.go
+++ b/db_test.go
@@ -374,7 +374,8 @@ func (s *SurrealDBTestSuite) TestConcurrentOperations() {
 				defer wg.Done()
 				user, err := surrealdb.Select[testUser](context.Background(), s.db, models.NewRecordID("missing", j))
 				s.Require().NoError(err)
-				s.Require().Nil(user.ID)
+				// With surrealcbor (new default), non-existent records return nil
+				s.Require().Nil(user)
 			}(i)
 		}
 		wg.Wait()

--- a/docs/migration_guide_to_v1.md
+++ b/docs/migration_guide_to_v1.md
@@ -34,3 +34,89 @@ point := models.GeometryPoint{
 5. Verify geospatial queries work as expected after migration
 
 **Related issue:** #223
+
+### Default CBOR Implementation Change
+
+**Introduced in:** v0.11.0
+
+**What changed:** The default CBOR implementation has changed from `fxamacker/cbor` to `surrealcbor`. This change provides better compatibility with SurrealDB's CBOR protocol, particularly for handling the NONE tag (tag 6) which is properly unmarshaled to Go `nil` values.
+
+**Why:** `surrealcbor` is specifically designed for SurrealDB's CBOR protocol and provides:
+- Proper handling of SurrealDB's NONE tag (unmarshals to Go `nil`)
+- Better performance for SurrealDB-specific data types
+- Native support for all SurrealDB CBOR tags (UUIDs, Record IDs, Geometry types, etc.)
+- More robust handling of SurrealDB's custom datetime and duration formats
+
+**Before (v0.x):**
+```go
+// Default configuration automatically used fxamacker/cbor
+conf := connection.NewConfig(u)
+// conf.Marshaler was &models.CborMarshaler{}
+// conf.Unmarshaler was &models.CborUnmarshaler{}
+```
+
+**After (v1.0):**
+```go
+// Default configuration now automatically uses surrealcbor
+conf := connection.NewConfig(u)
+// conf.Marshaler is surrealcbor.New()
+// conf.Unmarshaler is surrealcbor.New()
+
+// To explicitly use the legacy fxamacker/cbor implementation:
+conf.Marshaler = &models.CborMarshaler{}
+conf.Unmarshaler = &models.CborUnmarshaler{}
+```
+
+**Environment variable support:**
+```bash
+# Use surrealcbor (default, no need to set)
+# SURREALDB_CBOR_IMPL=""
+
+# Explicitly use surrealcbor
+SURREALDB_CBOR_IMPL="surrealcbor"
+
+# Use legacy fxamacker/cbor implementation
+SURREALDB_CBOR_IMPL="fxamackercbor"
+```
+
+**Key behavioral difference:**
+
+When selecting non-existent records, the two implementations behave differently:
+
+- **fxamacker/cbor**: Returns a struct with nil fields (e.g., `user.ID == nil`)
+- **surrealcbor**: Returns nil for the entire struct (e.g., `user == nil`)
+
+**Code that may need updating:**
+```go
+// Old code that worked with fxamacker/cbor default:
+user, err := surrealdb.Select[User](ctx, db, recordID)
+if err != nil {
+    return err
+}
+if user.ID == nil {
+    // Handle non-existent record
+}
+
+// Updated code for surrealcbor default:
+user, err := surrealdb.Select[User](ctx, db, recordID)
+if err != nil {
+    return err
+}
+if user == nil {
+    // Handle non-existent record
+}
+```
+
+**Migration steps:**
+1. **No action required for most users** - the new default provides better compatibility
+2. If you were explicitly setting surrealcbor before, you can remove the explicit configuration as it's now the default
+3. Update any code that depends on fxamacker/cbor-specific behavior to work with surrealcbor
+4. **Update tests and code that check for non-existent records** - change from checking field nullability to checking struct nullability
+5. Test your application thoroughly, paying attention to:
+   - NONE/null value handling
+   - Non-existent record detection
+   - Custom datetime parsing
+   - UUID and Record ID serialization
+   - Geometry type handling
+
+**Note:** `models.CborMarshaler` and `models.CborUnmarshaler` are deprecated in v0.11.0 and will be removed in v1. Use `surrealcbor.New()` instead.

--- a/example_fromconnection_fxamacker_cbor_decopts_test.go
+++ b/example_fromconnection_fxamacker_cbor_decopts_test.go
@@ -123,7 +123,7 @@ func ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit() {
 		conf.Logger = logger.New(handler)
 		// Set a custom small limit that will be exceeded
 		// Note: fxamacker/cbor requires MaxArrayElements to be at least 16
-		conf.Unmarshaler = &models.CborUnmarshaler{
+		conf.Unmarshaler = &models.CborUnmarshaler{ //nolint:staticcheck // Example demonstrating fxamacker/cbor DecOptions
 			DecOptions: cbor.DecOptions{
 				MaxArrayElements: 16, // Set to minimum allowed value
 			},
@@ -178,7 +178,7 @@ func ExampleCborUnmarshaler_DecOptions_customLargeLimit() {
 	conf := connection.NewConfig(u)
 	conf.Logger = nil
 	// Set a custom larger limit that accommodates the data
-	conf.Unmarshaler = &models.CborUnmarshaler{
+	conf.Unmarshaler = &models.CborUnmarshaler{ //nolint:staticcheck // Example demonstrating fxamacker/cbor DecOptions
 		DecOptions: cbor.DecOptions{
 			// Note that the default value is 131072.
 			// We use smaller value just to make test run quickly.

--- a/example_fromconnection_fxamackercbor_test.go
+++ b/example_fromconnection_fxamackercbor_test.go
@@ -1,0 +1,68 @@
+package surrealdb_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gws"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// FromConnection can take any connection.Connection implementation with
+// a custom connection.Config that can be used to specify a CBOR marshaler and unmarshaler.
+// This example demonstrates how to explicitly use the legacy fxamacker/cbor implementation
+// instead of the default surrealcbor implementation.
+func ExampleFromConnection_alternativeCBORImpl_fxamackerCBOR() {
+	conf := connection.NewConfig(testenv.MustParseSurrealDBWSURL())
+	// To explicitly use the legacy fxamacker/cbor implementation,
+	// override the default surrealcbor with fxamacker-based marshalers.
+	// Note: fxamacker/cbor is deprecated in favor of surrealcbor.
+	conf.Marshaler = &models.CborMarshaler{}     //nolint:staticcheck // Intentional use of deprecated type for example
+	conf.Unmarshaler = &models.CborUnmarshaler{} //nolint:staticcheck // Intentional use of deprecated type for example
+
+	conn := gws.New(conf)
+	db, err := surrealdb.FromConnection(context.Background(), conn)
+	if err != nil {
+		panic(err)
+	}
+
+	db, err = testenv.Init(db, "surrealdbexamples", "fxamackercbor", "user")
+	if err != nil {
+		panic(err)
+	}
+
+	// Define a sample struct
+	type User struct {
+		ID    *models.RecordID `json:"id,omitempty"`
+		Name  string           `json:"name"`
+		Email string           `json:"email"`
+		// Note that with fxamacker/cbor you need to use models.CustomDateTime
+		// instead of time.Time for proper datetime handling
+		CreatedAt models.CustomDateTime `json:"created_at"`
+	}
+
+	// Create a user
+	createdAt, _ := time.Parse(time.RFC3339, "2023-10-01T12:00:00Z")
+	user := User{
+		Name:      "Bob",
+		Email:     "bob@example.com",
+		CreatedAt: models.CustomDateTime{Time: createdAt},
+	}
+
+	// Insert the user
+	created, err := surrealdb.Insert[User](context.Background(), db, "user", user)
+	if err != nil {
+		panic(err)
+	}
+
+	if created != nil && len(*created) > 0 {
+		fmt.Printf("Created user: %s with email: %s\n", (*created)[0].Name, (*created)[0].Email)
+	}
+
+	// Output:
+	// Created user: Bob with email: bob@example.com
+}

--- a/example_query_none_null_test.go
+++ b/example_query_none_null_test.go
@@ -83,9 +83,9 @@ func ExampleQuery_none_and_null_handling_allExistingFields() {
 	// ID: t:f, Nullable: false, Option: none
 }
 
-func ExampleQuery_none_and_null_handling_explicitFields() {
+func ExampleQuery_none_and_null_handling_explicitFields_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = false
+	c.UseFxamackerCBOR = true
 
 	db := c.MustNew()
 
@@ -223,9 +223,9 @@ func ExampleQuery_none_and_null_handling_explicitFields_surrealcbor() {
 	// ID: t:f, Nullable: false, Option: <nil>
 }
 
-func ExampleQuery_none_and_null_handling_explicitFields_ints() {
+func ExampleQuery_none_and_null_handling_explicitFields_ints_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = false
+	c.UseFxamackerCBOR = true
 
 	db := c.MustNew()
 
@@ -363,9 +363,9 @@ func ExampleQuery_none_and_null_handling_explicitFields_ints_surrealcbor() {
 	// ID: t:f, Nullable: 1, Option: <nil>
 }
 
-func ExampleQuery_create_none_null_fields() {
+func ExampleQuery_create_none_null_fields_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = false
+	c.UseFxamackerCBOR = true
 
 	db := c.MustNew()
 
@@ -512,9 +512,9 @@ func ExampleQuery_create_none_null_fields_surrealcbor() {
 }
 
 //nolint:gocritic
-func ExampleQuery_null_none_customdatetime_roundtrip() {
+func ExampleQuery_null_none_customdatetime_roundtrip_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = false
+	c.UseFxamackerCBOR = true
 
 	db := c.MustNew()
 

--- a/example_query_none_null_test.go
+++ b/example_query_none_null_test.go
@@ -85,7 +85,7 @@ func ExampleQuery_none_and_null_handling_allExistingFields() {
 
 func ExampleQuery_none_and_null_handling_explicitFields_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseFxamackerCBOR = true
+	c.CBORImpl = testenv.CBORImplFxamackerCBOR
 
 	db := c.MustNew()
 
@@ -155,7 +155,7 @@ func ExampleQuery_none_and_null_handling_explicitFields_legacy_fxamackercbor() {
 
 func ExampleQuery_none_and_null_handling_explicitFields_surrealcbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = true
+	c.CBORImpl = testenv.CBORImplSurrealCBOR
 
 	db := c.MustNew()
 
@@ -225,7 +225,7 @@ func ExampleQuery_none_and_null_handling_explicitFields_surrealcbor() {
 
 func ExampleQuery_none_and_null_handling_explicitFields_ints_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseFxamackerCBOR = true
+	c.CBORImpl = testenv.CBORImplFxamackerCBOR
 
 	db := c.MustNew()
 
@@ -295,7 +295,7 @@ func ExampleQuery_none_and_null_handling_explicitFields_ints_legacy_fxamackercbo
 
 func ExampleQuery_none_and_null_handling_explicitFields_ints_surrealcbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = true
+	c.CBORImpl = testenv.CBORImplSurrealCBOR
 
 	db := c.MustNew()
 
@@ -365,7 +365,7 @@ func ExampleQuery_none_and_null_handling_explicitFields_ints_surrealcbor() {
 
 func ExampleQuery_create_none_null_fields_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseFxamackerCBOR = true
+	c.CBORImpl = testenv.CBORImplFxamackerCBOR
 
 	db := c.MustNew()
 
@@ -439,7 +439,7 @@ func ExampleQuery_create_none_null_fields_legacy_fxamackercbor() {
 
 func ExampleQuery_create_none_null_fields_surrealcbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = true
+	c.CBORImpl = testenv.CBORImplSurrealCBOR
 
 	db := c.MustNew()
 
@@ -514,7 +514,7 @@ func ExampleQuery_create_none_null_fields_surrealcbor() {
 //nolint:gocritic
 func ExampleQuery_null_none_customdatetime_roundtrip_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseFxamackerCBOR = true
+	c.CBORImpl = testenv.CBORImplFxamackerCBOR
 
 	db := c.MustNew()
 
@@ -742,7 +742,7 @@ func ExampleQuery_null_none_customdatetime_roundtrip_legacy_fxamackercbor() {
 //nolint:gocritic
 func ExampleQuery_null_none_customdatetime_roundtrip_surrealcbor() {
 	c := testenv.MustNewConfig("example", "query", "t")
-	c.UseSurrealCBOR = true
+	c.CBORImpl = testenv.CBORImplSurrealCBOR
 
 	db := c.MustNew()
 

--- a/example_select_nonexistent_test.go
+++ b/example_select_nonexistent_test.go
@@ -1,0 +1,75 @@
+package surrealdb_test
+
+import (
+	"context"
+	"fmt"
+
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// ExampleSelect_nonExistentRecord_fxamackercbor demonstrates how fxamacker/cbor
+// handles non-existent records - it returns a struct with non-nil CustomNil{} for missing pointer fields
+func ExampleSelect_nonExistentRecord_fxamackercbor() {
+	c := testenv.MustNewConfig("example", "select", "user")
+	c.UseFxamackerCBOR = true
+
+	db := c.MustNew()
+
+	type User struct {
+		ID       *models.RecordID `json:"id,omitempty"`
+		Username string           `json:"username"`
+		Email    string           `json:"email"`
+	}
+
+	// Try to select a record that doesn't exist
+	user, err := surrealdb.Select[User](context.Background(), db, models.NewRecordID("user", "does_not_exist"))
+	if err != nil {
+		panic(err)
+	}
+
+	// With fxamacker/cbor, non-existent records return a struct where:
+	// - Pointer fields that would be NONE become nil (behavior changed after v1.0.0)
+	// - This example shows the current behavior with fxamacker
+	fmt.Printf("User found: %t\n", user != nil)
+	fmt.Printf("User.ID is nil: %t\n", user.ID == nil)
+	fmt.Printf("User.ID type: %T\n", user.ID)
+	fmt.Printf("User.Username: %q\n", user.Username)
+	fmt.Printf("User.Email: %q\n", user.Email)
+
+	// Output:
+	// User found: true
+	// User.ID is nil: true
+	// User.ID type: *models.RecordID
+	// User.Username: ""
+	// User.Email: ""
+}
+
+// ExampleSelect_nonExistentRecord_surrealcbor demonstrates how surrealcbor
+// handles non-existent records - it returns nil
+func ExampleSelect_nonExistentRecord_surrealcbor() {
+	c := testenv.MustNewConfig("example", "select", "user")
+	c.UseSurrealCBOR = true
+
+	db := c.MustNew()
+
+	type User struct {
+		ID       *models.RecordID `json:"id,omitempty"`
+		Username string           `json:"username"`
+		Email    string           `json:"email"`
+	}
+
+	// Try to select a record that doesn't exist
+	user, err := surrealdb.Select[User](context.Background(), db, models.NewRecordID("user", "does_not_exist"))
+	if err != nil {
+		panic(err)
+	}
+
+	// With surrealcbor, non-existent records return nil
+	// - This is why tests like s.Require().Nil(user) pass
+	fmt.Printf("User found: %t\n", user != nil)
+
+	// Output:
+	// User found: false
+}

--- a/example_select_nonexistent_test.go
+++ b/example_select_nonexistent_test.go
@@ -13,7 +13,7 @@ import (
 // handles non-existent records - it returns a struct with non-nil CustomNil{} for missing pointer fields
 func ExampleSelect_nonExistentRecord_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "select", "user")
-	c.UseFxamackerCBOR = true
+	c.CBORImpl = testenv.CBORImplFxamackerCBOR
 
 	db := c.MustNew()
 
@@ -50,7 +50,7 @@ func ExampleSelect_nonExistentRecord_fxamackercbor() {
 // handles non-existent records - it returns nil
 func ExampleSelect_nonExistentRecord_surrealcbor() {
 	c := testenv.MustNewConfig("example", "select", "user")
-	c.UseSurrealCBOR = true
+	c.CBORImpl = testenv.CBORImplSurrealCBOR
 
 	db := c.MustNew()
 

--- a/example_upsert_test.go
+++ b/example_upsert_test.go
@@ -109,9 +109,9 @@ func ExampleUpsert() {
 	// Selected person: {persons:yusuke Yusuke Updated Last {0001-01-01 00:00:00 +0000 UTC} <nil>}
 }
 
-func ExampleUpsert_unmarshal_error_fxamackercbor() {
+func ExampleUpsert_unmarshal_error_fxamackercbor_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "person")
-	c.UseSurrealCBOR = false
+	c.UseFxamackerCBOR = true
 
 	db := c.MustNew()
 

--- a/example_upsert_test.go
+++ b/example_upsert_test.go
@@ -111,7 +111,7 @@ func ExampleUpsert() {
 
 func ExampleUpsert_unmarshal_error_fxamackercbor_legacy_fxamackercbor() {
 	c := testenv.MustNewConfig("example", "query", "person")
-	c.UseFxamackerCBOR = true
+	c.CBORImpl = testenv.CBORImplFxamackerCBOR
 
 	db := c.MustNew()
 
@@ -150,7 +150,7 @@ func ExampleUpsert_unmarshal_error_fxamackercbor_legacy_fxamackercbor() {
 // similar but different error message compared to fxamacker/cbor
 func ExampleUpsert_unmarshal_error_surrealcbor() {
 	c := testenv.MustNewConfig("example", "query", "person")
-	c.UseSurrealCBOR = true
+	c.CBORImpl = testenv.CBORImplSurrealCBOR
 
 	db := c.MustNew()
 

--- a/internal/fakesdb/server.go
+++ b/internal/fakesdb/server.go
@@ -25,8 +25,9 @@ import (
 	"time"
 
 	"github.com/lxzan/gws"
+	"github.com/surrealdb/surrealdb.go/internal/codec"
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
-	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 // cryptoRandInt generates a cryptographically secure random integer in [0, max)
@@ -166,8 +167,8 @@ type Server struct {
 	sessions       []*Session
 	ctx            context.Context
 	cancel         context.CancelFunc
-	marshaler      *models.CborMarshaler
-	unmarshaler    *models.CborUnmarshaler
+	marshaler      codec.Marshaler
+	unmarshaler    codec.Unmarshaler
 
 	// TokenSignUp is the token returned by any successful SignUp operation
 	// This is used to verify that the SignUp operation works correctly.
@@ -190,6 +191,9 @@ type Handler struct {
 // Use "127.0.0.1:0" to bind to a random available port.
 func NewServer(addr string) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
+
+	c := surrealcbor.New()
+
 	s := &Server{
 		addr:         addr,
 		connections:  make(map[*gws.Conn]bool),
@@ -197,8 +201,8 @@ func NewServer(addr string) *Server {
 		sessions:     make([]*Session, 0),
 		ctx:          ctx,
 		cancel:       cancel,
-		marshaler:    &models.CborMarshaler{},
-		unmarshaler:  &models.CborUnmarshaler{},
+		marshaler:    c,
+		unmarshaler:  c,
 	}
 
 	handler := &Handler{server: s}

--- a/pkg/connection/config.go
+++ b/pkg/connection/config.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
-	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 // NewConfig creates a new Config with the SurrealDB endpoint specified by the URL.
@@ -15,10 +15,12 @@ import (
 // It is not absolutely necessary to create a Config using this function,
 // but it is recommended to use this function to ensure that everything needed for the connection is set up correctly.
 func NewConfig(u *url.URL) *Config {
+	// Use surrealcbor as the default CBOR implementation for better SurrealDB compatibility
+	codec := surrealcbor.New()
 	return &Config{
 		URL:         *u,
-		Marshaler:   &models.CborMarshaler{},
-		Unmarshaler: &models.CborUnmarshaler{},
+		Marshaler:   codec,
+		Unmarshaler: codec,
 		BaseURL:     fmt.Sprintf("%s://%s", u.Scheme, u.Host),
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
 	}

--- a/pkg/connection/http/connection_test.go
+++ b/pkg/connection/http/connection_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
-	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 type RoundTripFunc func(req *http.Request) *http.Response
@@ -62,10 +62,11 @@ func (s *HTTPTestSuite) TestMockClientEngine_MakeRequest() {
 		}
 	})
 
+	c := surrealcbor.New()
 	p := &connection.Config{
 		BaseURL:     "http://test.surreal",
-		Marshaler:   &models.CborMarshaler{},
-		Unmarshaler: &models.CborUnmarshaler{},
+		Marshaler:   c,
+		Unmarshaler: c,
 	}
 
 	httpEngine := New(p)

--- a/pkg/connection/integration/connection_test.go
+++ b/pkg/connection/integration/connection_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/logger"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 type testUser struct {
@@ -32,17 +33,19 @@ func TestConnectionTestSuite(t *testing.T) {
 	ts := new(ConnectionTestSuite)
 	ts.connImplementations = make(map[string]connection.Connection)
 
+	c := surrealcbor.New()
+
 	ts.connImplementations["ws"] = gorillaws.New(&connection.Config{
 		BaseURL:     "ws://localhost:8000",
-		Marshaler:   &models.CborMarshaler{},
-		Unmarshaler: &models.CborUnmarshaler{},
+		Marshaler:   c,
+		Unmarshaler: c,
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
 	})
 
 	ts.connImplementations["http"] = http.New(&connection.Config{
 		BaseURL:     "http://localhost:8000",
-		Marshaler:   &models.CborMarshaler{},
-		Unmarshaler: &models.CborUnmarshaler{},
+		Marshaler:   c,
+		Unmarshaler: c,
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
 	})
 

--- a/pkg/models/cbor.go
+++ b/pkg/models/cbor.go
@@ -73,6 +73,11 @@ func registerCborTags() cbor.TagSet {
 	return tags
 }
 
+// CborMarshaler provides CBOR marshaling using fxamacker/cbor.
+//
+// Deprecated: Use surrealcbor.New() instead for better SurrealDB compatibility.
+// CborMarshaler will be removed in a future version. The surrealcbor implementation
+// provides proper handling of SurrealDB's NONE tag and other custom CBOR features.
 type CborMarshaler struct {
 	once sync.Once
 	em   cbor.EncMode
@@ -91,6 +96,11 @@ func (c *CborMarshaler) cborEncMode() cbor.EncMode {
 	return c.em
 }
 
+// CborUnmarshaler provides CBOR unmarshaling using fxamacker/cbor.
+//
+// Deprecated: Use surrealcbor.New() instead for better SurrealDB compatibility.
+// CborUnmarshaler will be removed in a future version. The surrealcbor implementation
+// provides proper handling of SurrealDB's NONE tag and other custom CBOR features.
 type CborUnmarshaler struct {
 	once sync.Once
 	dm   cbor.DecMode

--- a/surrealcbor/cbor_fxamacker_compat_test.go
+++ b/surrealcbor/cbor_fxamacker_compat_test.go
@@ -73,8 +73,8 @@ func TestCompatibilityWithFxamacker_types(t *testing.T) {
 // This serves as a reference for our field resolver behavior
 func TestCompatibilityWithFxamacker_fieldResolver(t *testing.T) {
 	// Create reusable marshaler and unmarshaler
-	marshaler := &models.CborMarshaler{}
-	unmarshaler := &models.CborUnmarshaler{}
+	marshaler := &models.CborMarshaler{}     //nolint:staticcheck // Used for compatibility testing
+	unmarshaler := &models.CborUnmarshaler{} //nolint:staticcheck // Used for compatibility testing
 	t.Run("empty json tag", func(t *testing.T) {
 		type EmptyTag struct {
 			Field1 string `json:""`

--- a/surrealcbor/decode_bench_test.go
+++ b/surrealcbor/decode_bench_test.go
@@ -124,7 +124,7 @@ func BenchmarkDecoder(b *testing.B) {
 	}
 
 	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
-		unmarshaler := &models.CborUnmarshaler{}
+		unmarshaler := &models.CborUnmarshaler{} //nolint:staticcheck // Used for benchmarking
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -195,7 +195,7 @@ func BenchmarkDecoderNested(b *testing.B) {
 	}
 
 	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
-		unmarshaler := &models.CborUnmarshaler{}
+		unmarshaler := &models.CborUnmarshaler{} //nolint:staticcheck // Used for benchmarking
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -250,7 +250,7 @@ func BenchmarkDecoderEmbedded(b *testing.B) {
 	}
 
 	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
-		unmarshaler := &models.CborUnmarshaler{}
+		unmarshaler := &models.CborUnmarshaler{} //nolint:staticcheck // Used for benchmarking
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -310,7 +310,7 @@ func BenchmarkDecoderLargeSlice(b *testing.B) {
 	}
 
 	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
-		unmarshaler := &models.CborUnmarshaler{}
+		unmarshaler := &models.CborUnmarshaler{} //nolint:staticcheck // Used for benchmarking
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -377,7 +377,7 @@ func BenchmarkDecoderMixedTypes(b *testing.B) {
 	}
 
 	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
-		unmarshaler := &models.CborUnmarshaler{}
+		unmarshaler := &models.CborUnmarshaler{} //nolint:staticcheck // Used for benchmarking
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -426,7 +426,7 @@ func BenchmarkDecoderCaseInsensitive(b *testing.B) {
 	}
 
 	b.Run("fxamacker_unmarshaler", func(b *testing.B) {
-		unmarshaler := &models.CborUnmarshaler{}
+		unmarshaler := &models.CborUnmarshaler{} //nolint:staticcheck // Used for benchmarking
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
@@ -477,7 +477,7 @@ func BenchmarkDecoderWithNone(b *testing.B) {
 	}
 
 	// Use models marshaler since it knows how to encode CustomNil as Tag 6
-	marshaler := &models.CborMarshaler{}
+	marshaler := &models.CborMarshaler{} //nolint:staticcheck // Used for benchmarking
 	encoded, err := marshaler.Marshal(data)
 	if err != nil {
 		b.Fatal(err)

--- a/surrealcbor/decode_rawmessage_test.go
+++ b/surrealcbor/decode_rawmessage_test.go
@@ -1,4 +1,4 @@
-package surrealcbor
+package surrealcbor_test
 
 import (
 	"math"
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
 )
 
 func TestDecodeRawMessage(t *testing.T) {
@@ -18,7 +19,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		// RawMessage should contain the exact CBOR bytes
@@ -36,7 +37,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, data, []byte(rawMsg))
@@ -58,7 +59,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, data, []byte(rawMsg))
@@ -78,7 +79,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, data, []byte(rawMsg))
@@ -96,7 +97,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, data, []byte(rawMsg))
@@ -117,7 +118,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		// RawMessage should contain the tag bytes
@@ -152,7 +153,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var decoded TestStruct
-		err = Unmarshal(data, &decoded)
+		err = surrealcbor.Unmarshal(data, &decoded)
 		require.NoError(t, err)
 
 		assert.Equal(t, "test-id", decoded.ID)
@@ -185,7 +186,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var decoded connection.RPCResponse[cbor.RawMessage]
-		err = Unmarshal(data, &decoded)
+		err = surrealcbor.Unmarshal(data, &decoded)
 		require.NoError(t, err)
 
 		assert.Equal(t, "123", decoded.ID)
@@ -221,7 +222,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, data, []byte(rawMsg))
@@ -249,7 +250,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		}
 
 		var rawMsg cbor.RawMessage
-		err := Unmarshal(cborData, &rawMsg)
+		err := surrealcbor.Unmarshal(cborData, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, cborData, []byte(rawMsg))
@@ -278,7 +279,7 @@ func TestDecodeRawMessage(t *testing.T) {
 		}
 
 		var rawMsg cbor.RawMessage
-		err := Unmarshal(cborData, &rawMsg)
+		err := surrealcbor.Unmarshal(cborData, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, cborData, []byte(rawMsg))
@@ -307,7 +308,7 @@ func TestDecodeRawMessageInSlice(t *testing.T) {
 		require.NoError(t, err)
 
 		var decoded []cbor.RawMessage
-		err = Unmarshal(sliceData, &decoded)
+		err = surrealcbor.Unmarshal(sliceData, &decoded)
 		require.NoError(t, err)
 
 		assert.Len(t, decoded, 3)
@@ -346,7 +347,7 @@ func TestRawMessagePointerNotSupported(t *testing.T) {
 
 		// Correct usage: cbor.RawMessage (not *cbor.RawMessage)
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, data, []byte(rawMsg))
@@ -362,7 +363,7 @@ func TestRawMessagePointerNotSupported(t *testing.T) {
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		// RawMessage contains the CBOR encoding of nil
@@ -386,18 +387,18 @@ func TestDecodeAllTypeMapIntoRawMessage(t *testing.T) {
 		}
 
 		// Use our Marshal to properly encode SurrealDB types with tags
-		data, err := Marshal(testMap)
+		data, err := surrealcbor.Marshal(testMap)
 		require.NoError(t, err)
 
 		var rawMsg cbor.RawMessage
-		err = Unmarshal(data, &rawMsg)
+		err = surrealcbor.Unmarshal(data, &rawMsg)
 		require.NoError(t, err)
 
 		assert.Equal(t, data, []byte(rawMsg))
 
 		var decoded map[string]any
 		// Use our own Unmarshal to properly decode SurrealDB types
-		err = Unmarshal(rawMsg, &decoded)
+		err = surrealcbor.Unmarshal(rawMsg, &decoded)
 		require.NoError(t, err)
 
 		assert.Equal(t, uint64(42), decoded["int"])


### PR DESCRIPTION
This SDK will use surrealcbor as the default and the only implementation of SurrealDB's CBOR protocol in the near future (v1), so that the SDK is easier to use and understand.

To prepare for the migration, I made it the default implementation while marking the previous implementation as deprecated.

Related to #335
