### PR TITLE
surrealql: Enable returning using SelectQuery without intermediate variable

### DIFF
--- a/contrib/surrealql/example_transaction_query_test.go
+++ b/contrib/surrealql/example_transaction_query_test.go
@@ -186,3 +186,43 @@ func ExampleTransactionQuery_Return_withPlaceholders() {
 	//   return_param_1: 5
 	//   table_1: test
 }
+
+func ExampleTransactionQuery_Return_selectQueryString() {
+	// Create a transaction that returns the result of a SELECT query
+	tx := surrealql.Begin().
+		Let("name", "Alice").
+		Let("email", "alice@example.com").
+		Do(surrealql.Create("person").
+			Set("name", surrealql.Var("name"))).
+		Return("SELECT * FROM person")
+
+	sql, _ := tx.Build()
+	fmt.Println(sql)
+	// Output:
+	// BEGIN TRANSACTION;
+	// LET $name = "Alice";
+	// LET $email = "alice@example.com";
+	// CREATE person SET name = $name;
+	// RETURN SELECT * FROM person;
+	// COMMIT TRANSACTION;
+}
+
+func ExampleTransactionQuery_Return_selectQueryInstance() {
+	// Create a transaction that returns the result of a SELECT query
+	tx := surrealql.Begin().
+		Let("name", "Alice").
+		Let("email", "alice@example.com").
+		Do(surrealql.Create("person").
+			Set("name", surrealql.Var("name"))).
+		Return("?", surrealql.Select("person"))
+
+	sql, _ := tx.Build()
+	fmt.Println(sql)
+	// Output:
+	// BEGIN TRANSACTION;
+	// LET $name = "Alice";
+	// LET $email = "alice@example.com";
+	// CREATE person SET name = $name;
+	// RETURN (SELECT * FROM person);
+	// COMMIT TRANSACTION;
+}

--- a/contrib/surrealql/statements.go
+++ b/contrib/surrealql/statements.go
@@ -135,33 +135,5 @@ func (t *ThrowStatement) build(c *queryBuildContext, b *strings.Builder) {
 func (r *ReturnStatement) build(c *queryBuildContext, b *strings.Builder) {
 	b.WriteString("RETURN ")
 
-	if len(r.args) == 0 {
-		// No placeholders, just return the raw expression
-		b.WriteString(r.expr)
-		return
-	}
-
-	// Process placeholders
-	var startIndex int
-	for _, arg := range r.args {
-		placeholder := strings.Index(r.expr[startIndex:], "?")
-		if placeholder < 0 {
-			break
-		}
-		placeholder += startIndex
-		b.WriteString(r.expr[startIndex:placeholder])
-		// Check if arg is a Var (variable reference)
-		if varRef, ok := arg.(Var); ok {
-			// Replace the first ? with the variable reference
-			b.WriteString(varRef.String())
-		} else {
-			// Regular value, create a parameter
-			paramName := c.generateAndAddParam("return_param", arg)
-			b.WriteString("$")
-			b.WriteString(paramName)
-		}
-		// Update the start index
-		startIndex = placeholder + 1
-	}
-	b.WriteString(r.expr[startIndex:])
+	buildQueryStringWithPlaceholders(c, b, "return_param", r.expr, r.args)
 }


### PR DESCRIPTION
Previously, the experimental `surrealql` library had only limited support for `RETURN SELECT ...`.

You were able to write like ``surrealql.Begin().Return("SELECT * FROM person")`` but not `surrealql.Begin().Return("?", surrealql.Select("person"))`.

Since this change, it just works.
