### PR TITLE
surrealql: Unified statements handling within Transaction, If-Else, and For

### DIFF
--- a/contrib/surrealql/begin.go
+++ b/contrib/surrealql/begin.go
@@ -1,6 +1,8 @@
 package surrealql
 
 // Begin creates a new transaction query
+//
+// See [TransactionQuery] for more details.
 func Begin() *TransactionQuery {
 	q := &TransactionQuery{
 		StatementsBuilder: &StatementsBuilder[TransactionQuery]{},

--- a/contrib/surrealql/for.go
+++ b/contrib/surrealql/for.go
@@ -5,6 +5,8 @@ import "strings"
 // For creates a new FOR statement, which iterates over an array or the results of a subquery.
 // The item parameter is the loop variable name, and iterable can be an array or a subquery.
 // Additional arguments can be provided for parameterized subqueries.
+//
+// See [ForStatement] for more details.
 func For[T exprLike](item string, iterableExpr T, iterableArgs ...any) *ForStatement {
 	s := &ForStatement{
 		item:     strings.TrimPrefix(item, "$"),
@@ -18,6 +20,7 @@ func For[T exprLike](item string, iterableExpr T, iterableArgs ...any) *ForState
 	return s
 }
 
+// ForStatement represents a FOR statement in SurrealQL
 type ForStatement struct {
 	item     string
 	iterable *expr

--- a/contrib/surrealql/statements.go
+++ b/contrib/surrealql/statements.go
@@ -8,7 +8,7 @@ import (
 //
 // T is the type of the struct embedding this builder, allowing method chaining to return the correct type.
 type StatementsBuilder[T any] struct {
-	statements []TransactionStatement
+	statements []Statement
 
 	// self is a reference to the struct embedding this builder, allowing method chaining to return the correct type and avoid type assertions.
 	// It must be set by the embedding struct after initialization.
@@ -62,18 +62,14 @@ func (t *StatementsBuilder[T]) Throw(err any) *T {
 }
 
 // Raw adds a raw SurrealQL statement to the transaction
-func (t *StatementsBuilder[T]) Raw(sql string) *T {
-	t.statements = append(t.statements, &RawStatement{
-		sql: sql,
-	})
+func (t *StatementsBuilder[T]) Raw(expr string, args ...any) *T {
+	t.statements = append(t.statements, Expr(expr, args...))
 	return t.self
 }
 
-// Query adds any Query to the transaction
-func (t *StatementsBuilder[T]) Query(query Query) *T {
-	t.statements = append(t.statements, &QueryStatement{
-		query: query,
-	})
+// Do adds any Do to the transaction
+func (t *StatementsBuilder[T]) Do(query Query) *T {
+	t.statements = append(t.statements, query)
 	return t.self
 }
 


### PR DESCRIPTION
This adds a few QoL improvements to the experimental `surrealql` library:

- You can add more kinds of statements within `THEN` and `ELSE`. Basically, you can expect the same set of functions for adding statements within `FOR`, `BEGIN TRANSACTION`, `THEN`, and `ELSE` now.
- The `Raw` method in the statements builder has been enhanced to support placeholders
- The `Query` method within transactions, for-loops, and if-else statements has been renamed to `Do` to indicate that it can accept any expressions and statements. Along with the enhanced `Raw` you should be able to express more queries with the library (This is a follow-up to my finding in #365)

