### PR TITLE
surrealql: Add UPDATE ONLY and DELETE ONLY

### DIFF
--- a/contrib/surrealql/example_delete_test.go
+++ b/contrib/surrealql/example_delete_test.go
@@ -7,6 +7,20 @@ import (
 	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
 )
 
+func ExampleDelete() {
+	// Delete expired sessions
+	query := surrealql.Delete("sessions").
+		Where("expires_at < ?", time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC))
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: DELETE sessions WHERE expires_at < $param_1
+	// Vars: map[param_1:2023-10-01 12:00:00 +0000 UTC]
+}
+
 func ExampleDelete_withReturnNone() {
 	// Delete expired sessions without returning results
 	query := surrealql.Delete("sessions").
@@ -20,4 +34,47 @@ func ExampleDelete_withReturnNone() {
 	// Output:
 	// SurrealQL: DELETE sessions WHERE expires_at < $param_1 RETURN NONE
 	// Vars: map[param_1:2023-10-01 12:00:00 +0000 UTC]
+}
+
+func ExampleDeleteOnly_withReturnBefore() {
+	// Delete a specific record and return its state before deletion
+	query := surrealql.DeleteOnly("users:123").
+		ReturnBefore()
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: DELETE ONLY users:123 RETURN BEFORE
+	// Vars: map[]
+}
+
+func ExampleDeleteOnly_withReturnAfter() {
+	// Delete a specific record and return its state after deletion
+	query := surrealql.DeleteOnly("users:123").
+		ReturnAfter()
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: DELETE ONLY users:123 RETURN AFTER
+	// Vars: map[]
+}
+
+func ExampleDelete_withWhereAndReturnDiff() {
+	// Delete inactive users and return the difference
+	query := surrealql.Delete("users").
+		Where("active = ?", false).
+		ReturnDiff()
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	fmt.Printf("Vars: %v\n", vars)
+
+	// Output:
+	// SurrealQL: DELETE users WHERE active = $param_1 RETURN DIFF
+	// Vars: map[param_1:false]
 }

--- a/contrib/surrealql/example_update_test.go
+++ b/contrib/surrealql/example_update_test.go
@@ -32,6 +32,22 @@ func ExampleUpdate_allInTable() {
 	// Var param_2: 2022-10-01 00:00:00 +0000 UTC
 }
 
+func ExampleUpdateOnly() {
+	// Update only one record in a table
+	query := surrealql.UpdateOnly(surrealql.Thing("users", 123)).
+		Set("name", "Alice")
+
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	dumpVars(vars)
+
+	// Output:
+	// SurrealQL: UPDATE ONLY $id_1 SET name = $param_1
+	// Vars:
+	//   id_1: users:123
+	//   param_1: Alice
+}
+
 func ExampleUpdate_allInMultipleTables() {
 	// Update all records in multiple tables
 	query := surrealql.Update("users", "products").


### PR DESCRIPTION
`UpdateOnly` is straightforward, while `DeleteOnly` is not!
As in the go doc comments, be sure to call any of `ReturnBefore`, `ReturnAfter`, `ReturnDiff` after `DeleteOnly`.

Ref #353