### PR TITLE
surrealql: Expr for building complex queries

### DIFF
--- a/contrib/surrealql/create.go
+++ b/contrib/surrealql/create.go
@@ -87,7 +87,7 @@ func (q *CreateQuery) build(c *queryBuildContext) (sql string) {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(t.Build(c))
+		b.WriteString(t.build(c))
 	}
 
 	if q.useContent && len(q.content) > 0 {

--- a/contrib/surrealql/delete.go
+++ b/contrib/surrealql/delete.go
@@ -95,7 +95,7 @@ func (q *DeleteQuery) build(c *queryBuildContext) (sql string) {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(target.Build(c))
+		b.WriteString(target.build(c))
 	}
 
 	if q.whereClause != nil && q.whereClause.hasConditions() {

--- a/contrib/surrealql/example_expr_test.go
+++ b/contrib/surrealql/example_expr_test.go
@@ -52,14 +52,14 @@ func ExampleExpr_withPlaceholders() {
 	fmt.Println(sql)
 	dumpVars(vars)
 	// Output:
-	// SELECT $param_1 * $param_2 + $param_3 AS calculation, math::mean([$fn_math_mean_1,$fn_math_mean_2,$fn_math_mean_3]) AS average FROM dummy
+	// SELECT $param_1 * $param_2 + $param_3 AS calculation, math::mean([$param_4,$param_5,$param_6]) AS average FROM dummy
 	// Vars:
-	//   fn_math_mean_1: 1
-	//   fn_math_mean_2: 2
-	//   fn_math_mean_3: 3
 	//   param_1: 10
 	//   param_2: 20
 	//   param_3: 5
+	//   param_4: 1
+	//   param_5: 2
+	//   param_6: 3
 }
 
 // ExampleExpr_withoutAlias demonstrates using Expr when you don't need aliasing
@@ -133,8 +133,8 @@ func ExampleExpr_withValues() {
 	fmt.Println(sql)
 	dumpVarsInline(vars)
 	// Output:
-	// SELECT math::mean([$fn_math_mean_1,$fn_math_mean_2,$fn_math_mean_3]) AS average FROM dummy
-	// Vars: fn_math_mean_1=1 fn_math_mean_2=2 fn_math_mean_3=3
+	// SELECT math::mean([$param_1,$param_2,$param_3]) AS average FROM dummy
+	// Vars: param_1=1 param_2=2 param_3=3
 }
 
 // ExampleExpr_withVariable demonstrates using Expr with variable references
@@ -193,4 +193,17 @@ func ExampleExpr_selectFuncResultWithAlias() {
 
 	// Output:
 	// SELECT math::sum((SELECT total FROM orders)) AS total FROM dummy
+}
+
+func ExampleExpr_callAnyOnSelectValueResult() {
+	// Expr supports Build() method to get the SurrealQL string and associated vars
+	expr := surrealql.Expr("?.any()", surrealql.Select(surrealql.Thing("plan", "hobby")).Value("<-subscribed<-user"))
+	sql, vars := expr.Build()
+	fmt.Println(sql)
+	dumpVars(vars)
+
+	// Output:
+	// (SELECT VALUE <-subscribed<-user FROM $from_id_1).any()
+	// Vars:
+	//   from_id_1: plan:hobby
 }

--- a/contrib/surrealql/expr_test.go
+++ b/contrib/surrealql/expr_test.go
@@ -8,7 +8,7 @@ import (
 
 func buildExpr(expr *expr) (sql string, vars map[string]any) {
 	c := newQueryBuildContext()
-	sql = expr.Build(&c)
+	sql = expr.build(&c)
 	return sql, c.vars
 }
 
@@ -50,12 +50,18 @@ func TestExpr_fnArgFromFieldAlias(t *testing.T) {
 
 func TestExpr_fnArgFromValue(t *testing.T) {
 	sql, vars := buildExpr(Expr("math::sum(?)", []int{100}))
-	assert.Equal(t, "math::sum($fn_math_sum_1)", sql)
-	assert.Equal(t, map[string]any{"fn_math_sum_1": []int{100}}, vars)
+	assert.Equal(t, "math::sum($param_1)", sql)
+	assert.Equal(t, map[string]any{"param_1": []int{100}}, vars)
 }
 
 func TestExpr_fnArgFromValueAlias(t *testing.T) {
 	sql, vars := buildExpr(Expr("math::sum(?)", []int{100}).As("total_amount"))
-	assert.Equal(t, "math::sum($fn_math_sum_1) AS total_amount", sql)
-	assert.Equal(t, map[string]any{"fn_math_sum_1": []int{100}}, vars)
+	assert.Equal(t, "math::sum($param_1) AS total_amount", sql)
+	assert.Equal(t, map[string]any{"param_1": []int{100}}, vars)
+}
+
+func TestExpr_anyinside(t *testing.T) {
+	sql, vars := buildExpr(Expr("? ANYINSIDE (->friend->out)", Thing("stdudent", 1)))
+	assert.Equal(t, "$param_1 ANYINSIDE (->friend->out)", sql)
+	assert.Equal(t, map[string]any{"param_1": Thing("stdudent", 1)}, vars)
 }

--- a/contrib/surrealql/for.go
+++ b/contrib/surrealql/for.go
@@ -33,7 +33,7 @@ func (f *ForStatement) Build() (sql string, vars map[string]any) {
 	builder.WriteString("FOR $")
 	builder.WriteString(f.item)
 	builder.WriteString(" IN ")
-	builder.WriteString(f.iterable.Build(&c))
+	builder.WriteString(f.iterable.build(&c))
 	builder.WriteString(" {\n")
 	f.build(&c, &builder)
 	builder.WriteString("};")

--- a/contrib/surrealql/relate.go
+++ b/contrib/surrealql/relate.go
@@ -68,11 +68,11 @@ func (q *RelateQuery) build(c *queryBuildContext) (sql string) {
 		b.WriteString("ONLY ")
 	}
 
-	b.WriteString(q.from.Build(c))
+	b.WriteString(q.from.build(c))
 	b.WriteString("->")
 	b.WriteString(escapeIdent(q.edge))
 	b.WriteString("->")
-	b.WriteString(q.to.Build(c))
+	b.WriteString(q.to.build(c))
 
 	if q.useContent && len(q.content) > 0 {
 		paramName := c.generateAndAddParam("content", q.content)

--- a/contrib/surrealql/select.go
+++ b/contrib/surrealql/select.go
@@ -387,7 +387,7 @@ func (q *SelectQuery) build(c *queryBuildContext) (sql string) {
 	if len(q.from) > 0 {
 		fromClauses := make([]string, len(q.from))
 		for i, f := range q.from {
-			fromClauses[i] = f.Build(c.in("from"))
+			fromClauses[i] = f.build(c.in("from"))
 		}
 		from := "FROM "
 		if q.only {
@@ -461,7 +461,7 @@ func (q *SelectQuery) buildSelectClause(c *queryBuildContext) string {
 			if i > 0 {
 				b.WriteString(", ")
 			}
-			b.WriteString(field.Build(c))
+			b.WriteString(field.build(c))
 		}
 	}
 

--- a/contrib/surrealql/sets_builder.go
+++ b/contrib/surrealql/sets_builder.go
@@ -36,7 +36,7 @@ func (sb *setsBuilder) buildSetClause(base *queryBuildContext) string {
 	var setParts []string
 
 	for _, setExpr := range sb.sets {
-		sql := setExpr.Build(base)
+		sql := setExpr.build(base)
 		setParts = append(setParts, sql)
 	}
 

--- a/contrib/surrealql/update.go
+++ b/contrib/surrealql/update.go
@@ -87,7 +87,7 @@ func (q *UpdateQuery) build(c *queryBuildContext) (sql string) {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(t.Build(c))
+		b.WriteString(t.build(c))
 	}
 
 	if setClause := q.buildSetClause(c); setClause != "" {

--- a/contrib/surrealql/upsert.go
+++ b/contrib/surrealql/upsert.go
@@ -150,7 +150,7 @@ func (q *UpsertQuery) build(c *queryBuildContext) (sql string) {
 			b.WriteString(", ")
 		}
 
-		tSQL := t.Build(c)
+		tSQL := t.build(c)
 		b.WriteString(tSQL)
 	}
 
@@ -717,7 +717,7 @@ func (c *upsertCommon) buildPrefix(bc *queryBuildContext, sql *strings.Builder) 
 			sql.WriteString(", ")
 		}
 
-		tSQL := t.Build(bc)
+		tSQL := t.build(bc)
 		sql.WriteString(tSQL)
 	}
 }


### PR DESCRIPTION
This addresses issues related to `Expr` reported in our Discord community.

1. Previously, queries like `(SELECT VALUE <-subscribed<-user FROM $from_id_1).any()` were not expressible using the `surrealql` library because there was no way to append `.any()` to a `SelectQuery` and to generate `sql` and `vars` directly from `Expr`. To address it, `Expr` has been enhanced to provide `Build() (sql string, vars map[string]any)`.

2. Previously, expressions like `Expr("? ANYINSIDE (->friend->out)", Thing("student", 1))` didn't work because it mistakenly treated `? ANYINSIDE ` as the var name prefix, resulting in the var name being like `fn_? ANYINSIDE_1`, resulting in broken queries. I fixed it so that `?` is replaced with a generic variable name, such as `$param_NUM`.