### PR TITLE
surrealql: Select with complex fields and aliases

### DIFF
--- a/contrib/surrealql/example_select_test.go
+++ b/contrib/surrealql/example_select_test.go
@@ -118,6 +118,29 @@ func ExampleSelect_fieldRaw() {
 	// Vars: map[]
 }
 
+func ExampleSelect_alias() {
+	// Select specific fields with an alias
+	query := surrealql.Select("users").
+		Field("*").
+		Alias("demodata", "? + ?", 1, 2).
+		Alias(
+			"followers_count",
+			surrealql.SelectOnly("follows").
+				Value("count()").
+				Where("out = $parent.id").
+				GroupAll(),
+		)
+	sql, vars := query.Build()
+	fmt.Println("SurrealQL:", sql)
+	dumpVars(vars)
+
+	// Output:
+	// SurrealQL: SELECT *, $param_1 + $param_2 AS demodata, (SELECT VALUE count() FROM ONLY follows WHERE out = $parent.id GROUP ALL) AS followers_count FROM users
+	// Vars:
+	//   param_1: 1
+	//   param_2: 2
+}
+
 func ExampleSelect_field() {
 	// Add fields to the SELECT query
 	query := surrealql.Select("users").

--- a/contrib/surrealql/expr.go
+++ b/contrib/surrealql/expr.go
@@ -112,14 +112,6 @@ func (f *expr) As(alias string) *expr {
 	}
 }
 
-func (f expr) isAll() bool {
-	// Check if the expression is a wildcard (e.g., "*")
-	if str, ok := f.expr.(string); ok && str == "*" {
-		return true
-	}
-	return false
-}
-
 // Build returns the SurrealQL expression for the field and any associated vars.
 func (f *expr) Build(c *queryBuildContext) (sql string) {
 	if f.isRawSQL {


### PR DESCRIPTION
This originates from some discussion made in our Discord community.

Two things:

- Previously, you couldn't build a SELECT query containing both `*` and extra fields, like `SELECT *, (SELECT ...) AS somealias FROM sometable`
- The way to alias fields have been not exposed well to the SDK consumers

The former just works since this change.

For the latter, I've added `SelectQuery.Alias(alias string, field any, args ...any)` which is exposed via [the pkg.go.dev documentation](https://pkg.go.dev/github.com/surrealdb/surrealdb.go/contrib/surrealql#SelectQuery) for the `SelectQuery` struct, like other methods including `Field`, `FieldName`, and so on.