### PR TITLE
surrealql: Better support for nested statements in FOR and BEGIN

### DIFF
--- a/contrib/surrealql/delete.go
+++ b/contrib/surrealql/delete.go
@@ -79,12 +79,12 @@ func (q *DeleteQuery) ReturnDiff() *DeleteQuery {
 // Build returns the SurrealQL string and parameters
 func (q *DeleteQuery) Build() (sql string, params map[string]any) {
 	c := newQueryBuildContext()
-	return q.build(&c), c.vars
+	var b strings.Builder
+	q.build(&c, &b)
+	return b.String(), c.vars
 }
 
-func (q *DeleteQuery) build(c *queryBuildContext) (sql string) {
-	var b strings.Builder
-
+func (q *DeleteQuery) build(c *queryBuildContext, b *strings.Builder) {
 	b.WriteString("DELETE ")
 
 	if q.only {
@@ -95,20 +95,18 @@ func (q *DeleteQuery) build(c *queryBuildContext) (sql string) {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(target.build(c))
+		target.build(c, b)
 	}
 
 	if q.whereClause != nil && q.whereClause.hasConditions() {
-		b.WriteString(" WHERE ")
-		b.WriteString(q.whereClause.build(c))
+		b.WriteString(" ")
+		q.whereClause.build(c, b)
 	}
 
 	if q.returnClause != "" {
 		b.WriteString(" RETURN ")
 		b.WriteString(q.returnClause)
 	}
-
-	return b.String()
 }
 
 // String returns the SurrealQL string

--- a/contrib/surrealql/example_for_test.go
+++ b/contrib/surrealql/example_for_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/surrealdb/surrealdb.go/contrib/surrealql"
 )
 
+func ExampleFor_insideTransaction() {
+	createUser := surrealql.Create("user").Set(`id = type::thing("user", $name)`).Set("name = $name")
+	createUsers := surrealql.For("name", `["Tobie", "Jaime"]`).Query(createUser)
+	tx := surrealql.Begin().Query(createUsers)
+	sql, vars := tx.Build()
+	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
+
+	// Output:
+	// BEGIN TRANSACTION;
+	// FOR $name IN ["Tobie", "Jaime"] {
+	// CREATE user SET id = type::thing("user", $name), name = $name;
+	// };
+	// COMMIT TRANSACTION;
+}
+
 func ExampleForStatement_goSliceAsIterable() {
 	createUser := surrealql.Create("type::thing('person', $name)").Set("name = $name")
 
@@ -27,7 +48,7 @@ func ExampleForStatement_goSliceAsIterable() {
 	// Output:
 	// FOR $name IN $param_1 {
 	// CREATE type::thing('person', $name) SET name = $name;
-	// };
+	// }
 	// Var param_1: [Tobie Jaime]
 }
 
@@ -51,6 +72,6 @@ func ExampleForStatement_subqueryAsIterable() {
 	// Output:
 	// FOR $person IN (SELECT VALUE id FROM person WHERE age >= $param_1) {
 	// UPDATE $person SET can_vote = true;
-	// };
+	// }
 	// Var param_1: 18
 }

--- a/contrib/surrealql/example_transaction_query_test.go
+++ b/contrib/surrealql/example_transaction_query_test.go
@@ -29,9 +29,10 @@ func ExampleTransactionQuery_Query() {
 	// Output:
 	// BEGIN TRANSACTION;
 	// CREATE users:123 SET name = $param_1;
-	// UPDATE users:123 SET email = $param_1;
+	// UPDATE users:123 SET email = $param_2;
 	// COMMIT TRANSACTION;
-	// Var param_1: alice@example.com
+	// Var param_1: Alice
+	// Var param_2: alice@example.com
 }
 
 func ExampleTransactionQuery_If() {
@@ -81,18 +82,26 @@ func ExampleTransactionQuery_returningEarly() {
 		Query(updateAccount1).
 		Query(updateAccount2)
 
-	sql, _ := tx.Build()
+	sql, vars := tx.Build()
 	fmt.Println(sql)
+
+	keys := sort.StringSlice(slices.Collect(maps.Keys(vars)))
+	sort.Stable(keys)
+	for _, key := range keys {
+		fmt.Printf("Var %s: %v\n", key, vars[key])
+	}
 	// Output:
 	// BEGIN TRANSACTION;
 	// CREATE account:one SET balance = $param_1;
-	// CREATE account:two SET balance = $param_1;
+	// CREATE account:two SET balance = $param_2;
 	// IF !account:two.wants_to_send_money {
 	//     THROW "Customer doesn't want to send any money!";
 	// };
 	// UPDATE account:one SET balance += 300.00;
 	// UPDATE account:two SET balance -= 300.00;
 	// COMMIT TRANSACTION;
+	// Var param_1: 135605.16
+	// Var param_2: 91031.31
 }
 
 func ExampleTransactionQuery_LetTyped() {

--- a/contrib/surrealql/example_upsert_test.go
+++ b/contrib/surrealql/example_upsert_test.go
@@ -215,7 +215,7 @@ func ExampleUpsert_unset() {
 	fmt.Println(sql)
 	dumpVars(vars)
 	// Output:
-	// UPSERT product:cable SET name = $param_1, UNSET deprecated_field, legacy_data
+	// UPSERT product:cable SET name = $param_1 UNSET deprecated_field, legacy_data
 	// Vars:
 	//   param_1: USB Cable
 }

--- a/contrib/surrealql/expr_test.go
+++ b/contrib/surrealql/expr_test.go
@@ -1,6 +1,7 @@
 package surrealql
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,8 +9,9 @@ import (
 
 func buildExpr(expr *expr) (sql string, vars map[string]any) {
 	c := newQueryBuildContext()
-	sql = expr.build(&c)
-	return sql, c.vars
+	var b strings.Builder
+	expr.build(&c, &b)
+	return b.String(), c.vars
 }
 
 func TestExpr_string(t *testing.T) {

--- a/contrib/surrealql/for.go
+++ b/contrib/surrealql/for.go
@@ -30,15 +30,19 @@ func (f *ForStatement) Build() (sql string, vars map[string]any) {
 
 	var builder strings.Builder
 
+	f.build(&c, &builder)
+
+	return builder.String(), c.vars
+}
+
+func (f *ForStatement) build(c *queryBuildContext, builder *strings.Builder) {
 	builder.WriteString("FOR $")
 	builder.WriteString(f.item)
 	builder.WriteString(" IN ")
-	builder.WriteString(f.iterable.build(&c))
+	f.iterable.build(c, builder)
 	builder.WriteString(" {\n")
-	f.build(&c, &builder)
-	builder.WriteString("};")
-
-	return builder.String(), c.vars
+	f.StatementsBuilder.build(c, builder)
+	builder.WriteString("}")
 }
 
 // String returns the SurrealQL string

--- a/contrib/surrealql/insert.go
+++ b/contrib/surrealql/insert.go
@@ -119,18 +119,16 @@ func (q *InsertQuery) ReturnDiff() *InsertQuery {
 
 // Build returns the SurrealQL string and parameters for the query
 func (q *InsertQuery) Build() (query string, vars map[string]any) {
+	var b strings.Builder
 	c := newQueryBuildContext()
-	return q.build(&c), c.vars
+	q.build(&c, &b)
+	return b.String(), c.vars
 }
 
-func (q *InsertQuery) build(c *queryBuildContext) (sql string) {
-	var builder strings.Builder
-
-	q.buildInsertClause(&builder)
-	q.buildDataOrValues(c, &builder)
-	q.buildReturnClause(&builder)
-
-	return builder.String()
+func (q *InsertQuery) build(c *queryBuildContext, b *strings.Builder) {
+	q.buildInsertClause(b)
+	q.buildDataOrValues(c, b)
+	q.buildReturnClause(b)
 }
 
 // buildInsertClause builds the INSERT clause part
@@ -161,8 +159,7 @@ func (q *InsertQuery) buildDataOrValues(c *queryBuildContext, builder *strings.B
 // buildValueQuery builds the value query part
 func (q *InsertQuery) buildValueQuery(c *queryBuildContext, builder *strings.Builder) {
 	builder.WriteString(" (")
-	sql := q.valueQuery.build(c)
-	builder.WriteString(sql)
+	q.valueQuery.build(c, builder)
 	builder.WriteString(")")
 }
 

--- a/contrib/surrealql/query.go
+++ b/contrib/surrealql/query.go
@@ -23,10 +23,10 @@ type Query interface {
 	// Build returns the SurrealQL string and parameters for the query
 	Build() (string, map[string]any)
 
-	// build returns the SurrealQL string in the provided build context.
+	// build generates the SurrealQL string in the provided build context.
 	// The build mutates the context, and the context is propagated across
 	// multiple sub queries so that variables are unique.
-	build(c *queryBuildContext) (sql string)
+	build(c *queryBuildContext, b *strings.Builder)
 
 	// String returns the SurrealQL string for the query
 	String() string

--- a/contrib/surrealql/raw.go
+++ b/contrib/surrealql/raw.go
@@ -1,7 +1,6 @@
 package surrealql
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -21,17 +20,27 @@ type rawQuery struct {
 
 func (q *rawQuery) Build() (sql string, params map[string]any) {
 	c := newQueryBuildContext()
-	return q.build(&c), c.vars
+	var b strings.Builder
+	q.build(&c, &b)
+	return b.String(), c.vars
 }
 
-func (q *rawQuery) build(c *queryBuildContext) (sql string) {
+func (q *rawQuery) build(c *queryBuildContext, b *strings.Builder) {
 	// Replace ? placeholders with positional arguments using context
-	sql = q.sql
+	var start int
 	for _, arg := range q.args {
 		paramName := c.generateAndAddParam("raw", arg)
-		sql = strings.Replace(sql, "?", fmt.Sprintf("$%s", paramName), 1)
+		placeholder := strings.Index(q.sql[start:], "?")
+		if placeholder < 0 {
+			break
+		}
+		placeholder += start
+		b.WriteString(q.sql[start:placeholder])
+		b.WriteString("$")
+		b.WriteString(paramName)
+		start = placeholder + 1
 	}
-	return sql
+	b.WriteString(q.sql[start:])
 }
 
 func (q *rawQuery) String() string {

--- a/contrib/surrealql/sets_builder.go
+++ b/contrib/surrealql/sets_builder.go
@@ -16,6 +16,10 @@ func newSetsBuilder() setsBuilder {
 	}
 }
 
+func (sb *setsBuilder) hasSets() bool {
+	return len(sb.sets) > 0
+}
+
 // addSet adds a field or expression to the SET clause
 // Can be used for simple assignment: addSet("name = ?", "value")
 // Or for compound operations: addSet("count += ?", 1)
@@ -28,17 +32,17 @@ func (sb *setsBuilder) addSet(expr string, args []any) {
 }
 
 // buildSetClause builds the SET clause and adds parameters to the base query
-func (sb *setsBuilder) buildSetClause(base *queryBuildContext) string {
+func (sb *setsBuilder) buildSetClause(base *queryBuildContext, b *strings.Builder) {
 	if len(sb.sets) == 0 {
-		return ""
+		return
 	}
 
-	var setParts []string
+	b.WriteString("SET ")
 
-	for _, setExpr := range sb.sets {
-		sql := setExpr.build(base)
-		setParts = append(setParts, sql)
+	for i, setExpr := range sb.sets {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		setExpr.build(base, b)
 	}
-
-	return strings.Join(setParts, ", ")
 }

--- a/contrib/surrealql/statements.go
+++ b/contrib/surrealql/statements.go
@@ -91,17 +91,7 @@ func (t *StatementsBuilder[T]) Return(expr string, args ...any) *T {
 // Build returns the SurrealQL string and parameters for the transaction
 func (t *StatementsBuilder[T]) build(c *queryBuildContext, builder *strings.Builder) {
 	for _, stmt := range t.statements {
-		if qs, ok := stmt.(*QueryStatement); ok {
-			sql, vars := qs.query.Build()
-			builder.WriteString(strings.TrimRight(sql, ";"))
-			builder.WriteString(";\n")
-			// Merge parameters
-			for k, v := range vars {
-				c.vars[k] = v
-			}
-		} else {
-			builder.WriteString(stmt.build(c))
-			builder.WriteString(";\n")
-		}
+		stmt.build(c, builder)
+		builder.WriteString(";\n")
 	}
 }

--- a/contrib/surrealql/update.go
+++ b/contrib/surrealql/update.go
@@ -71,12 +71,12 @@ func (q *UpdateQuery) ReturnDiff() *UpdateQuery {
 // Build returns the SurrealQL string and parameters
 func (q *UpdateQuery) Build() (sql string, vars map[string]any) {
 	c := newQueryBuildContext()
-	return q.build(&c), c.vars
+	var b strings.Builder
+	q.build(&c, &b)
+	return b.String(), c.vars
 }
 
-func (q *UpdateQuery) build(c *queryBuildContext) (sql string) {
-	var b strings.Builder
-
+func (q *UpdateQuery) build(c *queryBuildContext, b *strings.Builder) {
 	b.WriteString("UPDATE ")
 
 	if q.only {
@@ -87,25 +87,23 @@ func (q *UpdateQuery) build(c *queryBuildContext) (sql string) {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(t.build(c))
+		t.build(c, b)
 	}
 
-	if setClause := q.buildSetClause(c); setClause != "" {
-		b.WriteString(" SET ")
-		b.WriteString(setClause)
+	if q.hasSets() {
+		b.WriteString(" ")
+		q.buildSetClause(c, b)
 	}
 
 	if q.whereClause != nil && q.whereClause.hasConditions() {
-		b.WriteString(" WHERE ")
-		b.WriteString(q.whereClause.build(c))
+		b.WriteString(" ")
+		q.whereClause.build(c, b)
 	}
 
 	if q.returnClause != "" {
 		b.WriteString(" RETURN ")
 		b.WriteString(q.returnClause)
 	}
-
-	return b.String()
 }
 
 // String returns the SurrealQL string

--- a/contrib/surrealql/upsert_test.go
+++ b/contrib/surrealql/upsert_test.go
@@ -206,7 +206,7 @@ func TestUpsert_Basic(t *testing.T) {
 					Unset("deprecated_field").
 					Build()
 			},
-			wantSQL: "UPSERT product:cable SET name = $param_1, UNSET deprecated_field",
+			wantSQL: "UPSERT product:cable SET name = $param_1 UNSET deprecated_field",
 			wantVars: map[string]any{
 				"param_1": "USB Cable",
 			},
@@ -219,7 +219,7 @@ func TestUpsert_Basic(t *testing.T) {
 					Unset("deprecated_field", "legacy_data", "old_column").
 					Build()
 			},
-			wantSQL: "UPSERT product:storage SET name = $param_1, UNSET deprecated_field, legacy_data, old_column",
+			wantSQL: "UPSERT product:storage SET name = $param_1 UNSET deprecated_field, legacy_data, old_column",
 			wantVars: map[string]any{
 				"param_1": "SSD Storage",
 			},
@@ -453,7 +453,7 @@ func TestUpsert_TypeSafety(t *testing.T) {
 			Unset("deprecated")
 
 		sql, _ := q.Build()
-		expected := "UPSERT product:gadget SET name = $param_1, price = $param_2, UNSET deprecated"
+		expected := "UPSERT product:gadget SET name = $param_1, price = $param_2 UNSET deprecated"
 		if sql != expected {
 			t.Errorf("Expected %q, got %q", expected, sql)
 		}


### PR DESCRIPTION
This primarily fixes an issue reported in our Discord community regarding the experimental `surrealql` library: `ForStatement` couldn't be nested inside transactions.

`For` inside transactions should just work by passing `ForStatement` to `TransactionQuery.Query`.

Apparently, we have some confusion between "statement" and "query" here- I'd rename `TransactionQuery.Query` to `TransactionQuery.Do` so that you can pass arbitrary statements or queries to the `Do` function.

Along with the primary fix, I've also found and fixed a few issues in surreal:

- `UNSET` was formatted incorrectly as `SET a, b, UNSET c, d` instead of `SET a, b UNSET c, d` (Notice the redundant `,` BEFORE `UNSET`)
- Placeholders were incorrectly bound to overlapping variables within transactions.
- Inefficient string concatenation- We now use `strings.Builder` in more places