### PR TITLE
surrealql: Add FOR support

### DIFF
--- a/contrib/surrealql/begin.go
+++ b/contrib/surrealql/begin.go
@@ -2,7 +2,11 @@ package surrealql
 
 // Begin creates a new transaction query
 func Begin() *TransactionQuery {
-	return &TransactionQuery{
-		statements: []TransactionStatement{},
+	q := &TransactionQuery{
+		StatementsBuilder: &StatementsBuilder[TransactionQuery]{},
 	}
+
+	q.self = q
+
+	return q
 }

--- a/contrib/surrealql/example_for_test.go
+++ b/contrib/surrealql/example_for_test.go
@@ -1,0 +1,32 @@
+package surrealql_test
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+
+	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
+)
+
+func ExampleForStatement_goSliceAsIterable() {
+	createUser := surrealql.Create("type::thing('person', $name)").Set("name = $name")
+
+	statement := surrealql.For("name", "?", []any{"Tobie", "Jaime"}).
+		Query(createUser)
+
+	sql, vars := statement.Build()
+	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// FOR $name IN $param_1 {
+	// CREATE type::thing('person', $name) SET name = $name;
+	// };
+	// Var param_1: [Tobie Jaime]
+}

--- a/contrib/surrealql/for.go
+++ b/contrib/surrealql/for.go
@@ -1,0 +1,42 @@
+package surrealql
+
+import "strings"
+
+// For creates a new FOR statement, which iterates over an array or the results of a subquery.
+// The item parameter is the loop variable name, and iterable can be an array or a subquery.
+// Additional arguments can be provided for parameterized subqueries.
+func For[T exprLike](item string, iterableExpr T, iterableArgs ...any) *ForStatement {
+	s := &ForStatement{
+		item:     strings.TrimPrefix(item, "$"),
+		iterable: Expr(iterableExpr, iterableArgs...),
+	}
+
+	s.StatementsBuilder = &StatementsBuilder[ForStatement]{
+		self: s,
+	}
+
+	return s
+}
+
+type ForStatement struct {
+	item     string
+	iterable *expr
+
+	*StatementsBuilder[ForStatement]
+}
+
+func (f *ForStatement) Build() (sql string, vars map[string]any) {
+	c := newQueryBuildContext()
+
+	var builder strings.Builder
+
+	builder.WriteString("FOR $")
+	builder.WriteString(f.item)
+	builder.WriteString(" IN ")
+	builder.WriteString(f.iterable.Build(&c))
+	builder.WriteString(" {\n")
+	f.build(&c, &builder)
+	builder.WriteString("};")
+
+	return builder.String(), c.vars
+}

--- a/contrib/surrealql/statements.go
+++ b/contrib/surrealql/statements.go
@@ -1,0 +1,107 @@
+package surrealql
+
+import (
+	"strings"
+)
+
+// StatementsBuilder provides common functionality for building a series of statements
+//
+// T is the type of the struct embedding this builder, allowing method chaining to return the correct type.
+type StatementsBuilder[T any] struct {
+	statements []TransactionStatement
+
+	// self is a reference to the struct embedding this builder, allowing method chaining to return the correct type and avoid type assertions.
+	// It must be set by the embedding struct after initialization.
+	self *T
+}
+
+// Let adds a LET statement to the transaction
+func (t *StatementsBuilder[T]) Let(variable string, value any) *T {
+	if !strings.HasPrefix(variable, "$") {
+		variable = "$" + variable
+	}
+	t.statements = append(t.statements, &LetStatement{
+		variable: variable,
+		value:    value,
+	})
+	return t.self
+}
+
+// LetTyped adds a typed LET statement to the transaction
+func (t *StatementsBuilder[T]) LetTyped(variable, dataType string, value any) *T {
+	if !strings.HasPrefix(variable, "$") {
+		variable = "$" + variable
+	}
+	t.statements = append(t.statements, &LetStatement{
+		variable: variable,
+		dataType: dataType,
+		value:    value,
+	})
+	return t.self
+}
+
+// If adds an IF statement to the transaction
+func (t *StatementsBuilder[T]) If(condition string) *IfBuilder[T] {
+	ifStmt := &IfStatement{
+		condition: condition,
+	}
+	b := &IfBuilder[T]{
+		transaction: t.self,
+		ifStatement: ifStmt,
+	}
+	t.statements = append(t.statements, ifStmt)
+	return b
+}
+
+// Throw adds a THROW statement to the transaction
+func (t *StatementsBuilder[T]) Throw(err any) *T {
+	t.statements = append(t.statements, &ThrowStatement{
+		err: err,
+	})
+	return t.self
+}
+
+// Raw adds a raw SurrealQL statement to the transaction
+func (t *StatementsBuilder[T]) Raw(sql string) *T {
+	t.statements = append(t.statements, &RawStatement{
+		sql: sql,
+	})
+	return t.self
+}
+
+// Query adds any Query to the transaction
+func (t *StatementsBuilder[T]) Query(query Query) *T {
+	t.statements = append(t.statements, &QueryStatement{
+		query: query,
+	})
+	return t.self
+}
+
+// Return adds a RETURN statement to the transaction
+// The expr parameter is raw SQL that can contain placeholders (?)
+// Args are the values to substitute for the placeholders
+func (t *StatementsBuilder[T]) Return(expr string, args ...any) *T {
+	t.statements = append(t.statements, &ReturnStatement{
+		expr: expr,
+		args: args,
+	})
+	return t.self
+}
+
+// Build returns the SurrealQL string and parameters for the transaction
+func (t *StatementsBuilder[T]) build(c *queryBuildContext, builder *strings.Builder) {
+	for _, stmt := range t.statements {
+		if qs, ok := stmt.(*QueryStatement); ok {
+			sql, vars := qs.query.Build()
+			builder.WriteString(strings.TrimRight(sql, ";"))
+			builder.WriteString(";\n")
+			// Merge parameters
+			for k, v := range vars {
+				c.vars[k] = v
+			}
+		} else {
+			builder.WriteString(stmt.build(c))
+			builder.WriteString(";\n")
+		}
+	}
+}


### PR DESCRIPTION
As a starting point, I made the new `For` builder accept statements currently allowed in the existing `Begin` builder.

Please submit issues or let us know in the Discord channel if you find real-world use cases that aren't covered by the initially supported statements.

Once the next release (v1.0.0) gets released, the documentation for the new `For` builder will be available at https://pkg.go.dev/github.com/surrealdb/surrealdb.go/contrib/surrealql#For

Ref #354
