### PR TITLE
Add support for SurrealDB v3 Sessions and Interactive Transactions

### DIFF
--- a/contrib/testenv/session_transaction_exploration_test.go
+++ b/contrib/testenv/session_transaction_exploration_test.go
@@ -100,8 +100,10 @@ func sendCustomRPC[T any](
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Use the underlying gorilla connection to write
-	conn.Conn.WriteMessage(2, data) // 2 = BinaryMessage
+	// Use the underlying gorilla connection to write (2 is BinaryMessage)
+	if err := conn.Conn.WriteMessage(2, data); err != nil {
+		return nil, fmt.Errorf("failed to write message: %w", err)
+	}
 
 	// Wait for response with timeout
 	select {
@@ -788,9 +790,9 @@ func TestExplore_DetachRPC(t *testing.T) {
 
 	// Test detach with session at top level succeeds
 	t.Run("detach with session at top level succeeds", func(t *testing.T) {
-		res, err := sendInSession[any](conn, ctx, "detach", &sessionUUID)
-		require.NoError(t, err, "detach with session at top level should succeed")
-		assert.NotNil(t, res, "response should not be nil")
+		detachRes, detachErr := sendInSession[any](conn, ctx, "detach", &sessionUUID)
+		require.NoError(t, detachErr, "detach with session at top level should succeed")
+		assert.NotNil(t, detachRes, "response should not be nil")
 	})
 
 	// Create another session for testing double detach
@@ -897,9 +899,9 @@ func TestExplore_CommitRPC(t *testing.T) {
 	// Test commit with txn in map fails (wrong format)
 	t.Run("commit with txn in map fails", func(t *testing.T) {
 		var commitRes connection.RPCResponse[any]
-		err := connection.Send(conn, ctx, &commitRes, "commit", map[string]any{"txn": txnID})
-		require.Error(t, err, "commit with txn in map should fail")
-		assert.Contains(t, err.Error(), "transaction", "error should mention transaction")
+		sendErr := connection.Send(conn, ctx, &commitRes, "commit", map[string]any{"txn": txnID})
+		require.Error(t, sendErr, "commit with txn in map should fail")
+		assert.Contains(t, sendErr.Error(), "transaction", "error should mention transaction")
 	})
 
 	// Start another transaction for testing direct param
@@ -938,8 +940,8 @@ func TestExplore_CancelRPC(t *testing.T) {
 	// Test cancel with direct param succeeds (correct format)
 	t.Run("cancel with direct param succeeds", func(t *testing.T) {
 		var cancelRes connection.RPCResponse[any]
-		err := connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
-		require.NoError(t, err, "cancel with direct param should succeed")
+		sendErr := connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+		require.NoError(t, sendErr, "cancel with direct param should succeed")
 	})
 
 	// Start another transaction for testing map format
@@ -1129,7 +1131,7 @@ func TestExplore_TransactionAutoCommit(t *testing.T) {
 		if arr, ok := result.([]any); ok {
 			count = len(arr)
 		}
-		assert.Equal(t, 0, count, "cancelled transaction data should be rolled back")
+		assert.Equal(t, 0, count, "canceled transaction data should be rolled back")
 	})
 }
 
@@ -1283,7 +1285,7 @@ func TestExplore_QueryWithTxnTopLevel(t *testing.T) {
 		var cancelRes connection.RPCResponse[any]
 		err := connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
 		require.NoError(t, err, "cancel should succeed")
-		t.Logf("Transaction cancelled")
+		t.Logf("Transaction canceled")
 
 		// Check data is rolled back - use a different connection to avoid any session state issues
 		conn3 := setupWSConnection(t, "explore_txn_toplevel", "txn_toplevel_test")
@@ -1307,7 +1309,7 @@ func TestExplore_QueryWithTxnTopLevel(t *testing.T) {
 		if ok {
 			count = len(resultArr)
 		}
-		assert.Equal(t, 0, count, "cancelled transaction data should be rolled back")
+		assert.Equal(t, 0, count, "canceled transaction data should be rolled back")
 		t.Logf("SELECT after cancel count: %d", count)
 	})
 

--- a/contrib/testenv/session_transaction_exploration_test.go
+++ b/contrib/testenv/session_transaction_exploration_test.go
@@ -1,4 +1,4 @@
-package surrealdb_test
+package testenv
 
 import (
 	"bytes"
@@ -15,7 +15,6 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/surrealdb/surrealdb.go/contrib/testenv"
 	"github.com/surrealdb/surrealdb.go/internal/rand"
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
@@ -170,7 +169,7 @@ func setupWSConnection(t *testing.T, namespace, database string) *gorillaws.Conn
 	t.Helper()
 
 	c := surrealcbor.New()
-	wsURL := testenv.GetSurrealDBWSURL()
+	wsURL := GetSurrealDBWSURL()
 	// gorillaws.Connect appends "/rpc" to BaseURL, so we need to strip it if present
 	baseURL := strings.TrimSuffix(wsURL, "/rpc")
 	conn := gorillaws.New(&connection.Config{
@@ -211,7 +210,7 @@ func setupHTTPConnection(t *testing.T, namespace, database string) *surrealhttp.
 
 	c := surrealcbor.New()
 	// Derive HTTP URL from WebSocket URL
-	wsURL := testenv.GetSurrealDBWSURL()
+	wsURL := GetSurrealDBWSURL()
 	httpURL := strings.ReplaceAll(wsURL, "ws://", "http://")
 	httpURL = strings.ReplaceAll(httpURL, "wss://", "https://")
 	// Remove /rpc suffix that's needed for WebSocket but not for HTTP
@@ -269,7 +268,7 @@ func setupHTTPConnectionInfo(t *testing.T, namespace, database string) *httpConn
 
 	c := surrealcbor.New()
 	// Derive HTTP URL from WebSocket URL
-	wsURL := testenv.GetSurrealDBWSURL()
+	wsURL := GetSurrealDBWSURL()
 	httpURL := strings.ReplaceAll(wsURL, "ws://", "http://")
 	httpURL = strings.ReplaceAll(httpURL, "wss://", "https://")
 	// Remove /rpc suffix that's needed for WebSocket but not for HTTP
@@ -395,10 +394,10 @@ func sendHTTPInTransaction[T any](
 }
 
 // getVersion gets and checks the SurrealDB version via a separate DB connection
-func getVersion(t *testing.T) *testenv.SurrealDBVersion {
+func getVersion(t *testing.T) *SurrealDBVersion {
 	t.Helper()
-	db := testenv.MustNew("version_check", "version_check", "dummy")
-	v, err := testenv.GetVersion(context.Background(), db)
+	db := MustNew("version_check", "version_check", "dummy")
+	v, err := GetVersion(context.Background(), db)
 	require.NoError(t, err)
 	_ = db.Close(context.Background())
 	return v
@@ -416,7 +415,7 @@ func TestExplore_HTTPConnection_Sessions(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_http", "session_test", "test_table")
+	_ = MustNew("explore_http", "session_test", "test_table")
 
 	info := setupHTTPConnectionInfo(t, "explore_http", "session_test")
 	ctx := context.Background()
@@ -490,7 +489,7 @@ func TestExplore_HTTPConnection_Transactions(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_http", "txn_test", "test_table")
+	_ = MustNew("explore_http", "txn_test", "test_table")
 
 	info := setupHTTPConnectionInfo(t, "explore_http", "txn_test")
 	ctx := context.Background()
@@ -575,7 +574,7 @@ func TestExplore_HTTPConnection_Transactions(t *testing.T) {
 // This confirms that the HTTP connection is properly set up and only session/transaction
 // RPCs are unsupported.
 func TestExplore_HTTPConnection_QueryWorks(t *testing.T) {
-	_ = testenv.MustNew("explore_http", "query_test", "test_table")
+	_ = MustNew("explore_http", "query_test", "test_table")
 
 	conn := setupHTTPConnection(t, "explore_http", "query_test")
 	ctx := context.Background()
@@ -629,7 +628,7 @@ func TestExplore_AttachRPC(t *testing.T) {
 	}
 
 	// Ensure namespace/database exist
-	_ = testenv.MustNew("explore_sessions", "attach_test", "test_table")
+	_ = MustNew("explore_sessions", "attach_test", "test_table")
 
 	conn := setupWSConnection(t, "explore_sessions", "attach_test")
 	ctx := context.Background()
@@ -687,7 +686,7 @@ func TestExplore_SessionWorkflow(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_sessions", "workflow_test", "test_table")
+	_ = MustNew("explore_sessions", "workflow_test", "test_table")
 
 	conn := setupWSConnection(t, "explore_sessions", "workflow_test")
 	ctx := context.Background()
@@ -776,7 +775,7 @@ func TestExplore_DetachRPC(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_sessions", "detach_test", "test_table")
+	_ = MustNew("explore_sessions", "detach_test", "test_table")
 
 	conn := setupWSConnection(t, "explore_sessions", "detach_test")
 	ctx := context.Background()
@@ -821,7 +820,7 @@ func TestExplore_BeginRPC(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_txn", "begin_test", "test_table")
+	_ = MustNew("explore_txn", "begin_test", "test_table")
 
 	conn := setupWSConnection(t, "explore_txn", "begin_test")
 	ctx := context.Background()
@@ -883,7 +882,7 @@ func TestExplore_CommitRPC(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_txn", "commit_test", "test_table")
+	_ = MustNew("explore_txn", "commit_test", "test_table")
 
 	conn := setupWSConnection(t, "explore_txn", "commit_test")
 	ctx := context.Background()
@@ -924,7 +923,7 @@ func TestExplore_CancelRPC(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_txn", "cancel_test", "test_table")
+	_ = MustNew("explore_txn", "cancel_test", "test_table")
 
 	conn := setupWSConnection(t, "explore_txn", "cancel_test")
 	ctx := context.Background()
@@ -964,7 +963,7 @@ func TestExplore_TransactionIsolation(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_txn", "isolation_test", "users")
+	_ = MustNew("explore_txn", "isolation_test", "users")
 
 	conn := setupWSConnection(t, "explore_txn", "isolation_test")
 	ctx := context.Background()
@@ -1054,7 +1053,7 @@ func TestExplore_TransactionAutoCommit(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_txn", "autocommit_test", "items")
+	_ = MustNew("explore_txn", "autocommit_test", "items")
 
 	conn := setupWSConnection(t, "explore_txn", "autocommit_test")
 	ctx := context.Background()
@@ -1141,7 +1140,7 @@ func TestExplore_CRUDInTransaction(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_crud_txn", "crud_test", "products")
+	_ = MustNew("explore_crud_txn", "crud_test", "products")
 
 	conn := setupWSConnection(t, "explore_crud_txn", "crud_test")
 	ctx := context.Background()
@@ -1203,7 +1202,7 @@ func TestExplore_QueryWithTxnTopLevel(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_txn_toplevel", "txn_toplevel_test", "records")
+	_ = MustNew("explore_txn_toplevel", "txn_toplevel_test", "records")
 
 	conn := setupWSConnection(t, "explore_txn_toplevel", "txn_toplevel_test")
 	ctx := context.Background()
@@ -1365,7 +1364,7 @@ func TestExplore_MultipleTransactions(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_multi_txn", "multi_txn_test", "accounts")
+	_ = MustNew("explore_multi_txn", "multi_txn_test", "accounts")
 
 	conn := setupWSConnection(t, "explore_multi_txn", "multi_txn_test")
 	ctx := context.Background()
@@ -1447,7 +1446,7 @@ func TestExplore_TransactionOwnership(t *testing.T) {
 		t.Skipf("Skipping: SurrealDB version %s does not support sessions/transactions (requires v3+)", v)
 	}
 
-	_ = testenv.MustNew("explore_txn_ownership", "ownership_test", "items")
+	_ = MustNew("explore_txn_ownership", "ownership_test", "items")
 
 	conn := setupWSConnection(t, "explore_txn_ownership", "ownership_test")
 	ctx := context.Background()

--- a/db.go
+++ b/db.go
@@ -12,8 +12,15 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
 	"github.com/surrealdb/surrealdb.go/pkg/connection/http"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
+
+// sendable is a constraint for types that can send RPC requests.
+// It is satisfied by *DB, *Session, and *Transaction.
+type sendable interface {
+	*DB | *Session | *Transaction
+}
 
 type VersionData struct {
 	Version   string `json:"version"`
@@ -453,22 +460,37 @@ func (db *DB) CloseLiveNotifications(liveQueryID string) error {
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-func Kill(ctx context.Context, db *DB, id string) error {
+// Kill terminates a live query and closes the notification channel.
+// S can be *DB or *Session (not *Transaction, as live queries are session-scoped).
+func Kill[S sendable](ctx context.Context, s S, id string) error {
 	// First kill the live query on the server
-	_, err := send[any](ctx, db, "kill", id)
+	_, err := send[any](ctx, s, "kill", id)
 	if err != nil {
 		return err
 	}
 
 	// Then close the notification channel to prevent leaks
-	return db.CloseLiveNotifications(id)
+	switch v := any(s).(type) {
+	case *DB:
+		return v.CloseLiveNotifications(id)
+	case *Session:
+		return v.CloseLiveNotifications(id)
+	case *Transaction:
+		// Transactions don't have their own live notification channels
+		return v.db.CloseLiveNotifications(id)
+	}
+	return nil
 }
 
-func Live(ctx context.Context, db *DB, table models.Table, diff bool) (*models.UUID, error) {
-	return send[models.UUID](ctx, db, "live", table, diff)
+// Live starts a live query on a table.
+// S can be *DB or *Session (not *Transaction, as live queries are session-scoped).
+func Live[S sendable](ctx context.Context, s S, table models.Table, diff bool) (*models.UUID, error) {
+	return send[models.UUID](ctx, s, "live", table, diff)
 }
 
 // Query executes a query against the SurrealDB database.
+//
+// S can be *DB, *Session, or *Transaction.
 //
 // [Query] supports:
 //
@@ -582,8 +604,8 @@ func Live(ctx context.Context, db *DB, table models.Table, diff bool) (*models.U
 // If you tried to insert the same duplicate record using the [Query] RPC method with `INSERT` statement,
 // you may get no [RPCError], but a [QueryError] saying so, enabling you to easily diferentiate
 // between retriable and non-retriable errors.
-func Query[TResult any](ctx context.Context, db *DB, sql string, vars map[string]any) (*[]QueryResult[TResult], error) {
-	res, err := send[[]QueryResult[cbor.RawMessage]](ctx, db, "query", sql, vars)
+func Query[TResult any, S sendable](ctx context.Context, s S, sql string, vars map[string]any) (*[]QueryResult[TResult], error) {
+	res, err := send[[]QueryResult[cbor.RawMessage]](ctx, s, "query", sql, vars)
 	if err != nil {
 		return nil, err
 	}
@@ -592,6 +614,17 @@ func Query[TResult any](ctx context.Context, db *DB, sql string, vars map[string
 	var (
 		errs error
 	)
+
+	// Get the unmarshaler based on the sender type
+	var unmarshaler func([]byte, any) error
+	switch v := any(s).(type) {
+	case *DB:
+		unmarshaler = v.con.GetUnmarshaler().Unmarshal
+	case *Session:
+		unmarshaler = v.db.con.GetUnmarshaler().Unmarshal
+	case *Transaction:
+		unmarshaler = v.db.con.GetUnmarshaler().Unmarshal
+	}
 
 	// We unmarshal []QueryResult[cbor.RawMessage] first,
 	// and then unmarshal each cbor.RawMessage to TResult.
@@ -609,7 +642,7 @@ func Query[TResult any](ctx context.Context, db *DB, sql string, vars map[string
 		if result.Status == "ERR" {
 			var errMsg string
 			if result.Result != nil {
-				if err := db.con.GetUnmarshaler().Unmarshal(result.Result, &errMsg); err != nil {
+				if err := unmarshaler(result.Result, &errMsg); err != nil {
 					return nil, fmt.Errorf("failed to unmarshal error message: %w", err)
 				}
 			}
@@ -618,7 +651,7 @@ func Query[TResult any](ctx context.Context, db *DB, sql string, vars map[string
 			}
 			errs = errors.Join(errs, e)
 		} else if result.Result != nil {
-			if err := db.con.GetUnmarshaler().Unmarshal(result.Result, &r); err != nil {
+			if err := unmarshaler(result.Result, &r); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 			}
 		}
@@ -633,48 +666,61 @@ func Query[TResult any](ctx context.Context, db *DB, sql string, vars map[string
 	return &qr, errs
 }
 
-func Create[TResult any, TWhat TableOrRecord](ctx context.Context, db *DB, what TWhat, data any) (*TResult, error) {
-	return send[TResult](ctx, db, "create", what, data)
+// Create creates a new record in the database.
+// S can be *DB, *Session, or *Transaction.
+func Create[TResult any, TWhat TableOrRecord, S sendable](ctx context.Context, s S, what TWhat, data any) (*TResult, error) {
+	return send[TResult](ctx, s, "create", what, data)
 }
 
-func Select[TResult any, TWhat TableOrRecord](ctx context.Context, db *DB, what TWhat) (*TResult, error) {
-	return send[TResult](ctx, db, "select", what)
+// Select retrieves records from the database.
+// S can be *DB, *Session, or *Transaction.
+func Select[TResult any, TWhat TableOrRecord, S sendable](ctx context.Context, s S, what TWhat) (*TResult, error) {
+	return send[TResult](ctx, s, "select", what)
 }
 
-// Patches either all records in a table or a single record with specified patches.
-func Patch[TWhat TableOrRecord](ctx context.Context, db *DB, what TWhat, patches []PatchData) (*[]PatchData, error) {
-	return send[[]PatchData](ctx, db, "patch", what, patches, true)
+// Patch applies patches to records in the database.
+// S can be *DB, *Session, or *Transaction.
+func Patch[TWhat TableOrRecord, S sendable](ctx context.Context, s S, what TWhat, patches []PatchData) (*[]PatchData, error) {
+	return send[[]PatchData](ctx, s, "patch", what, patches, true)
 }
 
-func Delete[TResult any, TWhat TableOrRecord](ctx context.Context, db *DB, what TWhat) (*TResult, error) {
-	return send[TResult](ctx, db, "delete", what)
+// Delete removes records from the database.
+// S can be *DB, *Session, or *Transaction.
+func Delete[TResult any, TWhat TableOrRecord, S sendable](ctx context.Context, s S, what TWhat) (*TResult, error) {
+	return send[TResult](ctx, s, "delete", what)
 }
 
-func Upsert[TResult any, TWhat TableOrRecord](ctx context.Context, db *DB, what TWhat, data any) (*TResult, error) {
-	return send[TResult](ctx, db, "upsert", what, data)
+// Upsert creates or updates a record in the database.
+// S can be *DB, *Session, or *Transaction.
+func Upsert[TResult any, TWhat TableOrRecord, S sendable](ctx context.Context, s S, what TWhat, data any) (*TResult, error) {
+	return send[TResult](ctx, s, "upsert", what, data)
 }
 
-// Update a table or record in the database like a PUT request.
-func Update[TResult any, TWhat TableOrRecord](ctx context.Context, db *DB, what TWhat, data any) (*TResult, error) {
-	return send[TResult](ctx, db, "update", what, data)
+// Update replaces a record in the database like a PUT request.
+// S can be *DB, *Session, or *Transaction.
+func Update[TResult any, TWhat TableOrRecord, S sendable](ctx context.Context, s S, what TWhat, data any) (*TResult, error) {
+	return send[TResult](ctx, s, "update", what, data)
 }
 
-// Merge a table or record in the database like a PATCH request.
-func Merge[TResult any, TWhat TableOrRecord](ctx context.Context, db *DB, what TWhat, data any) (*TResult, error) {
-	return send[TResult](ctx, db, "merge", what, data)
+// Merge merges data into a record in the database like a PATCH request.
+// S can be *DB, *Session, or *Transaction.
+func Merge[TResult any, TWhat TableOrRecord, S sendable](ctx context.Context, s S, what TWhat, data any) (*TResult, error) {
+	return send[TResult](ctx, s, "merge", what, data)
 }
 
 // Insert creates records with either specified IDs or generated IDs.
+// S can be *DB, *Session, or *Transaction.
 //
 // Insert cannot create a relationship. If you want to create a relationship,
 // use InsertRelation if you need to specify the ID of the relationship,
 // or use Relate if you want to create a relationship with a generated ID.
-func Insert[TResult any](ctx context.Context, db *DB, what models.Table, data any) (*[]TResult, error) {
-	return send[[]TResult](ctx, db, "insert", what, data)
+func Insert[TResult any, S sendable](ctx context.Context, s S, what models.Table, data any) (*[]TResult, error) {
+	return send[[]TResult](ctx, s, "insert", what, data)
 }
 
 // Relate creates a relationship between two records in the table
 // with a generated relationship ID.
+// S can be *DB, *Session, or *Transaction.
 //
 // The relation needs to be specified via the `Relation` field of the Relationship struct.
 //
@@ -689,11 +735,12 @@ func Insert[TResult any](ctx context.Context, db *DB, what models.Table, data an
 //
 // In case you only care about the returned relationship's ID,
 // use `connection.ResponseID[models.RecordID]` for the TResult type parameter.
-func Relate[TResult any](ctx context.Context, db *DB, rel *Relationship) (*TResult, error) {
-	return send[TResult](ctx, db, "relate", rel.In, rel.Relation, rel.Out, rel.Data)
+func Relate[TResult any, S sendable](ctx context.Context, s S, rel *Relationship) (*TResult, error) {
+	return send[TResult](ctx, s, "relate", rel.In, rel.Relation, rel.Out, rel.Data)
 }
 
 // InsertRelation inserts a relation between two records in the database.
+// S can be *DB, *Session, or *Transaction.
 //
 // It creates a relationship from relationship.In to relationship.Out.
 //
@@ -702,7 +749,7 @@ func Relate[TResult any](ctx context.Context, db *DB, rel *Relationship) (*TResu
 //
 // In case you only care about the returned relationship's ID,
 // use `connection.ResponseID[models.RecordID]` for the TResult type parameter.
-func InsertRelation[TResult any](ctx context.Context, db *DB, relationship *Relationship) (*TResult, error) {
+func InsertRelation[TResult any, S sendable](ctx context.Context, s S, relationship *Relationship) (*TResult, error) {
 	rel := map[string]any{
 		"in":  relationship.In,
 		"out": relationship.Out,
@@ -714,14 +761,15 @@ func InsertRelation[TResult any](ctx context.Context, db *DB, relationship *Rela
 		rel[k] = v
 	}
 
-	return send[TResult](ctx, db, "insert_relation", relationship.Relation, rel)
+	return send[TResult](ctx, s, "insert_relation", relationship.Relation, rel)
 }
 
 // QueryRaw composes a query from the provided QueryStmt objects,
 // and execute it using the query RPC method.
+// S can be *DB, *Session, or *Transaction.
 //
 // You may want to use [Query] with [github.com/surrealdb/surrealdb.go/contrib/surrealql] instead.
-func QueryRaw(ctx context.Context, db *DB, queries *[]QueryStmt) error {
+func QueryRaw[S sendable](ctx context.Context, s S, queries *[]QueryStmt) error {
 	preparedQuery := ""
 	parameters := map[string]any{}
 	for i := 0; i < len(*queries); i++ {
@@ -736,15 +784,28 @@ func QueryRaw(ctx context.Context, db *DB, queries *[]QueryStmt) error {
 		return fmt.Errorf("no query to run")
 	}
 
-	res, err := send[[]QueryResult[cbor.RawMessage]](ctx, db, "query", preparedQuery, parameters)
+	res, err := send[[]QueryResult[cbor.RawMessage]](ctx, s, "query", preparedQuery, parameters)
 	if err != nil {
 		return err
+	}
+
+	// Get the unmarshaler based on the sender type
+	var unmarshaler interface {
+		Unmarshal(data []byte, v any) error
+	}
+	switch v := any(s).(type) {
+	case *DB:
+		unmarshaler = v.con.GetUnmarshaler()
+	case *Session:
+		unmarshaler = v.db.con.GetUnmarshaler()
+	case *Transaction:
+		unmarshaler = v.db.con.GetUnmarshaler()
 	}
 
 	for i := 0; i < len(*queries); i++ {
 		// assign results
 		(*queries)[i].Result = (*res)[i]
-		(*queries)[i].unmarshaler = db.con.GetUnmarshaler()
+		(*queries)[i].unmarshaler = unmarshaler
 	}
 
 	return nil
@@ -753,10 +814,44 @@ func QueryRaw(ctx context.Context, db *DB, queries *[]QueryStmt) error {
 // send is a helper function to send a request to the SurrealDB server
 // in case the expected response is a connection.RPCResponse[TResult].
 // If one expects other types of responses, use db.con.Send directly.
-func send[TResult any](ctx context.Context, db *DB, method string, params ...any) (*TResult, error) {
+//
+// The function uses a type switch to determine how to send the request:
+//   - *DB: uses connection.Send (no session/txn context)
+//   - *Session: uses connection.Call with session UUID
+//   - *Transaction: uses connection.Call with session and txn UUIDs
+func send[TResult any, S sendable](ctx context.Context, s S, method string, params ...any) (*TResult, error) {
 	var res connection.RPCResponse[TResult]
-	if err := connection.Send(db.con, ctx, &res, method, params...); err != nil {
-		return nil, err
+
+	switch v := any(s).(type) {
+	case *DB:
+		if err := connection.Send(v.con, ctx, &res, method, params...); err != nil {
+			return nil, err
+		}
+	case *Session:
+		if v.isClosed() {
+			return nil, constants.ErrSessionClosed
+		}
+		req := &connection.RPCRequest{
+			Method:  method,
+			Params:  params,
+			Session: v.id,
+		}
+		if err := connection.Call(v.db.con, ctx, &res, req); err != nil {
+			return nil, err
+		}
+	case *Transaction:
+		if v.isClosed() {
+			return nil, constants.ErrTransactionClosed
+		}
+		req := &connection.RPCRequest{
+			Method:  method,
+			Params:  params,
+			Session: v.sessionID,
+			Txn:     v.id,
+		}
+		if err := connection.Call(v.db.con, ctx, &res, req); err != nil {
+			return nil, err
+		}
 	}
 
 	return res.Result, nil

--- a/db.go
+++ b/db.go
@@ -843,7 +843,7 @@ func send[TResult any, S sendable](ctx context.Context, s S, method string, para
 			return nil, err
 		}
 	case *Transaction:
-		if v.isClosed() {
+		if v.IsClosed() {
 			return nil, constants.ErrTransactionClosed
 		}
 		req := &connection.RPCRequest{

--- a/db.go
+++ b/db.go
@@ -22,6 +22,12 @@ type sendable interface {
 	*DB | *Session | *Transaction
 }
 
+// liveQueryable is a constraint for types that support live queries.
+// Live queries are session-scoped and not supported within transactions.
+type liveQueryable interface {
+	*DB | *Session
+}
+
 type VersionData struct {
 	Version   string `json:"version"`
 	Build     string `json:"build"`
@@ -462,7 +468,7 @@ func (db *DB) CloseLiveNotifications(liveQueryID string) error {
 
 // Kill terminates a live query and closes the notification channel.
 // S can be *DB or *Session (not *Transaction, as live queries are session-scoped).
-func Kill[S sendable](ctx context.Context, s S, id string) error {
+func Kill[S liveQueryable](ctx context.Context, s S, id string) error {
 	// First kill the live query on the server
 	_, err := send[any](ctx, s, "kill", id)
 	if err != nil {
@@ -475,16 +481,13 @@ func Kill[S sendable](ctx context.Context, s S, id string) error {
 		return v.CloseLiveNotifications(id)
 	case *Session:
 		return v.CloseLiveNotifications(id)
-	case *Transaction:
-		// Transactions don't have their own live notification channels
-		return v.db.CloseLiveNotifications(id)
 	}
 	return nil
 }
 
 // Live starts a live query on a table.
 // S can be *DB or *Session (not *Transaction, as live queries are session-scoped).
-func Live[S sendable](ctx context.Context, s S, table models.Table, diff bool) (*models.UUID, error) {
+func Live[S liveQueryable](ctx context.Context, s S, table models.Table, diff bool) (*models.UUID, error) {
 	return send[models.UUID](ctx, s, "live", table, diff)
 }
 

--- a/example_v3_session_test.go
+++ b/example_v3_session_test.go
@@ -1,0 +1,127 @@
+package surrealdb_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+)
+
+// ExampleDB_Attach demonstrates creating and using an additional session.
+// Sessions allow independent authentication, namespace selection, and variable scope.
+// This feature requires SurrealDB v3+ and WebSocket connections.
+func ExampleDB_Attach() {
+	// Skip if not v3+ (this is for documentation purposes)
+	ctx := context.Background()
+
+	// Connect using WebSocket (sessions require WebSocket)
+	db, err := surrealdb.FromEndpointURLString(ctx, testenv.GetSurrealDBWSURL())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close(ctx)
+
+	// Sign in as root on the main connection
+	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create an additional session
+	session, err := db.Attach(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer session.Detach(ctx)
+
+	fmt.Printf("Session created with ID: %s\n", session.ID())
+
+	// The session starts unauthenticated - sign in and select namespace/database
+	if _, err := session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := session.Use(ctx, "test", "test"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Set a session-scoped variable
+	if err := session.Let(ctx, "user_id", "user123"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Query using the session - the variable is available
+	type Result struct {
+		UserID string `json:"user_id"`
+	}
+	results, err := surrealdb.Query[Result](ctx, session, "RETURN $user_id", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(*results) > 0 {
+		fmt.Printf("Session variable $user_id: %s\n", (*results)[0].Result)
+	}
+
+	// Note: This example requires SurrealDB v3+ and will fail on earlier versions.
+	// Output is not verified because session IDs are dynamic.
+}
+
+// ExampleSession_Begin demonstrates starting a transaction within a session.
+// Transactions within sessions are isolated and can be committed or cancelled.
+func ExampleSession_Begin() {
+	ctx := context.Background()
+
+	// Connect using WebSocket
+	db, err := surrealdb.FromEndpointURLString(ctx, testenv.GetSurrealDBWSURL())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close(ctx)
+
+	// Sign in and set up
+	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Use(ctx, "test", "test"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a session
+	session, err := db.Attach(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer session.Detach(ctx)
+
+	// Authenticate and configure the session
+	if _, err := session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+		log.Fatal(err)
+	}
+	if err := session.Use(ctx, "test", "test"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Start a transaction within the session
+	tx, err := session.Begin(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Transaction started with ID: %s\n", tx.ID())
+	fmt.Printf("Transaction is in session: %s\n", tx.SessionID())
+
+	// Perform operations in the transaction
+	// ... your operations here ...
+
+	// Commit or cancel
+	if err := tx.Commit(ctx); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Transaction committed successfully")
+
+	// Note: This example requires SurrealDB v3+ and will fail on earlier versions.
+	// Output is not verified because transaction IDs are dynamic.
+}

--- a/example_v3_session_test.go
+++ b/example_v3_session_test.go
@@ -21,11 +21,16 @@ func ExampleDB_Attach() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer db.Close(ctx)
+	defer func() {
+		if closeErr := db.Close(ctx); closeErr != nil {
+			log.Printf("Failed to close db: %v", closeErr)
+		}
+	}()
 
 	// Sign in as root on the main connection
-	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
-		log.Fatal(err)
+	_, err = db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	if err != nil {
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
 
 	// Create an additional session
@@ -33,21 +38,24 @@ func ExampleDB_Attach() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer session.Detach(ctx)
+	defer func() { _ = session.Detach(ctx) }()
 
 	fmt.Printf("Session created with ID: %s\n", session.ID())
 
 	// The session starts unauthenticated - sign in and select namespace/database
-	if _, err := session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err := session.Use(ctx, "test", "test"); err != nil {
+	err = session.Use(ctx, "test", "test")
+	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Set a session-scoped variable
-	if err := session.Let(ctx, "user_id", "user123"); err != nil {
+	err = session.Let(ctx, "user_id", "user123")
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -69,7 +77,7 @@ func ExampleDB_Attach() {
 }
 
 // ExampleSession_Begin demonstrates starting a transaction within a session.
-// Transactions within sessions are isolated and can be committed or cancelled.
+// Transactions within sessions are isolated and can be committed or canceled.
 func ExampleSession_Begin() {
 	ctx := context.Background()
 
@@ -78,14 +86,20 @@ func ExampleSession_Begin() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer db.Close(ctx)
+	defer func() {
+		if closeErr := db.Close(ctx); closeErr != nil {
+			log.Printf("Failed to close db: %v", closeErr)
+		}
+	}()
 
 	// Sign in and set up
-	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
-		log.Fatal(err)
+	_, err = db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	if err != nil {
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
-	if err := db.Use(ctx, "test", "test"); err != nil {
-		log.Fatal(err)
+	err = db.Use(ctx, "test", "test")
+	if err != nil {
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
 
 	// Create a session
@@ -93,13 +107,15 @@ func ExampleSession_Begin() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer session.Detach(ctx)
+	defer func() { _ = session.Detach(ctx) }()
 
 	// Authenticate and configure the session
-	if _, err := session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	if err != nil {
 		log.Fatal(err)
 	}
-	if err := session.Use(ctx, "test", "test"); err != nil {
+	err = session.Use(ctx, "test", "test")
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -116,7 +132,8 @@ func ExampleSession_Begin() {
 	// ... your operations here ...
 
 	// Commit or cancel
-	if err := tx.Commit(ctx); err != nil {
+	err = tx.Commit(ctx)
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/example_v3_transaction_test.go
+++ b/example_v3_transaction_test.go
@@ -11,7 +11,7 @@ import (
 
 // ExampleDB_Begin demonstrates starting an interactive transaction.
 // Interactive transactions allow executing statements one at a time
-// and conditionally committing or cancelling based on results.
+// and conditionally committing or canceling based on results.
 // This feature requires SurrealDB v3+ and WebSocket connections.
 func ExampleDB_Begin() {
 	ctx := context.Background()
@@ -21,14 +21,20 @@ func ExampleDB_Begin() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer db.Close(ctx)
+	defer func() {
+		if closeErr := db.Close(ctx); closeErr != nil {
+			log.Printf("Failed to close db: %v", closeErr)
+		}
+	}()
 
 	// Sign in and select namespace/database
-	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
-		log.Fatal(err)
+	_, err = db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	if err != nil {
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
-	if err := db.Use(ctx, "test", "test"); err != nil {
-		log.Fatal(err)
+	err = db.Use(ctx, "test", "test")
+	if err != nil {
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
 
 	// Start an interactive transaction
@@ -47,9 +53,9 @@ func ExampleDB_Begin() {
 
 	// Perform operations within the transaction
 	type Product struct {
-		ID    string  `json:"id"`
-		Name  string  `json:"name"`
-		Stock int     `json:"stock"`
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Stock int    `json:"stock"`
 	}
 
 	// Create a product
@@ -73,7 +79,8 @@ func ExampleDB_Begin() {
 	}
 
 	// Commit the transaction to persist changes
-	if err := tx.Commit(ctx); err != nil {
+	err = tx.Commit(ctx)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -93,14 +100,20 @@ func ExampleTransaction_conditionalCommit() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer db.Close(ctx)
+	defer func() {
+		if closeErr := db.Close(ctx); closeErr != nil {
+			log.Printf("Failed to close db: %v", closeErr)
+		}
+	}()
 
 	// Sign in and configure
-	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
-		log.Fatal(err)
+	_, err = db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	if err != nil {
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
-	if err := db.Use(ctx, "test", "test"); err != nil {
-		log.Fatal(err)
+	err = db.Use(ctx, "test", "test")
+	if err != nil {
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
 
 	// Start transaction
@@ -141,16 +154,18 @@ func ExampleTransaction_conditionalCommit() {
 		}
 
 		// Commit the transaction
-		if err := tx.Commit(ctx); err != nil {
+		err = tx.Commit(ctx)
+		if err != nil {
 			log.Fatal(err)
 		}
 		fmt.Println("Transaction committed: inventory updated")
 	} else {
 		// Not enough stock - cancel transaction
-		if err := tx.Cancel(ctx); err != nil {
+		err = tx.Cancel(ctx)
+		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Println("Transaction cancelled: insufficient stock")
+		fmt.Println("Transaction canceled: insufficient stock")
 	}
 
 	// Output depends on inventory state
@@ -159,6 +174,8 @@ func ExampleTransaction_conditionalCommit() {
 // ExampleTransaction_isolation demonstrates transaction isolation.
 // Changes made in a transaction are not visible to other connections
 // until the transaction is committed.
+//
+//nolint:gocyclo // Example code - complexity is acceptable for demonstration purposes
 func ExampleTransaction_isolation() {
 	ctx := context.Background()
 
@@ -167,21 +184,31 @@ func ExampleTransaction_isolation() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer db1.Close(ctx)
+	defer func() {
+		if closeErr := db1.Close(ctx); closeErr != nil {
+			log.Printf("Failed to close db1: %v", closeErr)
+		}
+	}()
 
 	db2, err := surrealdb.FromEndpointURLString(ctx, testenv.GetSurrealDBWSURL())
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:gocritic // Example code - log.Fatal is acceptable
 	}
-	defer db2.Close(ctx)
+	defer func() {
+		if closeErr := db2.Close(ctx); closeErr != nil {
+			log.Printf("Failed to close db2: %v", closeErr)
+		}
+	}()
 
 	// Configure both connections
 	for _, db := range []*surrealdb.DB{db1, db2} {
-		if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
-			log.Fatal(err)
+		_, signInErr := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+		if signInErr != nil {
+			log.Fatal(signInErr)
 		}
-		if err := db.Use(ctx, "test", "test"); err != nil {
-			log.Fatal(err)
+		useErr := db.Use(ctx, "test", "test")
+		if useErr != nil {
+			log.Fatal(useErr)
 		}
 	}
 
@@ -218,7 +245,8 @@ func ExampleTransaction_isolation() {
 	}
 
 	// Commit
-	if err := tx.Commit(ctx); err != nil {
+	err = tx.Commit(ctx)
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/example_v3_transaction_test.go
+++ b/example_v3_transaction_test.go
@@ -1,0 +1,237 @@
+package surrealdb_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+)
+
+// ExampleDB_Begin demonstrates starting an interactive transaction.
+// Interactive transactions allow executing statements one at a time
+// and conditionally committing or cancelling based on results.
+// This feature requires SurrealDB v3+ and WebSocket connections.
+func ExampleDB_Begin() {
+	ctx := context.Background()
+
+	// Connect using WebSocket (transactions require WebSocket)
+	db, err := surrealdb.FromEndpointURLString(ctx, testenv.GetSurrealDBWSURL())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close(ctx)
+
+	// Sign in and select namespace/database
+	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Use(ctx, "test", "test"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Start an interactive transaction
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Always clean up if not committed
+	defer func() {
+		if !tx.IsClosed() {
+			_ = tx.Cancel(ctx)
+		}
+	}()
+
+	fmt.Printf("Transaction started with ID: %s\n", tx.ID())
+
+	// Perform operations within the transaction
+	type Product struct {
+		ID    string  `json:"id"`
+		Name  string  `json:"name"`
+		Stock int     `json:"stock"`
+	}
+
+	// Create a product
+	_, err = surrealdb.Query[[]Product](ctx, tx,
+		"CREATE products:widget SET name = 'Widget', stock = 100", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Query within the same transaction - changes are visible
+	results, err := surrealdb.Query[[]Product](ctx, tx,
+		"SELECT * FROM products:widget", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(*results) > 0 && len((*results)[0].Result) > 0 {
+		fmt.Printf("Product in transaction: %s (stock: %d)\n",
+			(*results)[0].Result[0].Name,
+			(*results)[0].Result[0].Stock)
+	}
+
+	// Commit the transaction to persist changes
+	if err := tx.Commit(ctx); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Transaction committed")
+
+	// Note: This example requires SurrealDB v3+ and will fail on earlier versions.
+	// Output is not verified because transaction IDs are dynamic.
+}
+
+// ExampleTransaction_conditionalCommit demonstrates conditional commit/cancel.
+// Based on query results, you can decide whether to commit or rollback.
+func ExampleTransaction_conditionalCommit() {
+	ctx := context.Background()
+
+	// Connect using WebSocket
+	db, err := surrealdb.FromEndpointURLString(ctx, testenv.GetSurrealDBWSURL())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close(ctx)
+
+	// Sign in and configure
+	if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Use(ctx, "test", "test"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Start transaction
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Simulate a business operation: deduct from inventory
+	type Inventory struct {
+		Stock int `json:"stock"`
+	}
+
+	// Check current stock
+	results, err := surrealdb.Query[[]Inventory](ctx, tx,
+		"SELECT stock FROM inventory:item1", nil)
+	if err != nil {
+		_ = tx.Cancel(ctx)
+		log.Fatal(err)
+	}
+
+	var currentStock int
+	if len(*results) > 0 && len((*results)[0].Result) > 0 {
+		currentStock = (*results)[0].Result[0].Stock
+	}
+
+	requestedQuantity := 5
+
+	// Conditional logic based on query results
+	if currentStock >= requestedQuantity {
+		// Update stock
+		_, err = surrealdb.Query[any](ctx, tx,
+			"UPDATE inventory:item1 SET stock -= $qty",
+			map[string]any{"qty": requestedQuantity})
+		if err != nil {
+			_ = tx.Cancel(ctx)
+			log.Fatal(err)
+		}
+
+		// Commit the transaction
+		if err := tx.Commit(ctx); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Transaction committed: inventory updated")
+	} else {
+		// Not enough stock - cancel transaction
+		if err := tx.Cancel(ctx); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Transaction cancelled: insufficient stock")
+	}
+
+	// Output depends on inventory state
+}
+
+// ExampleTransaction_isolation demonstrates transaction isolation.
+// Changes made in a transaction are not visible to other connections
+// until the transaction is committed.
+func ExampleTransaction_isolation() {
+	ctx := context.Background()
+
+	// Create two connections
+	db1, err := surrealdb.FromEndpointURLString(ctx, testenv.GetSurrealDBWSURL())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db1.Close(ctx)
+
+	db2, err := surrealdb.FromEndpointURLString(ctx, testenv.GetSurrealDBWSURL())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db2.Close(ctx)
+
+	// Configure both connections
+	for _, db := range []*surrealdb.DB{db1, db2} {
+		if _, err := db.SignIn(ctx, map[string]any{"user": "root", "pass": "root"}); err != nil {
+			log.Fatal(err)
+		}
+		if err := db.Use(ctx, "test", "test"); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// Start transaction on db1
+	tx, err := db1.Begin(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if !tx.IsClosed() {
+			_ = tx.Cancel(ctx)
+		}
+	}()
+
+	// Create record in transaction
+	_, err = surrealdb.Query[any](ctx, tx,
+		"CREATE items:isolated SET value = 'hidden'", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Query from db2 - should NOT see uncommitted data
+	type Item struct {
+		Value string `json:"value"`
+	}
+	results, err := surrealdb.Query[[]Item](ctx, db2,
+		"SELECT * FROM items:isolated", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(*results) > 0 && len((*results)[0].Result) == 0 {
+		fmt.Println("Before commit: db2 cannot see uncommitted data")
+	}
+
+	// Commit
+	if err := tx.Commit(ctx); err != nil {
+		log.Fatal(err)
+	}
+
+	// Now db2 should see the data
+	results, err = surrealdb.Query[[]Item](ctx, db2,
+		"SELECT * FROM items:isolated", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(*results) > 0 && len((*results)[0].Result) > 0 {
+		fmt.Println("After commit: db2 can see committed data")
+	}
+
+	// Note: This example requires SurrealDB v3+ and will fail on earlier versions.
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -38,6 +38,16 @@ type Connection interface {
 	//
 	// The `ctx` is used to cancel the request if the context is canceled.
 	Send(ctx context.Context, method string, params ...any) (*RPCResponse[cbor.RawMessage], error)
+	// Call sends a custom RPC request to SurrealDB and expects a response.
+	// Unlike Send, Call accepts an RPCRequest directly, allowing you to set
+	// Session and Txn fields for session-scoped or transaction-scoped operations (SurrealDB v3+).
+	//
+	// The `req` is the RPC request to send. The ID field will be set automatically if empty.
+	// The `ctx` is used to cancel the request if the context is canceled.
+	//
+	// For HTTP connections, this method returns an error if req.Session or req.Txn is set,
+	// as sessions and transactions require WebSocket connections.
+	Call(ctx context.Context, req *RPCRequest) (*RPCResponse[cbor.RawMessage], error)
 	Use(ctx context.Context, namespace string, database string) error
 	Let(ctx context.Context, key string, value any) error
 	Authenticate(ctx context.Context, token string) error

--- a/pkg/connection/gorillaws/connection.go
+++ b/pkg/connection/gorillaws/connection.go
@@ -323,6 +323,17 @@ func (c *Connection) GetUnmarshaler() codec.Unmarshaler {
 // HTTP and WebSocket, to behave differently in case of a timeout.
 // The WebSocketConnection would return ErrTimeout, while the HTTPConnection would return context.DeadlineExceeded.
 func (c *Connection) Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error) {
+	request := &connection.RPCRequest{
+		Method: method,
+		Params: params,
+	}
+	return c.Call(ctx, request)
+}
+
+// Call sends a custom RPC request to SurrealDB and expects a response.
+// Unlike Send, Call accepts an RPCRequest directly, allowing you to set
+// Session and Txn fields for session-scoped or transaction-scoped operations (SurrealDB v3+).
+func (c *Connection) Call(ctx context.Context, req *connection.RPCRequest) (*connection.RPCResponse[cbor.RawMessage], error) {
 	if c.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, c.Timeout)
@@ -340,20 +351,20 @@ func (c *Connection) Send(ctx context.Context, method string, params ...any) (*c
 	default:
 	}
 
-	id := rand.NewRequestID(constants.RequestIDLength)
-	request := &connection.RPCRequest{
-		ID:     id,
-		Method: method,
-		Params: params,
+	// Set request ID if not already set
+	id := req.ID
+	if id == nil || id == "" {
+		id = rand.NewRequestID(constants.RequestIDLength)
+		req.ID = id
 	}
 
-	responseChan, err := c.CreateResponseChannel(id)
+	responseChan, err := c.CreateResponseChannel(fmt.Sprintf("%v", id))
 	if err != nil {
 		return nil, err
 	}
-	defer c.RemoveResponseChannel(id)
+	defer c.RemoveResponseChannel(fmt.Sprintf("%v", id))
 
-	if err := c.write(request); err != nil {
+	if err := c.write(req); err != nil {
 		return nil, err
 	}
 

--- a/pkg/connection/gws/connection.go
+++ b/pkg/connection/gws/connection.go
@@ -314,6 +314,17 @@ func (c *Connection) CloseLiveNotifications(id string) error {
 
 // Send implements connection.Connection.
 func (c *Connection) Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error) {
+	request := &connection.RPCRequest{
+		Method: method,
+		Params: params,
+	}
+	return c.Call(ctx, request)
+}
+
+// Call implements connection.Connection.
+// Unlike Send, Call accepts an RPCRequest directly, allowing you to set
+// Session and Txn fields for session-scoped or transaction-scoped operations (SurrealDB v3+).
+func (c *Connection) Call(ctx context.Context, req *connection.RPCRequest) (*connection.RPCResponse[cbor.RawMessage], error) {
 	if c.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, c.Timeout)
@@ -328,22 +339,22 @@ func (c *Connection) Send(ctx context.Context, method string, params ...any) (*c
 	default:
 	}
 
-	id := rand.NewRequestID(constants.RequestIDLength)
-	request := &connection.RPCRequest{
-		ID:     id,
-		Method: method,
-		Params: params,
+	// Set request ID if not already set
+	id := req.ID
+	if id == nil || id == "" {
+		id = rand.NewRequestID(constants.RequestIDLength)
+		req.ID = id
 	}
 
-	c.logDebug("Sending RPC request", "id", id, "method", method)
+	c.logDebug("Sending RPC request", "id", id, "method", req.Method)
 
-	responseChan, err := c.CreateResponseChannel(id)
+	responseChan, err := c.CreateResponseChannel(fmt.Sprintf("%v", id))
 	if err != nil {
 		return nil, err
 	}
-	defer c.RemoveResponseChannel(id)
+	defer c.RemoveResponseChannel(fmt.Sprintf("%v", id))
 
-	if err := c.write(request); err != nil {
+	if err := c.write(req); err != nil {
 		return nil, err
 	}
 

--- a/pkg/connection/http/connection.go
+++ b/pkg/connection/http/connection.go
@@ -77,15 +77,34 @@ func (c *Connection) GetUnmarshaler() codec.Unmarshaler {
 }
 
 func (c *Connection) Send(ctx context.Context, method string, params ...any) (*connection.RPCResponse[cbor.RawMessage], error) {
+	request := &connection.RPCRequest{
+		Method: method,
+		Params: params,
+	}
+	return c.Call(ctx, request)
+}
+
+// Call sends a custom RPC request to SurrealDB and expects a response.
+// For HTTP connections, this method returns an error if req.Session or req.Txn is set,
+// as sessions and interactive transactions require WebSocket connections.
+func (c *Connection) Call(ctx context.Context, request *connection.RPCRequest) (*connection.RPCResponse[cbor.RawMessage], error) {
+	// HTTP connections do not support sessions or transactions
+	if request.Session != nil {
+		return nil, constants.ErrSessionsNotSupported
+	}
+	if request.Txn != nil {
+		return nil, constants.ErrTransactionsNotSupported
+	}
+
 	if c.BaseURL == "" {
 		return nil, constants.ErrNoBaseURL
 	}
 
-	request := &connection.RPCRequest{
-		ID:     rand.NewRequestID(constants.RequestIDLength),
-		Method: method,
-		Params: params,
+	// Set request ID if not already set
+	if request.ID == nil || request.ID == "" {
+		request.ID = rand.NewRequestID(constants.RequestIDLength)
 	}
+
 	reqBody, err := c.Marshaler.Marshal(request)
 	if err != nil {
 		return nil, err

--- a/pkg/connection/model.go
+++ b/pkg/connection/model.go
@@ -2,9 +2,9 @@ package connection
 
 // RPCError represents a JSON-RPC error
 type RPCError struct {
-	Code        int    `json:"code" msgpack:"code"`
-	Message     string `json:"message,omitempty" msgpack:"message,omitempty"`
-	Description string `json:"description,omitempty" msgpack:"message,omitempty"`
+	Code        int    `json:"code"`
+	Message     string `json:"message,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 func (r RPCError) Error() string {
@@ -23,27 +23,30 @@ func (r *RPCError) Is(target error) bool {
 	return ok
 }
 
-// RPCRequest represents an incoming JSON-RPC request
+// RPCRequest represents an incoming JSON-RPC request.
+// For SurrealDB v3+, Session and Txn can be set to scope the request to a specific session or transaction.
 type RPCRequest struct {
-	ID     any    `json:"id" msgpack:"id"`
-	Method string `json:"method,omitempty" msgpack:"method,omitempty"`
-	Params []any  `json:"params,omitempty" msgpack:"params,omitempty"`
+	ID      any    `json:"id"`
+	Method  string `json:"method,omitempty"`
+	Params  []any  `json:"params,omitempty"`
+	Session any    `json:"session,omitempty"` // SurrealDB v3: session UUID for session-scoped operations
+	Txn     any    `json:"txn,omitempty"`     // SurrealDB v3: transaction UUID for transaction-scoped operations
 }
 
 // RPCResponse represents an outgoing JSON-RPC response
 type RPCResponse[T any] struct {
 	// ID is the ID of the request this response corresponds to.
 	// Note that this is always nil in case of HTTPConnection.
-	ID     any       `json:"id" msgpack:"id"`
-	Error  *RPCError `json:"error,omitempty" msgpack:"error,omitempty"`
-	Result *T        `json:"result,omitempty" msgpack:"result,omitempty"`
+	ID     any       `json:"id"`
+	Error  *RPCError `json:"error,omitempty"`
+	Result *T        `json:"result,omitempty"`
 }
 
 // RPCNotification represents an outgoing JSON-RPC notification
 type RPCNotification struct {
-	ID     any    `json:"id" msgpack:"id"`
-	Method string `json:"method,omitempty" msgpack:"method,omitempty"`
-	Params []any  `json:"params,omitempty" msgpack:"params,omitempty"`
+	ID     any    `json:"id"`
+	Method string `json:"method,omitempty"`
+	Params []any  `json:"params,omitempty"`
 }
 
 type RPCFunction string
@@ -73,4 +76,11 @@ var (
 	Merge        RPCFunction = "merge"
 	Patch        RPCFunction = "patch"
 	Delete       RPCFunction = "delete"
+
+	// SurrealDB v3+ session and transaction methods
+	Attach RPCFunction = "attach"
+	Detach RPCFunction = "detach"
+	Begin  RPCFunction = "begin"
+	Commit RPCFunction = "commit"
+	Cancel RPCFunction = "cancel"
 )

--- a/pkg/connection/send.go
+++ b/pkg/connection/send.go
@@ -3,14 +3,35 @@ package connection
 import (
 	"context"
 	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
 )
 
+// Send sends a request to SurrealDB using the connection's Send method.
+// It unmarshals the response into the provided res parameter.
 func Send[Result any](c Connection, ctx context.Context, res *RPCResponse[Result], method string, params ...interface{}) error {
 	rawRes, err := c.Send(ctx, method, params...)
 	if err != nil {
 		return err
 	}
 
+	return unmarshalResponse(c, rawRes, res)
+}
+
+// Call sends a custom RPC request to SurrealDB using the connection's Call method.
+// Unlike Send, Call accepts an RPCRequest directly, allowing you to set
+// Session and Txn fields for session-scoped or transaction-scoped operations (SurrealDB v3+).
+func Call[Result any](c Connection, ctx context.Context, res *RPCResponse[Result], req *RPCRequest) error {
+	rawRes, err := c.Call(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	return unmarshalResponse(c, rawRes, res)
+}
+
+// unmarshalResponse is a shared helper to unmarshal the RPC response.
+func unmarshalResponse[Result any](c Connection, rawRes *RPCResponse[cbor.RawMessage], res *RPCResponse[Result]) error {
 	if res == nil {
 		return nil
 	}

--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -16,4 +16,10 @@ var (
 	ErrNoUnmarshaler      = errors.New("unmarshaler is not set")
 	ErrNoNamespaceOrDB    = errors.New("namespace or database or both are not set")
 	ErrMethodNotAvailable = errors.New("method not available on this connection")
+
+	// Session and transaction errors (SurrealDB v3+)
+	ErrSessionsNotSupported     = errors.New("sessions require WebSocket connection")
+	ErrTransactionsNotSupported = errors.New("interactive transactions require WebSocket connection")
+	ErrSessionClosed            = errors.New("session already detached")
+	ErrTransactionClosed        = errors.New("transaction already committed or cancelled")
 )

--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -21,5 +21,5 @@ var (
 	ErrSessionsNotSupported     = errors.New("sessions require WebSocket connection")
 	ErrTransactionsNotSupported = errors.New("interactive transactions require WebSocket connection")
 	ErrSessionClosed            = errors.New("session already detached")
-	ErrTransactionClosed        = errors.New("transaction already committed or cancelled")
+	ErrTransactionClosed        = errors.New("transaction already committed or canceled")
 )

--- a/session.go
+++ b/session.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Session methods intentionally mirror DB methods with similar structure
 package surrealdb
 
 import (
@@ -402,22 +403,7 @@ func (s *Session) CloseLiveNotifications(liveQueryID string) error {
 	return s.db.con.CloseLiveNotifications(liveQueryID)
 }
 
-// connection returns the underlying connection for internal use.
-func (s *Session) connection() connection.Connection {
-	return s.db.con
-}
-
-// sessionID returns the session ID for internal use.
-func (s *Session) sessionID() *models.UUID {
-	return s.id
-}
-
-// txnID returns nil since Session doesn't have a transaction.
-func (s *Session) txnID() *models.UUID {
-	return nil
-}
-
-// isClosed returns whether the session is closed.
+// isClosed returns whether the session is closed (for internal use by send function).
 func (s *Session) isClosed() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/session.go
+++ b/session.go
@@ -1,0 +1,425 @@
+package surrealdb
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gofrs/uuid"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Session represents an additional SurrealDB session on a WebSocket connection.
+// Sessions scope live notifications and can have their own transactions.
+//
+// Sessions are only supported on WebSocket connections (SurrealDB v3+).
+// Each session starts unauthenticated and without a selected namespace/database,
+// so you must call SignIn/Authenticate and Use after creating a session.
+//
+// Session satisfies the sendable constraint, so all surrealdb.Query,
+// surrealdb.Create, etc. functions work with sessions directly.
+type Session struct {
+	db     *DB
+	id     *models.UUID
+	closed bool
+	mu     sync.RWMutex
+}
+
+// Attach creates a new session on the WebSocket connection.
+// Sessions are only supported on WebSocket connections (SurrealDB v3+).
+//
+// The new session starts unauthenticated and without a selected namespace/database.
+// You must call SignIn/Authenticate and Use on the session before making queries.
+//
+// Example:
+//
+//	session, err := db.Attach(ctx)
+//	if err != nil {
+//	    return err
+//	}
+//	defer session.Detach(ctx)
+//
+//	// Authenticate the session
+//	_, err = session.SignIn(ctx, Auth{Username: "root", Password: "root"})
+//	if err != nil {
+//	    return err
+//	}
+//
+//	// Select namespace and database
+//	err = session.Use(ctx, "test", "test")
+//	if err != nil {
+//	    return err
+//	}
+//
+//	// Now the session is ready for queries
+//	results, err := surrealdb.Query[[]User](ctx, session, "SELECT * FROM users", nil)
+func (db *DB) Attach(ctx context.Context) (*Session, error) {
+	// Check if the connection is a WebSocket connection
+	if _, ok := db.con.(connection.WebSocketConnection); !ok {
+		return nil, constants.ErrSessionsNotSupported
+	}
+
+	// Generate a new UUID for the session
+	newUUID, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	sessionID := models.UUID{UUID: newUUID}
+
+	// Send the attach RPC request with the session UUID as a top-level field
+	req := &connection.RPCRequest{
+		Method:  string(connection.Attach),
+		Session: &sessionID,
+	}
+
+	var res connection.RPCResponse[any]
+	if err := connection.Call(db.con, ctx, &res, req); err != nil {
+		return nil, err
+	}
+
+	return &Session{
+		db: db,
+		id: &sessionID,
+	}, nil
+}
+
+// ID returns the session's UUID.
+func (s *Session) ID() *models.UUID {
+	return s.id
+}
+
+// Detach deletes the session from the server.
+// After calling Detach, the session cannot be used anymore.
+func (s *Session) Detach(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return constants.ErrSessionClosed
+	}
+
+	// Send the detach RPC request
+	req := &connection.RPCRequest{
+		Method:  string(connection.Detach),
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[any]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return err
+	}
+
+	s.closed = true
+	return nil
+}
+
+// Begin starts a new interactive transaction in this session.
+// Interactive transactions are only supported on WebSocket connections (SurrealDB v3+).
+func (s *Session) Begin(ctx context.Context) (*Transaction, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return nil, constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	// Send the begin RPC request with the session UUID
+	req := &connection.RPCRequest{
+		Method:  string(connection.Begin),
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[models.UUID]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return nil, err
+	}
+
+	return &Transaction{
+		db:        s.db,
+		id:        res.Result,
+		sessionID: s.id,
+	}, nil
+}
+
+// SignUp signs up a new user in this session.
+func (s *Session) SignUp(ctx context.Context, authData any) (string, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return "", constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.SignUp),
+		Params:  []any{authData},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[string]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return "", err
+	}
+
+	if res.Result == nil {
+		return "", nil
+	}
+	return *res.Result, nil
+}
+
+// SignUpWithRefresh signs up a new user using a TYPE RECORD access method with WITH REFRESH enabled.
+func (s *Session) SignUpWithRefresh(ctx context.Context, authData any) (*Tokens, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return nil, constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.SignUp),
+		Params:  []any{authData},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[Tokens]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return nil, err
+	}
+
+	return res.Result, nil
+}
+
+// SignIn signs in an existing user in this session.
+func (s *Session) SignIn(ctx context.Context, authData any) (string, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return "", constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.SignIn),
+		Params:  []any{authData},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[string]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return "", err
+	}
+
+	if res.Result == nil {
+		return "", nil
+	}
+	return *res.Result, nil
+}
+
+// SignInWithRefresh signs in using a TYPE RECORD access method with WITH REFRESH enabled.
+func (s *Session) SignInWithRefresh(ctx context.Context, authData any) (*Tokens, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return nil, constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.SignIn),
+		Params:  []any{authData},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[Tokens]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return nil, err
+	}
+
+	return res.Result, nil
+}
+
+// Authenticate authenticates the session with the provided token.
+func (s *Session) Authenticate(ctx context.Context, token string) error {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.Authenticate),
+		Params:  []any{token},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[any]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Invalidate invalidates the authentication for this session.
+func (s *Session) Invalidate(ctx context.Context) error {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.Invalidate),
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[any]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Use selects the namespace and database for this session.
+func (s *Session) Use(ctx context.Context, ns, database string) error {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.Use),
+		Params:  []any{ns, database},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[any]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Let sets a variable in this session.
+func (s *Session) Let(ctx context.Context, key string, val any) error {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.Let),
+		Params:  []any{key, val},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[any]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Unset removes a variable from this session.
+func (s *Session) Unset(ctx context.Context, key string) error {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.Unset),
+		Params:  []any{key},
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[any]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Info returns information about the current session state.
+func (s *Session) Info(ctx context.Context) (map[string]any, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return nil, constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	req := &connection.RPCRequest{
+		Method:  string(connection.Info),
+		Session: s.id,
+	}
+
+	var res connection.RPCResponse[map[string]any]
+	if err := connection.Call(s.db.con, ctx, &res, req); err != nil {
+		return nil, err
+	}
+
+	if res.Result == nil {
+		return nil, nil
+	}
+	return *res.Result, nil
+}
+
+// Version returns the SurrealDB version information.
+func (s *Session) Version(ctx context.Context) (*VersionData, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return nil, constants.ErrSessionClosed
+	}
+	s.mu.RUnlock()
+
+	// Version doesn't need session context, but we include it for consistency
+	return s.db.Version(ctx)
+}
+
+// LiveNotifications returns a channel for receiving live query notifications.
+func (s *Session) LiveNotifications(liveQueryID string) (chan connection.Notification, error) {
+	return s.db.con.LiveNotifications(liveQueryID)
+}
+
+// CloseLiveNotifications closes the notification channel for a live query.
+func (s *Session) CloseLiveNotifications(liveQueryID string) error {
+	return s.db.con.CloseLiveNotifications(liveQueryID)
+}
+
+// connection returns the underlying connection for internal use.
+func (s *Session) connection() connection.Connection {
+	return s.db.con
+}
+
+// sessionID returns the session ID for internal use.
+func (s *Session) sessionID() *models.UUID {
+	return s.id
+}
+
+// txnID returns nil since Session doesn't have a transaction.
+func (s *Session) txnID() *models.UUID {
+	return nil
+}
+
+// isClosed returns whether the session is closed.
+func (s *Session) isClosed() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.closed
+}

--- a/session_test.go
+++ b/session_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
+// getVersion gets and checks the SurrealDB version via a separate DB connection
+func getVersion(t *testing.T) *testenv.SurrealDBVersion {
+	t.Helper()
+	db := testenv.MustNew("version_check", "version_check", "dummy")
+	v, err := testenv.GetVersion(context.Background(), db)
+	require.NoError(t, err)
+	_ = db.Close(context.Background())
+	return v
+}
+
 // mustNewWS creates a WebSocket connection for testing.
 // It uses GetSurrealDBWSURL() to always get a WebSocket URL,
 // even if SURREALDB_URL is set to an HTTP URL (e.g., in CI).

--- a/session_test.go
+++ b/session_test.go
@@ -146,7 +146,7 @@ func TestSession_BeginTransaction(t *testing.T) {
 
 	session, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session.Detach(ctx)
+	defer func() { _ = session.Detach(ctx) }()
 
 	// Authenticate and select namespace/database on the session
 	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
@@ -186,7 +186,7 @@ func TestSession_Query(t *testing.T) {
 
 	session, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session.Detach(ctx)
+	defer func() { _ = session.Detach(ctx) }()
 
 	// Authenticate and select namespace/database
 	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
@@ -240,7 +240,7 @@ func TestSession_Isolation_Namespace(t *testing.T) {
 	// Create session 1 pointing to db1
 	session1, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session1.Detach(ctx)
+	defer func() { _ = session1.Detach(ctx) }()
 
 	_, err = session1.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
 	require.NoError(t, err)
@@ -250,7 +250,7 @@ func TestSession_Isolation_Namespace(t *testing.T) {
 	// Create session 2 pointing to db2
 	session2, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session2.Detach(ctx)
+	defer func() { _ = session2.Detach(ctx) }()
 
 	_, err = session2.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
 	require.NoError(t, err)
@@ -300,7 +300,7 @@ func TestSession_Isolation_Variables(t *testing.T) {
 	// Create two sessions
 	session1, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session1.Detach(ctx)
+	defer func() { _ = session1.Detach(ctx) }()
 
 	_, err = session1.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
 	require.NoError(t, err)
@@ -309,7 +309,7 @@ func TestSession_Isolation_Variables(t *testing.T) {
 
 	session2, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session2.Detach(ctx)
+	defer func() { _ = session2.Detach(ctx) }()
 
 	_, err = session2.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
 	require.NoError(t, err)
@@ -355,7 +355,7 @@ func TestSession_CRUD_Query(t *testing.T) {
 
 	session, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session.Detach(ctx)
+	defer func() { _ = session.Detach(ctx) }()
 
 	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
 	require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestSession_CRUD_RPCs(t *testing.T) {
 
 	session, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session.Detach(ctx)
+	defer func() { _ = session.Detach(ctx) }()
 
 	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
 	require.NoError(t, err)

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,487 @@
+package surrealdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// mustNewWS creates a WebSocket connection for testing.
+// It uses GetSurrealDBWSURL() to always get a WebSocket URL,
+// even if SURREALDB_URL is set to an HTTP URL (e.g., in CI).
+// It also defines the specified tables for SurrealDB v3 compatibility.
+func mustNewWS(namespace, database string, tables ...string) *surrealdb.DB {
+	wsURL := testenv.GetSurrealDBWSURL()
+	db, err := surrealdb.FromEndpointURLString(context.Background(), wsURL)
+	if err != nil {
+		panic("Failed to create WebSocket connection: " + err.Error())
+	}
+
+	db, err = testenv.Init(db, namespace, database, tables...)
+	if err != nil {
+		panic("Failed to initialize test environment: " + err.Error())
+	}
+
+	// SurrealDB v3 requires explicit table definitions before use
+	if err = testenv.DefineSchemalessTables(db, tables...); err != nil {
+		panic("Failed to define tables: " + err.Error())
+	}
+
+	return db
+}
+
+// TestSession_Attach tests session creation on WebSocket connections.
+func TestSession_Attach(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	db := mustNewWS("session_test", "attach_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.NoError(t, err, "Attach should succeed on WebSocket connection")
+	require.NotNil(t, session, "Session should not be nil")
+	require.NotNil(t, session.ID(), "Session ID should not be nil")
+
+	t.Logf("Created session with ID: %s", session.ID().String())
+
+	// Clean up
+	err = session.Detach(ctx)
+	require.NoError(t, err, "Detach should succeed")
+}
+
+// TestSession_AttachHTTPError tests that Attach returns an error on HTTP connections.
+func TestSession_AttachHTTPError(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	db := testenv.MustNewHTTP("session_test", "attach_http_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.Error(t, err, "Attach should fail on HTTP connection")
+	assert.ErrorIs(t, err, constants.ErrSessionsNotSupported, "Error should be ErrSessionsNotSupported")
+	assert.Nil(t, session, "Session should be nil on error")
+}
+
+// TestSession_Detach tests session cleanup.
+func TestSession_Detach(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	db := mustNewWS("session_test", "detach_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.NoError(t, err)
+
+	err = session.Detach(ctx)
+	require.NoError(t, err, "Detach should succeed")
+}
+
+// TestSession_DoubleDetach tests that double detach returns an error.
+func TestSession_DoubleDetach(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	db := mustNewWS("session_test", "double_detach_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.NoError(t, err)
+
+	// First detach should succeed
+	err = session.Detach(ctx)
+	require.NoError(t, err)
+
+	// Second detach should fail
+	err = session.Detach(ctx)
+	require.Error(t, err, "Second Detach should fail")
+	assert.ErrorIs(t, err, constants.ErrSessionClosed, "Error should be ErrSessionClosed")
+}
+
+// TestSession_BeginTransaction tests starting a transaction within a session.
+func TestSession_BeginTransaction(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	db := mustNewWS("session_test", "begin_txn_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session.Detach(ctx)
+
+	// Authenticate and select namespace/database on the session
+	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+
+	err = session.Use(ctx, "session_test", "begin_txn_test")
+	require.NoError(t, err)
+
+	// Begin a transaction
+	tx, err := session.Begin(ctx)
+	require.NoError(t, err, "Begin should succeed")
+	require.NotNil(t, tx, "Transaction should not be nil")
+	require.NotNil(t, tx.ID(), "Transaction ID should not be nil")
+	require.NotNil(t, tx.SessionID(), "Transaction SessionID should not be nil")
+	assert.Equal(t, session.ID().String(), tx.SessionID().String(), "Transaction should be associated with the session")
+
+	t.Logf("Created transaction with ID: %s in session: %s", tx.ID().String(), tx.SessionID().String())
+
+	// Cancel the transaction
+	err = tx.Cancel(ctx)
+	require.NoError(t, err)
+}
+
+// TestSession_Query tests executing queries within a session.
+func TestSession_Query(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("session_test", "query_test", "users")
+
+	db := mustNewWS("session_test", "query_test", "users")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session.Detach(ctx)
+
+	// Authenticate and select namespace/database
+	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+
+	err = session.Use(ctx, "session_test", "query_test")
+	require.NoError(t, err)
+
+	type User struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	// Create a user using the session
+	results, err := surrealdb.Query[[]User](ctx, session, "CREATE users:session_user SET name = 'SessionUser'", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Equal(t, "OK", (*results)[0].Status)
+
+	// Select the user
+	selectResults, err := surrealdb.Query[[]User](ctx, session, "SELECT * FROM users", nil)
+	require.NoError(t, err)
+	require.NotNil(t, selectResults)
+	require.Len(t, *selectResults, 1)
+	assert.Equal(t, "OK", (*selectResults)[0].Status)
+	assert.Len(t, (*selectResults)[0].Result, 1)
+	assert.Equal(t, "SessionUser", (*selectResults)[0].Result[0].Name)
+}
+
+// TestSession_Isolation_Namespace tests that sessions can have independent namespace/database selections.
+func TestSession_Isolation_Namespace(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	// Create two different databases
+	_ = mustNewWS("session_isolation", "db1", "items")
+	_ = mustNewWS("session_isolation", "db2", "items")
+
+	db := mustNewWS("session_isolation", "db1", "items")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	// Create item in db1 using the main connection
+	_, err := surrealdb.Query[[]any](ctx, db, "CREATE items:item1 SET source = 'db1'", nil)
+	require.NoError(t, err)
+
+	// Create session 1 pointing to db1
+	session1, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session1.Detach(ctx)
+
+	_, err = session1.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+	err = session1.Use(ctx, "session_isolation", "db1")
+	require.NoError(t, err)
+
+	// Create session 2 pointing to db2
+	session2, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session2.Detach(ctx)
+
+	_, err = session2.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+	err = session2.Use(ctx, "session_isolation", "db2")
+	require.NoError(t, err)
+
+	// Create item in db2 using session2
+	_, err = surrealdb.Query[[]any](ctx, session2, "CREATE items:item2 SET source = 'db2'", nil)
+	require.NoError(t, err)
+
+	type Item struct {
+		ID     string `json:"id"`
+		Source string `json:"source"`
+	}
+
+	// Query from session1 - should only see db1 item
+	results1, err := surrealdb.Query[[]Item](ctx, session1, "SELECT * FROM items", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results1)
+	require.Len(t, *results1, 1)
+	assert.Len(t, (*results1)[0].Result, 1, "Session1 should only see 1 item from db1")
+	assert.Equal(t, "db1", (*results1)[0].Result[0].Source)
+
+	// Query from session2 - should only see db2 item
+	results2, err := surrealdb.Query[[]Item](ctx, session2, "SELECT * FROM items", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results2)
+	require.Len(t, *results2, 1)
+	assert.Len(t, (*results2)[0].Result, 1, "Session2 should only see 1 item from db2")
+	assert.Equal(t, "db2", (*results2)[0].Result[0].Source)
+}
+
+// TestSession_Isolation_Variables tests that sessions can have independent variables.
+func TestSession_Isolation_Variables(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("session_isolation", "var_test", "test_table")
+
+	db := mustNewWS("session_isolation", "var_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	// Create two sessions
+	session1, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session1.Detach(ctx)
+
+	_, err = session1.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+	err = session1.Use(ctx, "session_isolation", "var_test")
+	require.NoError(t, err)
+
+	session2, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session2.Detach(ctx)
+
+	_, err = session2.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+	err = session2.Use(ctx, "session_isolation", "var_test")
+	require.NoError(t, err)
+
+	// Set variable $x in session1
+	err = session1.Let(ctx, "x", "session1_value")
+	require.NoError(t, err)
+
+	// Set different variable $x in session2
+	err = session2.Let(ctx, "x", "session2_value")
+	require.NoError(t, err)
+
+	// Query $x from session1
+	results1, err := surrealdb.Query[string](ctx, session1, "RETURN $x", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results1)
+	require.Len(t, *results1, 1)
+	assert.Equal(t, "session1_value", (*results1)[0].Result, "Session1 should have its own $x value")
+
+	// Query $x from session2
+	results2, err := surrealdb.Query[string](ctx, session2, "RETURN $x", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results2)
+	require.Len(t, *results2, 1)
+	assert.Equal(t, "session2_value", (*results2)[0].Result, "Session2 should have its own $x value")
+}
+
+// TestSession_CRUD_Query tests Create, Select, Update, Delete operations within a session using Query.
+func TestSession_CRUD_Query(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("session_crud", "crud_test", "products")
+
+	db := mustNewWS("session_crud", "crud_test", "products")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session.Detach(ctx)
+
+	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+	err = session.Use(ctx, "session_crud", "crud_test")
+	require.NoError(t, err)
+
+	// SurrealDB v3 requires explicit table definition within the session context
+	defineRes, err := surrealdb.Query[any](ctx, session, "DEFINE TABLE IF NOT EXISTS products SCHEMALESS", nil)
+	require.NoError(t, err)
+	require.NotNil(t, defineRes)
+	require.Len(t, *defineRes, 1)
+	require.Equal(t, "OK", (*defineRes)[0].Status, "DEFINE TABLE should succeed")
+
+	type Product struct {
+		ID    string  `json:"id"`
+		Name  string  `json:"name"`
+		Price float64 `json:"price"`
+	}
+
+	// Create - using Query for reliable behavior in sessions
+	createResults, err := surrealdb.Query[[]Product](ctx, session, "CREATE products:widget SET name = 'Widget', price = 9.99", nil)
+	require.NoError(t, err)
+	require.NotNil(t, createResults)
+	require.Len(t, *createResults, 1)
+	require.Equal(t, "OK", (*createResults)[0].Status, "CREATE should succeed")
+	require.Len(t, (*createResults)[0].Result, 1)
+	assert.Equal(t, "Widget", (*createResults)[0].Result[0].Name)
+	assert.Equal(t, 9.99, (*createResults)[0].Result[0].Price)
+
+	// Select - using Query instead of Select for reliable behavior
+	selectResults, err := surrealdb.Query[[]Product](ctx, session, "SELECT * FROM products:widget", nil)
+	require.NoError(t, err)
+	require.NotNil(t, selectResults)
+	require.Len(t, *selectResults, 1)
+	require.Equal(t, "OK", (*selectResults)[0].Status, "SELECT should succeed")
+	require.Len(t, (*selectResults)[0].Result, 1)
+	assert.Equal(t, "Widget", (*selectResults)[0].Result[0].Name)
+
+	// Update - using Query instead of Update for reliable behavior
+	updateResults, err := surrealdb.Query[[]Product](ctx, session, "UPDATE products:widget SET name = 'Super Widget', price = 19.99", nil)
+	require.NoError(t, err)
+	require.NotNil(t, updateResults)
+	require.Len(t, *updateResults, 1)
+	require.Len(t, (*updateResults)[0].Result, 1)
+	assert.Equal(t, "Super Widget", (*updateResults)[0].Result[0].Name)
+	assert.Equal(t, 19.99, (*updateResults)[0].Result[0].Price)
+
+	// Delete - using Query instead of Delete for reliable behavior
+	deleteResults, err := surrealdb.Query[[]Product](ctx, session, "DELETE products:widget RETURN BEFORE", nil)
+	require.NoError(t, err)
+	require.NotNil(t, deleteResults)
+	require.Len(t, *deleteResults, 1)
+	require.Len(t, (*deleteResults)[0].Result, 1)
+	assert.Equal(t, "Super Widget", (*deleteResults)[0].Result[0].Name)
+
+	// Verify deleted
+	results, err := surrealdb.Query[[]Product](ctx, session, "SELECT * FROM products WHERE id = products:widget", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Empty(t, (*results)[0].Result, "Product should be deleted")
+}
+
+// TestSession_CRUD_RPCs tests Create, Select, Update, Delete operations within a session using RPC methods.
+func TestSession_CRUD_RPCs(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("session_crud_rpc", "crud_rpc_test", "products")
+
+	db := mustNewWS("session_crud_rpc", "crud_rpc_test", "products")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	session, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session.Detach(ctx)
+
+	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+	err = session.Use(ctx, "session_crud_rpc", "crud_rpc_test")
+	require.NoError(t, err)
+
+	// SurrealDB v3 requires explicit table definition within the session context
+	defineRes, err := surrealdb.Query[any](ctx, session, "DEFINE TABLE IF NOT EXISTS products SCHEMALESS", nil)
+	require.NoError(t, err)
+	require.NotNil(t, defineRes)
+	require.Len(t, *defineRes, 1)
+	require.Equal(t, "OK", (*defineRes)[0].Status, "DEFINE TABLE should succeed")
+
+	type Product struct {
+		ID    string  `json:"id"`
+		Name  string  `json:"name"`
+		Price float64 `json:"price"`
+	}
+
+	// Use RecordID for RPC methods
+	recordID := models.NewRecordID("products", "rpc_widget")
+
+	// Create using surrealdb.Create
+	product, err := surrealdb.Create[Product](ctx, session, recordID, map[string]any{
+		"name":  "RPC Widget",
+		"price": 9.99,
+	})
+	require.NoError(t, err, "Create should succeed")
+	require.NotNil(t, product)
+	assert.Equal(t, "RPC Widget", product.Name)
+	assert.Equal(t, 9.99, product.Price)
+
+	// Select using surrealdb.Select
+	selectedProduct, err := surrealdb.Select[Product](ctx, session, recordID)
+	require.NoError(t, err, "Select should succeed")
+	require.NotNil(t, selectedProduct)
+	assert.Equal(t, "RPC Widget", selectedProduct.Name)
+
+	// Update using surrealdb.Update
+	updatedProduct, err := surrealdb.Update[Product](ctx, session, recordID, map[string]any{
+		"name":  "Super RPC Widget",
+		"price": 19.99,
+	})
+	require.NoError(t, err, "Update should succeed")
+	require.NotNil(t, updatedProduct)
+	assert.Equal(t, "Super RPC Widget", updatedProduct.Name)
+	assert.Equal(t, 19.99, updatedProduct.Price)
+
+	// Delete using surrealdb.Delete
+	deletedProduct, err := surrealdb.Delete[Product](ctx, session, recordID)
+	require.NoError(t, err, "Delete should succeed")
+	require.NotNil(t, deletedProduct)
+	assert.Equal(t, "Super RPC Widget", deletedProduct.Name)
+
+	// Verify deleted using surrealdb.Select
+	verifyProduct, err := surrealdb.Select[Product](ctx, session, recordID)
+	require.NoError(t, err, "Select of deleted record should not error")
+	assert.Nil(t, verifyProduct, "Product should be deleted")
+}

--- a/session_transaction_exploration_test.go
+++ b/session_transaction_exploration_test.go
@@ -1,0 +1,1561 @@
+package surrealdb_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/internal/rand"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/connection/gorillaws"
+	surrealhttp "github.com/surrealdb/surrealdb.go/pkg/connection/http"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
+	"github.com/surrealdb/surrealdb.go/pkg/logger"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+	"github.com/surrealdb/surrealdb.go/surrealcbor"
+)
+
+// These tests explore the actual SurrealDB v3 RPC behavior for sessions and transactions.
+// They use low-level connection.Send to understand the exact parameter formats.
+
+// RPCRequestInTransaction is a request that includes a transaction ID.
+// SurrealDB v3 expects the txn field at the top level of the CBOR-encoded request.
+//
+// Transactions are CONNECTION-scoped, not session-scoped. Any session on the same
+// connection can use, commit, or cancel any transaction started on that connection.
+// The txn field specifies which transaction context to use for the operation.
+type RPCRequestInTransaction struct {
+	ID     any    `cbor:"id"`
+	Method string `cbor:"method,omitempty"`
+	Params []any  `cbor:"params,omitempty"`
+	Txn    any    `cbor:"txn,omitempty"`
+}
+
+// RPCRequestInSession is a request that includes a session ID.
+// SurrealDB v3 expects the session field at the top level of the CBOR-encoded request.
+//
+// Sessions scope authentication state, namespace/database selection, and live notifications.
+// New sessions start unauthenticated and must call signin and use before executing queries.
+// Sessions do NOT scope transactions - transactions are connection-scoped.
+type RPCRequestInSession struct {
+	ID      any    `cbor:"id"`
+	Method  string `cbor:"method,omitempty"`
+	Params  []any  `cbor:"params,omitempty"`
+	Session any    `cbor:"session,omitempty"`
+}
+
+// rpcRequestWithSessionTxn is used internally by sendCustomRPC for exploration tests.
+// It supports both session and txn fields, but in practice these are rarely needed together
+// since transactions are connection-scoped (not session-scoped). This struct is primarily
+// useful for testing edge cases like cross-session transaction usage.
+type rpcRequestWithSessionTxn struct {
+	ID      any    `cbor:"id"`
+	Method  string `cbor:"method,omitempty"`
+	Params  []any  `cbor:"params,omitempty"`
+	Session any    `cbor:"session,omitempty"`
+	Txn     any    `cbor:"txn,omitempty"`
+}
+
+// sendCustomRPC sends an RPC request with optional session and txn fields at the top level.
+// This bypasses connection.Send to allow us to include these fields in the CBOR encoding.
+func sendCustomRPC[T any](
+	conn *gorillaws.Connection,
+	ctx context.Context,
+	method string,
+	sessionID any,
+	txnID any,
+	params ...any,
+) (*connection.RPCResponse[T], error) {
+	// Create a unique request ID
+	id := fmt.Sprintf("test-%d", time.Now().UnixNano())
+
+	request := &rpcRequestWithSessionTxn{
+		ID:      id,
+		Method:  method,
+		Params:  params,
+		Session: sessionID,
+		Txn:     txnID,
+	}
+
+	// Create response channel before sending
+	responseChan, err := conn.CreateResponseChannel(id)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.RemoveResponseChannel(id)
+
+	// Marshal and write the request
+	data, err := conn.Marshaler.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Use the underlying gorilla connection to write
+	conn.Conn.WriteMessage(2, data) // 2 = BinaryMessage
+
+	// Wait for response with timeout
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res, open := <-responseChan:
+		if !open {
+			return nil, fmt.Errorf("response channel closed")
+		}
+
+		if res.Error != nil {
+			return nil, res.Error
+		}
+
+		// Unmarshal the result
+		var result T
+		if res.Result != nil {
+			resultData, err := res.Result.MarshalCBOR()
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal result for re-unmarshal: %w", err)
+			}
+			if err := conn.Unmarshaler.Unmarshal(resultData, &result); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal result: %w", err)
+			}
+		}
+
+		return &connection.RPCResponse[T]{
+			ID:     res.ID,
+			Error:  res.Error,
+			Result: &result,
+		}, nil
+	case <-time.After(10 * time.Second):
+		return nil, fmt.Errorf("timeout waiting for response")
+	}
+}
+
+// sendInTransaction sends an RPC request with the txn field at the top level.
+// Convenience wrapper around sendCustomRPC.
+func sendInTransaction[T any](
+	conn *gorillaws.Connection,
+	ctx context.Context,
+	method string,
+	txnID any,
+	params ...any,
+) (*connection.RPCResponse[T], error) {
+	return sendCustomRPC[T](conn, ctx, method, nil, txnID, params...)
+}
+
+// sendInSession sends an RPC request with the session field at the top level.
+// Convenience wrapper around sendCustomRPC.
+func sendInSession[T any](
+	conn *gorillaws.Connection,
+	ctx context.Context,
+	method string,
+	sessionID any,
+	params ...any,
+) (*connection.RPCResponse[T], error) {
+	return sendCustomRPC[T](conn, ctx, method, sessionID, nil, params...)
+}
+
+// setupWSConnection creates a WebSocket connection for testing.
+// Sessions and interactive transactions only work over WebSocket.
+// Returns *gorillaws.Connection to allow access to low-level connection for custom RPC requests.
+func setupWSConnection(t *testing.T, namespace, database string) *gorillaws.Connection {
+	t.Helper()
+
+	c := surrealcbor.New()
+	wsURL := testenv.GetSurrealDBWSURL()
+	conn := gorillaws.New(&connection.Config{
+		BaseURL:     wsURL,
+		Marshaler:   c,
+		Unmarshaler: c,
+		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
+	})
+
+	ctx := context.Background()
+
+	err := conn.Connect(ctx)
+	require.NoError(t, err)
+
+	err = conn.Use(ctx, namespace, database)
+	require.NoError(t, err)
+
+	// Sign in as root
+	var token connection.RPCResponse[string]
+	err = connection.Send(conn, ctx, &token, "signin", map[string]any{
+		"user": "root",
+		"pass": "root",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = conn.Close(ctx)
+	})
+
+	return conn
+}
+
+// setupHTTPConnection creates an HTTP connection for testing.
+// HTTP connections do NOT support sessions or interactive transactions.
+// This is used to verify that session/transaction RPCs fail appropriately over HTTP.
+func setupHTTPConnection(t *testing.T, namespace, database string) *surrealhttp.Connection {
+	t.Helper()
+
+	c := surrealcbor.New()
+	// Derive HTTP URL from WebSocket URL
+	wsURL := testenv.GetSurrealDBWSURL()
+	httpURL := strings.ReplaceAll(wsURL, "ws://", "http://")
+	httpURL = strings.ReplaceAll(httpURL, "wss://", "https://")
+
+	conn := surrealhttp.New(&connection.Config{
+		BaseURL:     httpURL,
+		Marshaler:   c,
+		Unmarshaler: c,
+	})
+
+	ctx := context.Background()
+
+	err := conn.Connect(ctx)
+	require.NoError(t, err)
+
+	err = conn.Use(ctx, namespace, database)
+	require.NoError(t, err)
+
+	// Sign in as root and store the token for HTTP requests
+	var tokenRes connection.RPCResponse[string]
+	err = connection.Send(conn, ctx, &tokenRes, "signin", map[string]any{
+		"user": "root",
+		"pass": "root",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tokenRes.Result)
+
+	// For HTTP connections, we must store the token via Authenticate
+	// so it gets included in the Authorization header
+	err = conn.Authenticate(ctx, *tokenRes.Result)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = conn.Close(ctx)
+	})
+
+	return conn
+}
+
+// httpConnectionInfo holds the information needed to make custom HTTP RPC requests
+// with session and txn fields at the CBOR top level.
+type httpConnectionInfo struct {
+	baseURL   string
+	namespace string
+	database  string
+	token     string
+	marshaler *surrealcbor.Codec
+}
+
+// setupHTTPConnectionInfo creates an HTTP connection and returns the info needed
+// for custom RPC requests. This is used to test session/transaction support over HTTP.
+func setupHTTPConnectionInfo(t *testing.T, namespace, database string) *httpConnectionInfo {
+	t.Helper()
+
+	c := surrealcbor.New()
+	// Derive HTTP URL from WebSocket URL
+	wsURL := testenv.GetSurrealDBWSURL()
+	httpURL := strings.ReplaceAll(wsURL, "ws://", "http://")
+	httpURL = strings.ReplaceAll(httpURL, "wss://", "https://")
+
+	conn := surrealhttp.New(&connection.Config{
+		BaseURL:     httpURL,
+		Marshaler:   c,
+		Unmarshaler: c,
+	})
+
+	ctx := context.Background()
+
+	err := conn.Connect(ctx)
+	require.NoError(t, err)
+
+	err = conn.Use(ctx, namespace, database)
+	require.NoError(t, err)
+
+	// Sign in as root and get the token
+	var tokenRes connection.RPCResponse[string]
+	err = connection.Send(conn, ctx, &tokenRes, "signin", map[string]any{
+		"user": "root",
+		"pass": "root",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tokenRes.Result)
+
+	t.Cleanup(func() {
+		_ = conn.Close(ctx)
+	})
+
+	return &httpConnectionInfo{
+		baseURL:   httpURL,
+		namespace: namespace,
+		database:  database,
+		token:     *tokenRes.Result,
+		marshaler: c,
+	}
+}
+
+// sendCustomHTTPRPC sends an RPC request over HTTP with optional session and txn fields
+// at the top level of the CBOR-encoded request body.
+// This bypasses the standard connection.Send to allow us to include these custom fields.
+func sendCustomHTTPRPC[T any](
+	info *httpConnectionInfo,
+	ctx context.Context,
+	method string,
+	sessionID any,
+	txnID any,
+	params ...any,
+) (*connection.RPCResponse[T], error) {
+	// Create request with session/txn at top level
+	request := &rpcRequestWithSessionTxn{
+		ID:      rand.NewRequestID(constants.RequestIDLength),
+		Method:  method,
+		Params:  params,
+		Session: sessionID,
+		Txn:     txnID,
+	}
+
+	reqBody, err := info.marshaler.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, info.baseURL+"/rpc", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/cbor")
+	req.Header.Set("Content-Type", "application/cbor")
+	req.Header.Set("Surreal-NS", info.namespace)
+	req.Header.Set("Surreal-DB", info.database)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", info.token))
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Unmarshal response
+	var rawRes connection.RPCResponse[T]
+	if err := info.marshaler.Unmarshal(respData, &rawRes); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if rawRes.Error != nil {
+		return nil, rawRes.Error
+	}
+
+	return &rawRes, nil
+}
+
+// sendHTTPInSession sends an RPC request over HTTP with the session field at the top level.
+func sendHTTPInSession[T any](
+	info *httpConnectionInfo,
+	ctx context.Context,
+	method string,
+	sessionID any,
+	params ...any,
+) (*connection.RPCResponse[T], error) {
+	return sendCustomHTTPRPC[T](info, ctx, method, sessionID, nil, params...)
+}
+
+// sendHTTPInTransaction sends an RPC request over HTTP with the txn field at the top level.
+func sendHTTPInTransaction[T any](
+	info *httpConnectionInfo,
+	ctx context.Context,
+	method string,
+	txnID any,
+	params ...any,
+) (*connection.RPCResponse[T], error) {
+	return sendCustomHTTPRPC[T](info, ctx, method, nil, txnID, params...)
+}
+
+// getVersion gets and checks the SurrealDB version via a separate DB connection
+func getVersion(t *testing.T) *testenv.SurrealDBVersion {
+	t.Helper()
+	db := testenv.MustNew("version_check", "version_check", "dummy")
+	v, err := testenv.GetVersion(context.Background(), db)
+	require.NoError(t, err)
+	_ = db.Close(context.Background())
+	return v
+}
+
+// TestExplore_HTTPConnection_Sessions tests whether session RPCs work over HTTP
+// when using custom RPC requests with the session field at the CBOR top level.
+// This test verifies the actual SurrealDB behavior for sessions over HTTP.
+//
+// DISCOVERY: Sessions DO work over HTTP when using custom CBOR requests with
+// the session field at the top level!
+func TestExplore_HTTPConnection_Sessions(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_http", "session_test", "test_table")
+
+	info := setupHTTPConnectionInfo(t, "explore_http", "session_test")
+	ctx := context.Background()
+
+	type queryResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// Test: Full session workflow over HTTP
+	t.Run("full session workflow over HTTP", func(t *testing.T) {
+		sessionUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+		t.Logf("Testing session UUID: %s", sessionUUID.String())
+
+		// Step 1: attach - create session
+		res, err := sendHTTPInSession[any](info, ctx, "attach", &sessionUUID)
+		require.NoError(t, err, "attach should succeed over HTTP")
+		t.Logf("attach succeeded: %+v", res.Result)
+
+		// Step 2: signin on the session
+		signinRes, err := sendHTTPInSession[string](info, ctx, "signin", &sessionUUID,
+			map[string]any{"user": "root", "pass": "root"})
+		require.NoError(t, err, "signin on session should succeed over HTTP")
+		t.Logf("signin on session succeeded, token length: %d", len(*signinRes.Result))
+
+		// Step 3: use namespace/database on the session
+		useRes, err := sendHTTPInSession[any](info, ctx, "use", &sessionUUID,
+			"explore_http", "session_test")
+		require.NoError(t, err, "use on session should succeed over HTTP")
+		t.Logf("use on session succeeded: %+v", useRes.Result)
+
+		// Step 4: query using the session
+		queryRes, err := sendHTTPInSession[[]queryResult](info, ctx, "query", &sessionUUID,
+			"CREATE test_table:http_session SET value = 'created via HTTP session'",
+			map[string]any{})
+		require.NoError(t, err, "query on session should succeed over HTTP")
+		require.NotNil(t, queryRes.Result, "query result should not be nil")
+		require.Len(t, *queryRes.Result, 1, "should have one query result")
+		assert.Equal(t, "OK", (*queryRes.Result)[0].Status, "query should succeed")
+		t.Logf("query on session succeeded: %+v", queryRes.Result)
+
+		// Step 5: detach - delete session
+		detachRes, err := sendHTTPInSession[any](info, ctx, "detach", &sessionUUID)
+		require.NoError(t, err, "detach should succeed over HTTP")
+		t.Logf("detach succeeded: %+v", detachRes.Result)
+
+		// Step 6: Verify session no longer exists
+		_, err = sendHTTPInSession[[]queryResult](info, ctx, "query", &sessionUUID,
+			"SELECT * FROM test_table", map[string]any{})
+		require.Error(t, err, "query with deleted session should fail")
+		assert.Contains(t, err.Error(), "Session not found", "error should indicate session not found")
+		t.Logf("query with deleted session failed as expected: %v", err)
+	})
+
+	// Test: attach without session field (standard Send) - should fail
+	t.Run("attach without session field over HTTP fails", func(t *testing.T) {
+		conn := setupHTTPConnection(t, "explore_http", "session_test")
+		var resAny connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &resAny, "attach")
+		require.Error(t, err, "attach without session field should fail")
+		t.Logf("attach without session field error: %v", err)
+	})
+}
+
+// TestExplore_HTTPConnection_Transactions tests whether transaction RPCs work over HTTP.
+// This test verifies the actual SurrealDB behavior for interactive transactions over HTTP.
+func TestExplore_HTTPConnection_Transactions(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_http", "txn_test", "test_table")
+
+	info := setupHTTPConnectionInfo(t, "explore_http", "txn_test")
+	ctx := context.Background()
+
+	type queryResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// Test: begin RPC over HTTP (doesn't need session/txn field)
+	t.Run("begin over HTTP", func(t *testing.T) {
+		// begin doesn't need session or txn field, so we can use standard request
+		res, err := sendCustomHTTPRPC[models.UUID](info, ctx, "begin", nil, nil)
+		if err != nil {
+			t.Logf("begin over HTTP failed: %v", err)
+			t.Logf("This indicates HTTP does not support interactive transactions")
+		} else {
+			t.Logf("begin over HTTP succeeded! txnID: %+v", res.Result)
+
+			// If begin worked, try to use the transaction for a query
+			txnID := res.Result
+			t.Run("query with txn field over HTTP", func(t *testing.T) {
+				queryRes, err := sendHTTPInTransaction[[]queryResult](info, ctx, "query", txnID,
+					"CREATE test_table:http_txn SET value = 'in transaction'",
+					map[string]any{})
+				if err != nil {
+					t.Logf("query with txn field over HTTP failed: %v", err)
+				} else {
+					t.Logf("query with txn field over HTTP succeeded: %+v", queryRes.Result)
+				}
+			})
+
+			// Try to commit
+			t.Run("commit over HTTP", func(t *testing.T) {
+				commitRes, err := sendCustomHTTPRPC[any](info, ctx, "commit", nil, nil, txnID)
+				if err != nil {
+					t.Logf("commit over HTTP failed: %v", err)
+				} else {
+					t.Logf("commit over HTTP succeeded: %+v", commitRes.Result)
+				}
+			})
+		}
+	})
+
+	// Test: begin with session field (test session+transaction combo)
+	// First attach a session, then try to begin a transaction in that session
+	t.Run("begin with session field over HTTP", func(t *testing.T) {
+		sessionUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+
+		// Step 1: Attach the session first
+		_, err := sendHTTPInSession[any](info, ctx, "attach", &sessionUUID)
+		require.NoError(t, err, "attach should succeed over HTTP")
+
+		// Step 2: Sign in on the session
+		_, err = sendHTTPInSession[string](info, ctx, "signin", &sessionUUID,
+			map[string]any{"user": "root", "pass": "root"})
+		require.NoError(t, err, "signin on session should succeed over HTTP")
+
+		// Step 3: Use namespace/database on the session
+		_, err = sendHTTPInSession[any](info, ctx, "use", &sessionUUID,
+			"explore_http", "txn_test")
+		require.NoError(t, err, "use on session should succeed over HTTP")
+
+		// Step 4: Try to begin a transaction in this session
+		res, err := sendHTTPInSession[models.UUID](info, ctx, "begin", &sessionUUID)
+		if err != nil {
+			t.Logf("begin with session over HTTP failed: %v", err)
+			t.Logf("This confirms interactive transactions are not available over HTTP, even within a valid session")
+		} else {
+			t.Logf("begin with session over HTTP succeeded! txnID: %+v", res.Result)
+			// Clean up transaction
+			_, _ = sendCustomHTTPRPC[any](info, ctx, "cancel", nil, nil, res.Result)
+		}
+
+		// Clean up session
+		_, _ = sendHTTPInSession[any](info, ctx, "detach", &sessionUUID)
+	})
+}
+
+// TestExplore_HTTPConnection_QueryWorks tests that regular queries work over HTTP.
+// This confirms that the HTTP connection is properly set up and only session/transaction
+// RPCs are unsupported.
+func TestExplore_HTTPConnection_QueryWorks(t *testing.T) {
+	_ = testenv.MustNew("explore_http", "query_test", "test_table")
+
+	conn := setupHTTPConnection(t, "explore_http", "query_test")
+	ctx := context.Background()
+
+	// queryResultWithSlice expects Result to be an array (for non-empty results)
+	type queryResultWithSlice struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// queryResultWithAnyResult handles both empty and non-empty results
+	type queryResultWithAnyResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result any    `cbor:"result"`
+	}
+
+	// Test: Regular query should work over HTTP (may return empty result)
+	t.Run("query works over HTTP", func(t *testing.T) {
+		var queryRes connection.RPCResponse[[]queryResultWithAnyResult]
+		err := connection.Send(conn, ctx, &queryRes, "query",
+			"SELECT * FROM test_table", map[string]any{})
+		require.NoError(t, err, "query should succeed over HTTP")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		t.Logf("query over HTTP succeeded: %+v", queryRes.Result)
+	})
+
+	// Test: CREATE should work over HTTP (auto-commits)
+	t.Run("create works over HTTP", func(t *testing.T) {
+		var queryRes connection.RPCResponse[[]queryResultWithSlice]
+		err := connection.Send(conn, ctx, &queryRes, "query",
+			"CREATE test_table:http_test SET value = 'created via HTTP'",
+			map[string]any{})
+		require.NoError(t, err, "CREATE should succeed over HTTP")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		require.Greater(t, len(*queryRes.Result), 0, "should have query result")
+		assert.Equal(t, "OK", (*queryRes.Result)[0].Status, "query should succeed")
+		t.Logf("CREATE over HTTP succeeded: %+v", queryRes.Result)
+	})
+}
+
+// TestExplore_AttachRPC tests the attach RPC method to understand:
+// - What parameters it accepts
+// - What type is returned (UUID? string?)
+// - The Go type mapping
+func TestExplore_AttachRPC(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	// Ensure namespace/database exist
+	_ = testenv.MustNew("explore_sessions", "attach_test", "test_table")
+
+	conn := setupWSConnection(t, "explore_sessions", "attach_test")
+	ctx := context.Background()
+
+	// Test 1: Call attach with no parameters - this should fail with "Expected a session ID"
+	t.Run("attach with no params requires session ID", func(t *testing.T) {
+		var resAny connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &resAny, "attach")
+		require.Error(t, err, "attach without session at top level should fail")
+		assert.Contains(t, err.Error(), "session", "error should mention session")
+	})
+
+	// Test 2: attach with session ID at top-level CBOR field should succeed
+	t.Run("attach with session at top level succeeds", func(t *testing.T) {
+		testUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+		res, err := sendInSession[any](conn, ctx, "attach", &testUUID)
+		require.NoError(t, err, "attach with session at top level should succeed")
+		assert.NotNil(t, res, "response should not be nil")
+		// Clean up
+		_, _ = sendInSession[any](conn, ctx, "detach", &testUUID)
+	})
+
+	// Test 3: attach with session ID as string at top-level CBOR field should also succeed
+	t.Run("attach with session string at top level succeeds", func(t *testing.T) {
+		testUUID := uuid.Must(uuid.NewV4()).String()
+		res, err := sendInSession[any](conn, ctx, "attach", testUUID)
+		require.NoError(t, err, "attach with session string at top level should succeed")
+		assert.NotNil(t, res, "response should not be nil")
+		// Clean up
+		_, _ = sendInSession[any](conn, ctx, "detach", testUUID)
+	})
+
+	// Test 4: Query with non-existent session ID should fail with "Session not found"
+	t.Run("query with non-existent session fails", func(t *testing.T) {
+		testUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+		type queryResult struct {
+			Status string `cbor:"status"`
+			Time   string `cbor:"time"`
+			Result []any  `cbor:"result"`
+		}
+		_, err := sendInSession[[]queryResult](conn, ctx, "query", &testUUID,
+			"SELECT * FROM test_table", map[string]any{})
+		require.Error(t, err, "query with non-existent session should fail")
+		assert.Contains(t, err.Error(), "Session not found", "error should indicate session not found")
+	})
+}
+
+// TestExplore_SessionWorkflow tests the complete session workflow:
+// 1. attach with session ID at top level → creates session
+// 2. query with session ID at top level → uses session
+// 3. detach with session ID at top level → deletes session
+func TestExplore_SessionWorkflow(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_sessions", "workflow_test", "test_table")
+
+	conn := setupWSConnection(t, "explore_sessions", "workflow_test")
+	ctx := context.Background()
+
+	type queryResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// Step 1: Create a session using attach with session at top level
+	sessionUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+	t.Logf("Creating session with UUID: %s", sessionUUID.String())
+
+	t.Run("1. attach creates session", func(t *testing.T) {
+		res, err := sendInSession[any](conn, ctx, "attach", &sessionUUID)
+		if err != nil {
+			t.Fatalf("attach failed: %v", err)
+		}
+		t.Logf("attach succeeded: %+v", res.Result)
+	})
+
+	// Step 1.5: Authenticate the new session (sessions start unauthenticated)
+	t.Run("1.5. signin on session", func(t *testing.T) {
+		res, err := sendInSession[string](conn, ctx, "signin", &sessionUUID,
+			map[string]any{"user": "root", "pass": "root"})
+		if err != nil {
+			t.Fatalf("signin on session failed: %v", err)
+		}
+		t.Logf("signin on session succeeded, token: %s", *res.Result)
+	})
+
+	// Step 1.6: Use namespace/database on the session
+	t.Run("1.6. use on session", func(t *testing.T) {
+		res, err := sendInSession[any](conn, ctx, "use", &sessionUUID,
+			"explore_sessions", "workflow_test")
+		if err != nil {
+			t.Fatalf("use on session failed: %v", err)
+		}
+		t.Logf("use on session succeeded: %+v", res.Result)
+	})
+
+	// Step 2: Use the session for a query
+	t.Run("2. query uses session", func(t *testing.T) {
+		res, err := sendInSession[any](conn, ctx, "query", &sessionUUID,
+			"SELECT * FROM test_table", map[string]any{})
+		require.NoError(t, err, "query with authenticated session should succeed")
+		assert.NotNil(t, res, "response should not be nil")
+	})
+
+	// Step 3: Start a transaction within the session
+	t.Run("3. begin transaction in session", func(t *testing.T) {
+		res, err := sendInSession[models.UUID](conn, ctx, "begin", &sessionUUID)
+		require.NoError(t, err, "begin in session should succeed")
+		require.NotNil(t, res.Result, "begin should return txn UUID")
+		t.Logf("begin in session returned txnID: %+v", res.Result)
+		// Cancel it to clean up
+		_, err = sendInSession[any](conn, ctx, "cancel", &sessionUUID, res.Result)
+		require.NoError(t, err, "cancel should succeed")
+	})
+
+	// Step 4: Detach (delete) the session
+	t.Run("4. detach deletes session", func(t *testing.T) {
+		res, err := sendInSession[any](conn, ctx, "detach", &sessionUUID)
+		if err != nil {
+			t.Fatalf("detach failed: %v", err)
+		}
+		t.Logf("detach succeeded: %+v", res.Result)
+	})
+
+	// Step 5: Verify session no longer exists
+	t.Run("5. query with deleted session fails", func(t *testing.T) {
+		_, err := sendInSession[[]queryResult](conn, ctx, "query", &sessionUUID,
+			"SELECT * FROM test_table", map[string]any{})
+		require.Error(t, err, "query with deleted session should fail")
+		assert.Contains(t, err.Error(), "Session not found", "error should indicate session not found")
+	})
+}
+
+// TestExplore_DetachRPC tests the detach RPC method to understand:
+// - What parameters it expects (session UUID format)
+// - Error behavior for invalid session
+func TestExplore_DetachRPC(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_sessions", "detach_test", "test_table")
+
+	conn := setupWSConnection(t, "explore_sessions", "detach_test")
+	ctx := context.Background()
+
+	// Create a session first using session at top level
+	sessionUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+	res, err := sendInSession[any](conn, ctx, "attach", &sessionUUID)
+	require.NoError(t, err)
+	t.Logf("Created session: %s, result: %+v", sessionUUID.String(), res.Result)
+
+	// Test detach with session at top level succeeds
+	t.Run("detach with session at top level succeeds", func(t *testing.T) {
+		res, err := sendInSession[any](conn, ctx, "detach", &sessionUUID)
+		require.NoError(t, err, "detach with session at top level should succeed")
+		assert.NotNil(t, res, "response should not be nil")
+	})
+
+	// Create another session for testing double detach
+	sessionUUID2 := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+	_, err = sendInSession[any](conn, ctx, "attach", &sessionUUID2)
+	require.NoError(t, err)
+
+	// Detach it
+	_, err = sendInSession[any](conn, ctx, "detach", &sessionUUID2)
+	require.NoError(t, err)
+
+	// Test double detach - SurrealDB allows double detach (idempotent behavior)
+	t.Run("double detach is idempotent", func(t *testing.T) {
+		_, err := sendInSession[any](conn, ctx, "detach", &sessionUUID2)
+		// SurrealDB allows double detach - this is idempotent behavior
+		assert.NoError(t, err, "double detach should be allowed (idempotent)")
+	})
+}
+
+// TestExplore_BeginRPC tests the begin RPC method to understand:
+// - What parameters it accepts
+// - What type is returned (transaction UUID)
+// - How session parameter works
+func TestExplore_BeginRPC(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_txn", "begin_test", "test_table")
+
+	conn := setupWSConnection(t, "explore_txn", "begin_test")
+	ctx := context.Background()
+
+	// Test 1: Begin transaction on default session returns models.UUID
+	t.Run("begin on default session returns UUID", func(t *testing.T) {
+		var resUUID connection.RPCResponse[models.UUID]
+		err := connection.Send(conn, ctx, &resUUID, "begin")
+		require.NoError(t, err, "begin should succeed")
+		require.NotNil(t, resUUID.Result, "begin should return a UUID")
+		t.Logf("begin returned models.UUID: %+v", resUUID.Result)
+		// Cancel it to clean up
+		var cancelRes connection.RPCResponse[any]
+		err = connection.Send(conn, ctx, &cancelRes, "cancel", resUUID.Result)
+		require.NoError(t, err, "cancel should succeed")
+	})
+
+	// Test 2: Verify the raw type returned by begin is models.UUID
+	t.Run("begin returns models.UUID type", func(t *testing.T) {
+		var resAny connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &resAny, "begin")
+		require.NoError(t, err, "begin should succeed")
+		require.NotNil(t, resAny.Result, "begin should return a value")
+		_, ok := (*resAny.Result).(models.UUID)
+		assert.True(t, ok, "begin should return models.UUID type, got %T", *resAny.Result)
+		// Cancel to clean up
+		var cancelRes connection.RPCResponse[any]
+		_ = connection.Send(conn, ctx, &cancelRes, "cancel", *resAny.Result)
+	})
+
+	// Test 3: Begin with session parameter succeeds
+	t.Run("begin with session at top level succeeds", func(t *testing.T) {
+		// Create a session using session at top-level CBOR field
+		sessionUUID := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+		_, err := sendInSession[any](conn, ctx, "attach", &sessionUUID)
+		require.NoError(t, err, "attach should succeed")
+
+		// Begin with session at top level
+		beginRes, err := sendInSession[models.UUID](conn, ctx, "begin", &sessionUUID)
+		require.NoError(t, err, "begin with session at top level should succeed")
+		require.NotNil(t, beginRes.Result, "begin should return txn UUID")
+		t.Logf("begin with session returned: %+v", beginRes.Result)
+
+		// Cancel the transaction
+		var cancelRes connection.RPCResponse[any]
+		err = connection.Send(conn, ctx, &cancelRes, "cancel", beginRes.Result)
+		require.NoError(t, err, "cancel should succeed")
+
+		// Clean up session
+		_, _ = sendInSession[any](conn, ctx, "detach", &sessionUUID)
+	})
+}
+
+// TestExplore_CommitRPC tests the commit RPC method to understand:
+// - Parameter format (txn key in map, or direct param)
+func TestExplore_CommitRPC(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_txn", "commit_test", "test_table")
+
+	conn := setupWSConnection(t, "explore_txn", "commit_test")
+	ctx := context.Background()
+
+	// Start a transaction to get txn ID
+	var beginRes connection.RPCResponse[any]
+	err := connection.Send(conn, ctx, &beginRes, "begin")
+	require.NoError(t, err)
+	txnID := *beginRes.Result
+	t.Logf("Transaction ID: %+v (type: %T)", txnID, txnID)
+
+	// Test commit with txn in map fails (wrong format)
+	t.Run("commit with txn in map fails", func(t *testing.T) {
+		var commitRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &commitRes, "commit", map[string]any{"txn": txnID})
+		require.Error(t, err, "commit with txn in map should fail")
+		assert.Contains(t, err.Error(), "transaction", "error should mention transaction")
+	})
+
+	// Start another transaction for testing direct param
+	err = connection.Send(conn, ctx, &beginRes, "begin")
+	require.NoError(t, err)
+	txnID = *beginRes.Result
+
+	// Test commit with direct param succeeds (correct format)
+	t.Run("commit with direct param succeeds", func(t *testing.T) {
+		var commitRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &commitRes, "commit", txnID)
+		require.NoError(t, err, "commit with direct param should succeed")
+	})
+}
+
+// TestExplore_CancelRPC tests the cancel RPC method to understand:
+// - Parameter format (params array vs map)
+func TestExplore_CancelRPC(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_txn", "cancel_test", "test_table")
+
+	conn := setupWSConnection(t, "explore_txn", "cancel_test")
+	ctx := context.Background()
+
+	// Start a transaction to cancel
+	var beginRes connection.RPCResponse[any]
+	err := connection.Send(conn, ctx, &beginRes, "begin")
+	require.NoError(t, err)
+	txnID := *beginRes.Result
+	t.Logf("Transaction ID: %+v (type: %T)", txnID, txnID)
+
+	// Test cancel with direct param succeeds (correct format)
+	t.Run("cancel with direct param succeeds", func(t *testing.T) {
+		var cancelRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+		require.NoError(t, err, "cancel with direct param should succeed")
+	})
+
+	// Start another transaction for testing map format
+	err = connection.Send(conn, ctx, &beginRes, "begin")
+	require.NoError(t, err)
+	txnID = *beginRes.Result
+
+	// Test cancel with txn in map fails (wrong format)
+	t.Run("cancel with txn in map fails", func(t *testing.T) {
+		var cancelRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &cancelRes, "cancel", map[string]any{"txn": txnID})
+		require.Error(t, err, "cancel with txn in map should fail")
+		assert.Contains(t, err.Error(), "transaction", "error should mention transaction")
+	})
+}
+
+// TestExplore_TransactionIsolation tests if transaction isolation works as expected
+func TestExplore_TransactionIsolation(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_txn", "isolation_test", "users")
+
+	conn := setupWSConnection(t, "explore_txn", "isolation_test")
+	ctx := context.Background()
+
+	// queryResultWithAnyResult handles both empty and non-empty results
+	// SurrealDB may return Result as an empty string when no records exist
+	type queryResultWithAnyResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result any    `cbor:"result"`
+	}
+
+	// Start a transaction
+	var beginRes connection.RPCResponse[models.UUID]
+	err := connection.Send(conn, ctx, &beginRes, "begin")
+	require.NoError(t, err)
+	txnID := beginRes.Result
+	t.Logf("Transaction ID: %+v", txnID)
+
+	// Test: Query with txn as positional param fails (wrong format - documented behavior)
+	t.Run("query with txn as positional param fails", func(t *testing.T) {
+		var queryRes connection.RPCResponse[[]queryResultWithAnyResult]
+		err := connection.Send(conn, ctx, &queryRes, "query",
+			"CREATE users:alice SET name = 'Alice'",
+			map[string]any{},
+			txnID)
+		// This fails because txn should be at top-level CBOR field, not positional param
+		require.Error(t, err, "query with txn as positional param should fail")
+		assert.Contains(t, err.Error(), "query", "error should be about query format")
+	})
+
+	// Test: Query with txn at top level succeeds (correct format)
+	t.Run("query with txn at top level succeeds", func(t *testing.T) {
+		res, err := sendInTransaction[[]queryResultWithAnyResult](conn, ctx, "query", txnID,
+			"CREATE users:alice SET name = 'Alice'",
+			map[string]any{})
+		require.NoError(t, err, "query with txn at top level should succeed")
+		require.NotNil(t, res.Result, "result should not be nil")
+	})
+
+	// Test: Check if data is visible before commit FROM A DIFFERENT CONNECTION
+	t.Run("uncommitted data not visible from other connection", func(t *testing.T) {
+		conn2 := setupWSConnection(t, "explore_txn", "isolation_test")
+		var queryRes connection.RPCResponse[[]queryResultWithAnyResult]
+		err := connection.Send(conn2, ctx, &queryRes, "query",
+			"SELECT * FROM users", map[string]any{})
+		require.NoError(t, err, "SELECT query should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		require.Greater(t, len(*queryRes.Result), 0, "should have query result")
+		// Result can be empty slice, empty string, or populated slice
+		result := (*queryRes.Result)[0].Result
+		count := 0
+		if arr, ok := result.([]any); ok {
+			count = len(arr)
+		}
+		assert.Equal(t, 0, count, "uncommitted data should not be visible from other connection")
+	})
+
+	// Cancel the transaction and verify rollback
+	t.Run("cancel rolls back data", func(t *testing.T) {
+		var cancelRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+		require.NoError(t, err, "cancel should succeed")
+
+		// Verify data is rolled back by checking from another connection
+		conn3 := setupWSConnection(t, "explore_txn", "isolation_test")
+		var queryRes connection.RPCResponse[[]queryResultWithAnyResult]
+		err = connection.Send(conn3, ctx, &queryRes, "query",
+			"SELECT * FROM users", map[string]any{})
+		require.NoError(t, err, "SELECT query should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		require.Greater(t, len(*queryRes.Result), 0, "should have query result")
+		// Result can be empty slice, empty string, or populated slice
+		result := (*queryRes.Result)[0].Result
+		count := 0
+		if arr, ok := result.([]any); ok {
+			count = len(arr)
+		}
+		assert.Equal(t, 0, count, "data should be rolled back after cancel")
+	})
+}
+
+// TestExplore_TransactionAutoCommit tests if transactions without txn param auto-commit
+func TestExplore_TransactionAutoCommit(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_txn", "autocommit_test", "items")
+
+	conn := setupWSConnection(t, "explore_txn", "autocommit_test")
+	ctx := context.Background()
+
+	// queryResultWithSlice expects Result to be an array (for non-empty results)
+	type queryResultWithSlice struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// queryResultWithAnyResult handles both empty and non-empty results
+	type queryResultWithAnyResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result any    `cbor:"result"`
+	}
+
+	t.Run("query without txn param auto-commits", func(t *testing.T) {
+		// Create without txn param - should auto-commit
+		var queryRes connection.RPCResponse[[]queryResultWithSlice]
+		err := connection.Send(conn, ctx, &queryRes, "query",
+			"CREATE items:test1 SET value = 100",
+			map[string]any{})
+		require.NoError(t, err, "CREATE without txn should succeed and auto-commit")
+
+		// Check from another connection - should be visible
+		conn2 := setupWSConnection(t, "explore_txn", "autocommit_test")
+		err = connection.Send(conn2, ctx, &queryRes, "query",
+			"SELECT * FROM items", map[string]any{})
+		require.NoError(t, err, "SELECT from another connection should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		require.Greater(t, len(*queryRes.Result), 0, "should have query result")
+		assert.Greater(t, len((*queryRes.Result)[0].Result), 0, "auto-committed data should be visible from other connection")
+	})
+
+	t.Run("begin with txn at top level then cancel rolls back", func(t *testing.T) {
+		// Clean up first
+		var cleanRes connection.RPCResponse[any]
+		_ = connection.Send(conn, ctx, &cleanRes, "query", "DELETE items", map[string]any{})
+
+		// Start transaction
+		var beginRes connection.RPCResponse[models.UUID]
+		err := connection.Send(conn, ctx, &beginRes, "begin")
+		require.NoError(t, err, "begin should succeed")
+		txnID := beginRes.Result
+		require.NotNil(t, txnID, "begin should return txn UUID")
+
+		// Create using txn at top level (correct format)
+		res, err := sendInTransaction[[]queryResultWithSlice](conn, ctx, "query", txnID,
+			"CREATE items:test2 SET value = 200",
+			map[string]any{})
+		require.NoError(t, err, "CREATE with txn at top level should succeed")
+		require.NotNil(t, res.Result, "result should not be nil")
+
+		// Cancel
+		var cancelRes connection.RPCResponse[any]
+		err = connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+		require.NoError(t, err, "cancel should succeed")
+
+		// Check after cancel - item should not exist (rolled back)
+		// Use queryResultWithAnyResult since Result can be empty string when no records
+		var queryRes connection.RPCResponse[[]queryResultWithAnyResult]
+		err = connection.Send(conn, ctx, &queryRes, "query",
+			"SELECT * FROM items WHERE id = items:test2",
+			map[string]any{})
+		require.NoError(t, err, "SELECT query should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		require.Greater(t, len(*queryRes.Result), 0, "should have query result")
+		// Result can be empty slice, empty string, or populated slice
+		result := (*queryRes.Result)[0].Result
+		count := 0
+		if arr, ok := result.([]any); ok {
+			count = len(arr)
+		}
+		assert.Equal(t, 0, count, "cancelled transaction data should be rolled back")
+	})
+}
+
+// TestExplore_CRUDInTransaction tests CRUD operations within a transaction
+func TestExplore_CRUDInTransaction(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_crud_txn", "crud_test", "products")
+
+	conn := setupWSConnection(t, "explore_crud_txn", "crud_test")
+	ctx := context.Background()
+
+	// Start transaction
+	var beginRes connection.RPCResponse[any]
+	err := connection.Send(conn, ctx, &beginRes, "begin")
+	require.NoError(t, err)
+	txnID := *beginRes.Result
+	t.Logf("Transaction ID: %+v (type: %T)", txnID, txnID)
+
+	// Test: create RPC within transaction using txn map (expected to fail - txn must be top-level)
+	t.Run("create with txn map param fails", func(t *testing.T) {
+		// Try create with txn as last param (map) - this should fail because txn must be top-level CBOR field
+		var createRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &createRes, "create",
+			"products:widget",
+			map[string]any{"name": "Widget", "price": 9.99},
+			map[string]any{"txn": txnID})
+		// The create itself may succeed but won't be in the transaction context
+		// Log the result for information
+		t.Logf("create with txn map: err=%v, result=%+v", err, createRes.Result)
+	})
+
+	// Test: select RPC within transaction using txn map (expected to not use transaction context)
+	t.Run("select with txn map param", func(t *testing.T) {
+		var selectRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &selectRes, "select",
+			"products",
+			map[string]any{"txn": txnID})
+		// The select may succeed but won't be in the transaction context
+		t.Logf("select with txn map: err=%v, result=%+v", err, selectRes.Result)
+	})
+
+	// Test: update RPC within transaction using txn map (expected to not use transaction context)
+	t.Run("update with txn map param", func(t *testing.T) {
+		var updateRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &updateRes, "update",
+			"products:widget",
+			map[string]any{"name": "Super Widget", "price": 19.99},
+			map[string]any{"txn": txnID})
+		// The update may succeed but won't be in the transaction context
+		t.Logf("update with txn map: err=%v, result=%+v", err, updateRes.Result)
+	})
+
+	// Cancel to clean up - this should succeed
+	t.Run("cancel transaction", func(t *testing.T) {
+		var cancelRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+		require.NoError(t, err, "cancel with direct txnID param should succeed")
+	})
+}
+
+// TestExplore_QueryWithTxnTopLevel tests query with txn as a top-level CBOR field
+// This is the key test to verify that SurrealDB v3 expects txn at the request level, not in params
+func TestExplore_QueryWithTxnTopLevel(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_txn_toplevel", "txn_toplevel_test", "records")
+
+	conn := setupWSConnection(t, "explore_txn_toplevel", "txn_toplevel_test")
+	ctx := context.Background()
+
+	type queryResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// Start a transaction
+	var beginRes connection.RPCResponse[models.UUID]
+	err := connection.Send(conn, ctx, &beginRes, "begin")
+	require.NoError(t, err)
+	txnID := beginRes.Result
+	t.Logf("Transaction ID: %+v (type: %T)", txnID, txnID)
+
+	// Test: Create record using txn as top-level CBOR field
+	t.Run("create with txn at top level", func(t *testing.T) {
+		res, err := sendInTransaction[[]queryResult](
+			conn, ctx, "query", txnID,
+			"CREATE records:test1 SET value = 'created in txn'",
+			map[string]any{},
+		)
+		require.NoError(t, err, "CREATE with txn top-level should succeed")
+		require.NotNil(t, res.Result, "result should not be nil")
+		require.Len(t, *res.Result, 1, "should have one query result")
+		assert.Equal(t, "OK", (*res.Result)[0].Status, "query should succeed")
+		t.Logf("CREATE with txn top-level succeeded: %+v", res.Result)
+	})
+
+	// Test: Select within transaction using txn at top level
+	t.Run("select with txn at top level", func(t *testing.T) {
+		res, err := sendInTransaction[[]queryResult](
+			conn, ctx, "query", txnID,
+			"SELECT * FROM records",
+			map[string]any{},
+		)
+		require.NoError(t, err, "SELECT with txn top-level should succeed")
+		require.NotNil(t, res.Result, "result should not be nil")
+		require.Len(t, *res.Result, 1, "should have one query result")
+		assert.Equal(t, "OK", (*res.Result)[0].Status, "query should succeed")
+		assert.Len(t, (*res.Result)[0].Result, 1, "should see 1 record within transaction")
+		t.Logf("SELECT with txn top-level result: %+v", res.Result)
+	})
+
+	// Test: Check isolation - select from DIFFERENT connection should NOT see uncommitted data
+	t.Run("select from different connection should not see uncommitted", func(t *testing.T) {
+		// Use a different connection to check isolation
+		conn2 := setupWSConnection(t, "explore_txn_toplevel", "txn_toplevel_test")
+
+		var queryRes connection.RPCResponse[any]
+		err := connection.Send(conn2, ctx, &queryRes, "query",
+			"SELECT * FROM records",
+			map[string]any{})
+		require.NoError(t, err, "SELECT from conn2 should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+
+		// Parse the result to get count
+		results, ok := (*queryRes.Result).([]any)
+		require.True(t, ok, "result should be an array")
+		require.Len(t, results, 1, "should have one query result")
+
+		firstResult, ok := results[0].(map[string]any)
+		require.True(t, ok, "first result should be a map")
+
+		resultArr, ok := firstResult["result"].([]any)
+		count := 0
+		if ok {
+			count = len(resultArr)
+		}
+		assert.Equal(t, 0, count, "uncommitted data should not be visible from different connection (isolation)")
+		t.Logf("SELECT from different connection count: %d", count)
+	})
+
+	// Test: Cancel and verify rollback
+	t.Run("cancel and verify rollback", func(t *testing.T) {
+		var cancelRes connection.RPCResponse[any]
+		err := connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+		require.NoError(t, err, "cancel should succeed")
+		t.Logf("Transaction cancelled")
+
+		// Check data is rolled back - use a different connection to avoid any session state issues
+		conn3 := setupWSConnection(t, "explore_txn_toplevel", "txn_toplevel_test")
+		var queryRes connection.RPCResponse[any]
+		err = connection.Send(conn3, ctx, &queryRes, "query",
+			"SELECT * FROM records",
+			map[string]any{})
+		require.NoError(t, err, "SELECT after cancel should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+
+		// Parse the result to get count
+		results, ok := (*queryRes.Result).([]any)
+		require.True(t, ok, "result should be an array")
+		require.Len(t, results, 1, "should have one query result")
+
+		firstResult, ok := results[0].(map[string]any)
+		require.True(t, ok, "first result should be a map")
+
+		resultArr, ok := firstResult["result"].([]any)
+		count := 0
+		if ok {
+			count = len(resultArr)
+		}
+		assert.Equal(t, 0, count, "cancelled transaction data should be rolled back")
+		t.Logf("SELECT after cancel count: %d", count)
+	})
+
+	// Test: New transaction with commit
+	t.Run("create and commit with txn at top level", func(t *testing.T) {
+		// Start new transaction
+		var beginRes2 connection.RPCResponse[models.UUID]
+		err := connection.Send(conn, ctx, &beginRes2, "begin")
+		require.NoError(t, err, "begin should succeed")
+		txnID2 := beginRes2.Result
+		require.NotNil(t, txnID2, "transaction ID should not be nil")
+		t.Logf("New Transaction ID: %+v", txnID2)
+
+		// Create using txn at top level
+		res, err := sendInTransaction[[]queryResult](
+			conn, ctx, "query", txnID2,
+			"CREATE records:committed SET value = 'will be committed'",
+			map[string]any{},
+		)
+		require.NoError(t, err, "CREATE in transaction should succeed")
+		require.NotNil(t, res.Result, "result should not be nil")
+		t.Logf("CREATE succeeded: %+v", res.Result)
+
+		// Commit
+		var commitRes connection.RPCResponse[any]
+		err = connection.Send(conn, ctx, &commitRes, "commit", txnID2)
+		require.NoError(t, err, "commit should succeed")
+		t.Logf("Transaction committed")
+
+		// Verify data persisted
+		var queryRes connection.RPCResponse[[]queryResult]
+		err = connection.Send(conn, ctx, &queryRes, "query",
+			"SELECT * FROM records",
+			map[string]any{})
+		require.NoError(t, err, "SELECT after commit should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		require.Len(t, *queryRes.Result, 1, "should have one query result")
+
+		count := len((*queryRes.Result)[0].Result)
+		assert.Equal(t, 1, count, "committed data should be visible")
+		t.Logf("SELECT after commit count: %d", count)
+	})
+}
+
+// TestExplore_MultipleTransactions tests multiple sequential transactions
+// Note: Concurrent transactions on the same connection may conflict even when writing to different records.
+// This is due to SurrealDB's optimistic concurrency control.
+// Uses the correct parameter formats discovered in Phase 1:
+// - txn at top-level CBOR field for queries
+// - txn as direct param for commit/cancel
+func TestExplore_MultipleTransactions(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_multi_txn", "multi_txn_test", "accounts")
+
+	conn := setupWSConnection(t, "explore_multi_txn", "multi_txn_test")
+	ctx := context.Background()
+
+	type queryResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// Test sequential transactions - first transaction
+	t.Run("first transaction creates and commits", func(t *testing.T) {
+		var begin1Res connection.RPCResponse[models.UUID]
+		err := connection.Send(conn, ctx, &begin1Res, "begin")
+		require.NoError(t, err, "begin txn1 should succeed")
+		txn1 := begin1Res.Result
+		require.NotNil(t, txn1, "txn1 ID should not be nil")
+		t.Logf("Transaction 1: %+v", txn1)
+
+		// Write in txn1 using txn at top level
+		res1, err := sendInTransaction[[]queryResult](conn, ctx, "query", txn1,
+			"CREATE accounts:a SET balance = 100",
+			map[string]any{})
+		require.NoError(t, err, "CREATE in txn1 should succeed")
+		require.NotNil(t, res1.Result, "txn1 result should not be nil")
+		t.Logf("Create in txn1: result=%+v", res1)
+
+		// Commit txn1
+		var commit1Res connection.RPCResponse[any]
+		err = connection.Send(conn, ctx, &commit1Res, "commit", txn1)
+		require.NoError(t, err, "commit txn1 should succeed")
+		t.Logf("Commit txn1: success")
+	})
+
+	// Test sequential transactions - second transaction
+	t.Run("second transaction creates and commits", func(t *testing.T) {
+		var begin2Res connection.RPCResponse[models.UUID]
+		err := connection.Send(conn, ctx, &begin2Res, "begin")
+		require.NoError(t, err, "begin txn2 should succeed")
+		txn2 := begin2Res.Result
+		require.NotNil(t, txn2, "txn2 ID should not be nil")
+		t.Logf("Transaction 2: %+v", txn2)
+
+		// Write in txn2 using txn at top level
+		res2, err := sendInTransaction[[]queryResult](conn, ctx, "query", txn2,
+			"CREATE accounts:b SET balance = 200",
+			map[string]any{})
+		require.NoError(t, err, "CREATE in txn2 should succeed")
+		require.NotNil(t, res2.Result, "txn2 result should not be nil")
+		t.Logf("Create in txn2: result=%+v", res2)
+
+		// Commit txn2
+		var commit2Res connection.RPCResponse[any]
+		err = connection.Send(conn, ctx, &commit2Res, "commit", txn2)
+		require.NoError(t, err, "commit txn2 should succeed")
+		t.Logf("Commit txn2: success")
+	})
+
+	// Verify both records exist
+	t.Run("verify both records exist", func(t *testing.T) {
+		var queryRes connection.RPCResponse[[]queryResult]
+		err := connection.Send(conn, ctx, &queryRes, "query",
+			"SELECT * FROM accounts", map[string]any{})
+		require.NoError(t, err, "final SELECT should succeed")
+		require.NotNil(t, queryRes.Result, "result should not be nil")
+		require.Len(t, *queryRes.Result, 1, "should have one query result")
+
+		count := len((*queryRes.Result)[0].Result)
+		assert.Equal(t, 2, count, "both transactions' data should be visible after commit")
+		t.Logf("Final SELECT count: %d", count)
+	})
+}
+
+// TestExplore_TransactionOwnership tests what happens when trying to use a transaction
+// started in one session from another session (transaction takeover attempt).
+func TestExplore_TransactionOwnership(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions/transactions (requires v3+)", v)
+	}
+
+	_ = testenv.MustNew("explore_txn_ownership", "ownership_test", "items")
+
+	conn := setupWSConnection(t, "explore_txn_ownership", "ownership_test")
+	ctx := context.Background()
+
+	type queryResult struct {
+		Status string `cbor:"status"`
+		Time   string `cbor:"time"`
+		Result []any  `cbor:"result"`
+	}
+
+	// Create two sessions
+	session1 := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+	session2 := models.UUID{UUID: uuid.Must(uuid.NewV4())}
+
+	// Setup session 1
+	_, err := sendInSession[any](conn, ctx, "attach", &session1)
+	require.NoError(t, err, "attach session1 should succeed")
+	_, err = sendInSession[string](conn, ctx, "signin", &session1,
+		map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err, "signin session1 should succeed")
+	_, err = sendInSession[any](conn, ctx, "use", &session1,
+		"explore_txn_ownership", "ownership_test")
+	require.NoError(t, err, "use session1 should succeed")
+
+	// Setup session 2
+	_, err = sendInSession[any](conn, ctx, "attach", &session2)
+	require.NoError(t, err, "attach session2 should succeed")
+	_, err = sendInSession[string](conn, ctx, "signin", &session2,
+		map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err, "signin session2 should succeed")
+	_, err = sendInSession[any](conn, ctx, "use", &session2,
+		"explore_txn_ownership", "ownership_test")
+	require.NoError(t, err, "use session2 should succeed")
+
+	t.Logf("Session 1: %s", session1.String())
+	t.Logf("Session 2: %s", session2.String())
+
+	// Start a transaction in session 1
+	t.Run("start transaction in session 1", func(t *testing.T) {
+		beginRes, err := sendInSession[models.UUID](conn, ctx, "begin", &session1)
+		require.NoError(t, err, "begin in session1 should succeed")
+		require.NotNil(t, beginRes.Result, "begin should return txn UUID")
+		txnID := beginRes.Result
+		t.Logf("Transaction started in session1: %+v", txnID)
+
+		// Create a record in the transaction using session 1
+		res, err := sendCustomRPC[[]queryResult](conn, ctx, "query", &session1, txnID,
+			"CREATE items:test1 SET value = 'from session1'",
+			map[string]any{})
+		require.NoError(t, err, "CREATE in session1's txn should succeed")
+		require.NotNil(t, res.Result, "result should not be nil")
+		t.Logf("Created in session1's txn: %+v", res.Result)
+
+		// Try to use the same transaction from session 2 (takeover attempt)
+		// DISCOVERY: SurrealDB allows this! Transactions are connection-scoped, not session-scoped.
+		t.Run("session 2 can use session 1's transaction", func(t *testing.T) {
+			res2, err := sendCustomRPC[[]queryResult](conn, ctx, "query", &session2, txnID,
+				"CREATE items:test2 SET value = 'from session2 takeover'",
+				map[string]any{})
+			// SurrealDB allows cross-session transaction usage
+			require.NoError(t, err, "transaction takeover should be allowed (transactions are connection-scoped)")
+			require.NotNil(t, res2.Result, "result should not be nil")
+			t.Logf("Session2 using session1's txn succeeded: %+v", res2.Result)
+		})
+
+		// Try to commit the transaction from session 2
+		// DISCOVERY: SurrealDB allows this! Any session can commit/cancel any transaction on the connection.
+		t.Run("session 2 can commit session 1's transaction", func(t *testing.T) {
+			// Note: commit/cancel use direct param, not session context
+			res, err := sendInSession[any](conn, ctx, "commit", &session2, txnID)
+			require.NoError(t, err, "cross-session commit should be allowed")
+			t.Logf("Session2 committed session1's txn: %+v", res.Result)
+		})
+
+		// Try to cancel from session 1 (original owner) after session 2 committed
+		// DISCOVERY: Transaction is already committed, so cancel fails with "Transaction not found"
+		t.Run("session 1 cancel fails after commit", func(t *testing.T) {
+			_, err := sendInSession[any](conn, ctx, "cancel", &session1, txnID)
+			require.Error(t, err, "cancel should fail - transaction already committed")
+			assert.Contains(t, err.Error(), "Transaction not found", "error should indicate txn not found")
+			t.Logf("Session1 cancel failed as expected: %v", err)
+
+			// Also try direct cancel (without session context) - same result
+			var cancelRes connection.RPCResponse[any]
+			err = connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+			require.Error(t, err, "direct cancel should also fail")
+			t.Logf("Direct cancel also failed: %v", err)
+		})
+	})
+
+	// Test: Transaction on default session, try to use from explicit session
+	// DISCOVERY: This is also allowed - transactions are truly connection-scoped
+	t.Run("default session transaction can be used from explicit session", func(t *testing.T) {
+		// Start transaction on default session (no session field)
+		var beginRes connection.RPCResponse[models.UUID]
+		err := connection.Send(conn, ctx, &beginRes, "begin")
+		require.NoError(t, err, "begin on default session should succeed")
+		txnID := beginRes.Result
+		t.Logf("Transaction on default session: %+v", txnID)
+
+		// Try to use this transaction from session 2
+		res, err := sendCustomRPC[[]queryResult](conn, ctx, "query", &session2, txnID,
+			"CREATE items:default_txn_test SET value = 'takeover from default'",
+			map[string]any{})
+		require.NoError(t, err, "using default session's txn from explicit session should be allowed")
+		require.NotNil(t, res.Result, "result should not be nil")
+		t.Logf("Session2 using default session's txn succeeded: %+v", res.Result)
+
+		// Clean up
+		var cancelRes connection.RPCResponse[any]
+		_ = connection.Send(conn, ctx, &cancelRes, "cancel", txnID)
+	})
+
+	// Cleanup sessions
+	_, _ = sendInSession[any](conn, ctx, "detach", &session1)
+	_, _ = sendInSession[any](conn, ctx, "detach", &session2)
+}

--- a/session_transaction_exploration_test.go
+++ b/session_transaction_exploration_test.go
@@ -171,8 +171,10 @@ func setupWSConnection(t *testing.T, namespace, database string) *gorillaws.Conn
 
 	c := surrealcbor.New()
 	wsURL := testenv.GetSurrealDBWSURL()
+	// gorillaws.Connect appends "/rpc" to BaseURL, so we need to strip it if present
+	baseURL := strings.TrimSuffix(wsURL, "/rpc")
 	conn := gorillaws.New(&connection.Config{
-		BaseURL:     wsURL,
+		BaseURL:     baseURL,
 		Marshaler:   c,
 		Unmarshaler: c,
 		Logger:      logger.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -212,6 +214,8 @@ func setupHTTPConnection(t *testing.T, namespace, database string) *surrealhttp.
 	wsURL := testenv.GetSurrealDBWSURL()
 	httpURL := strings.ReplaceAll(wsURL, "ws://", "http://")
 	httpURL = strings.ReplaceAll(httpURL, "wss://", "https://")
+	// Remove /rpc suffix that's needed for WebSocket but not for HTTP
+	httpURL = strings.TrimSuffix(httpURL, "/rpc")
 
 	conn := surrealhttp.New(&connection.Config{
 		BaseURL:     httpURL,
@@ -268,6 +272,8 @@ func setupHTTPConnectionInfo(t *testing.T, namespace, database string) *httpConn
 	wsURL := testenv.GetSurrealDBWSURL()
 	httpURL := strings.ReplaceAll(wsURL, "ws://", "http://")
 	httpURL = strings.ReplaceAll(httpURL, "wss://", "https://")
+	// Remove /rpc suffix that's needed for WebSocket but not for HTTP
+	httpURL = strings.TrimSuffix(httpURL, "/rpc")
 
 	conn := surrealhttp.New(&connection.Config{
 		BaseURL:     httpURL,

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,154 @@
+package surrealdb
+
+import (
+	"context"
+	"sync"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// Transaction represents an interactive SurrealDB transaction on a WebSocket connection.
+// Unlike text-based transactions (BEGIN TRANSACTION; ... COMMIT;), interactive transactions
+// allow executing statements one at a time and conditionally committing or cancelling.
+//
+// Transactions are only supported on WebSocket connections (SurrealDB v3+).
+//
+// Transaction satisfies the sendable constraint, so all surrealdb.Query,
+// surrealdb.Create, etc. functions work with transactions directly.
+//
+// Note: Transactions do NOT support session state changes like SignIn, Use, Let, etc.
+// The namespace/database and authentication are inherited from the session or connection
+// that started the transaction.
+type Transaction struct {
+	db        *DB
+	id        *models.UUID
+	sessionID *models.UUID // optional, nil for default session
+	closed    bool
+	mu        sync.RWMutex
+}
+
+// Begin starts a new interactive transaction on the default session.
+// Interactive transactions are only supported on WebSocket connections (SurrealDB v3+).
+//
+// Example:
+//
+//	tx, err := db.Begin(ctx)
+//	if err != nil {
+//	    return err
+//	}
+//	defer tx.Cancel(ctx) // Cancel if not committed
+//
+//	// Execute queries within the transaction
+//	_, err = surrealdb.Query[[]any](ctx, tx, "CREATE user:1 SET name = 'Alice'", nil)
+//	if err != nil {
+//	    return err
+//	}
+//
+//	// Commit the transaction
+//	return tx.Commit(ctx)
+func (db *DB) Begin(ctx context.Context) (*Transaction, error) {
+	// Check if the connection is a WebSocket connection
+	if _, ok := db.con.(connection.WebSocketConnection); !ok {
+		return nil, constants.ErrTransactionsNotSupported
+	}
+
+	// Send the begin RPC request
+	req := &connection.RPCRequest{
+		Method: string(connection.Begin),
+	}
+
+	var res connection.RPCResponse[models.UUID]
+	if err := connection.Call(db.con, ctx, &res, req); err != nil {
+		return nil, err
+	}
+
+	return &Transaction{
+		db: db,
+		id: res.Result,
+	}, nil
+}
+
+// ID returns the transaction's UUID.
+func (tx *Transaction) ID() *models.UUID {
+	return tx.id
+}
+
+// SessionID returns the session UUID if the transaction was started within a session.
+// Returns nil if the transaction was started on the default session.
+func (tx *Transaction) SessionID() *models.UUID {
+	return tx.sessionID
+}
+
+// IsClosed returns whether the transaction has been committed or cancelled.
+func (tx *Transaction) IsClosed() bool {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.closed
+}
+
+// Commit commits the transaction, making all changes permanent.
+// After calling Commit, the transaction cannot be used anymore.
+func (tx *Transaction) Commit(ctx context.Context) error {
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+
+	if tx.closed {
+		return constants.ErrTransactionClosed
+	}
+
+	// Send the commit RPC request with the transaction UUID as a positional param
+	var res connection.RPCResponse[any]
+	if err := connection.Send(tx.db.con, ctx, &res, string(connection.Commit), tx.id); err != nil {
+		return err
+	}
+
+	tx.closed = true
+	return nil
+}
+
+// Cancel cancels the transaction, discarding all changes.
+// After calling Cancel, the transaction cannot be used anymore.
+//
+// It's safe to call Cancel on an already committed or cancelled transaction;
+// it will return ErrTransactionClosed but won't cause any harm.
+func (tx *Transaction) Cancel(ctx context.Context) error {
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+
+	if tx.closed {
+		return constants.ErrTransactionClosed
+	}
+
+	// Send the cancel RPC request with the transaction UUID as a positional param
+	var res connection.RPCResponse[any]
+	if err := connection.Send(tx.db.con, ctx, &res, string(connection.Cancel), tx.id); err != nil {
+		return err
+	}
+
+	tx.closed = true
+	return nil
+}
+
+// connection returns the underlying connection for internal use.
+func (tx *Transaction) connection() connection.Connection {
+	return tx.db.con
+}
+
+// sessionID returns the session ID for internal use.
+func (tx *Transaction) sessionIDInternal() *models.UUID {
+	return tx.sessionID
+}
+
+// txnID returns the transaction ID for internal use.
+func (tx *Transaction) txnID() *models.UUID {
+	return tx.id
+}
+
+// isClosed returns whether the transaction is closed.
+func (tx *Transaction) isClosed() bool {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.closed
+}

--- a/transaction.go
+++ b/transaction.go
@@ -11,7 +11,7 @@ import (
 
 // Transaction represents an interactive SurrealDB transaction on a WebSocket connection.
 // Unlike text-based transactions (BEGIN TRANSACTION; ... COMMIT;), interactive transactions
-// allow executing statements one at a time and conditionally committing or cancelling.
+// allow executing statements one at a time and conditionally committing or canceling.
 //
 // Transactions are only supported on WebSocket connections (SurrealDB v3+).
 //
@@ -81,7 +81,7 @@ func (tx *Transaction) SessionID() *models.UUID {
 	return tx.sessionID
 }
 
-// IsClosed returns whether the transaction has been committed or cancelled.
+// IsClosed returns whether the transaction has been committed or canceled.
 func (tx *Transaction) IsClosed() bool {
 	tx.mu.RLock()
 	defer tx.mu.RUnlock()
@@ -111,7 +111,7 @@ func (tx *Transaction) Commit(ctx context.Context) error {
 // Cancel cancels the transaction, discarding all changes.
 // After calling Cancel, the transaction cannot be used anymore.
 //
-// It's safe to call Cancel on an already committed or cancelled transaction;
+// It's safe to call Cancel on an already committed or canceled transaction;
 // it will return ErrTransactionClosed but won't cause any harm.
 func (tx *Transaction) Cancel(ctx context.Context) error {
 	tx.mu.Lock()
@@ -129,26 +129,4 @@ func (tx *Transaction) Cancel(ctx context.Context) error {
 
 	tx.closed = true
 	return nil
-}
-
-// connection returns the underlying connection for internal use.
-func (tx *Transaction) connection() connection.Connection {
-	return tx.db.con
-}
-
-// sessionID returns the session ID for internal use.
-func (tx *Transaction) sessionIDInternal() *models.UUID {
-	return tx.sessionID
-}
-
-// txnID returns the transaction ID for internal use.
-func (tx *Transaction) txnID() *models.UUID {
-	return tx.id
-}
-
-// isClosed returns whether the transaction is closed.
-func (tx *Transaction) isClosed() bool {
-	tx.mu.RLock()
-	defer tx.mu.RUnlock()
-	return tx.closed
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -140,7 +140,7 @@ func TestTransaction_Cancel(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, results)
 	require.Len(t, *results, 1)
-	assert.Empty(t, (*results)[0].Result, "Cancelled transaction data should be rolled back")
+	assert.Empty(t, (*results)[0].Result, "Canceled transaction data should be rolled back")
 }
 
 // TestTransaction_DoubleCommit tests that committing a committed transaction returns an error.
@@ -168,7 +168,7 @@ func TestTransaction_DoubleCommit(t *testing.T) {
 	assert.ErrorIs(t, err, constants.ErrTransactionClosed, "Error should be ErrTransactionClosed")
 }
 
-// TestTransaction_DoubleCancel tests that cancelling a cancelled transaction returns an error.
+// TestTransaction_DoubleCancel tests that canceling a canceled transaction returns an error.
 func TestTransaction_DoubleCancel(t *testing.T) {
 	v := getVersion(t)
 	if !v.IsV3OrLater() {
@@ -406,7 +406,7 @@ func TestTransaction_QueryWithVariables(t *testing.T) {
 
 	tx, err := db.Begin(ctx)
 	require.NoError(t, err)
-	defer tx.Cancel(ctx)
+	defer func() { _ = tx.Cancel(ctx) }()
 
 	type User struct {
 		ID   string `json:"id"`
@@ -447,7 +447,7 @@ func TestTransaction_InSession(t *testing.T) {
 	// Create a session
 	session, err := db.Attach(ctx)
 	require.NoError(t, err)
-	defer session.Detach(ctx)
+	defer func() { _ = session.Detach(ctx) }()
 
 	// Authenticate and select namespace/database
 	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,0 +1,485 @@
+package surrealdb_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+	"github.com/surrealdb/surrealdb.go/pkg/constants"
+	"github.com/surrealdb/surrealdb.go/pkg/models"
+)
+
+// TestTransaction_Begin tests transaction creation on WebSocket connections.
+func TestTransaction_Begin(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	db := mustNewWS("txn_test", "begin_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err, "Begin should succeed on WebSocket connection")
+	require.NotNil(t, tx, "Transaction should not be nil")
+	require.NotNil(t, tx.ID(), "Transaction ID should not be nil")
+	assert.Nil(t, tx.SessionID(), "Transaction on default session should have nil SessionID")
+	assert.False(t, tx.IsClosed(), "Transaction should not be closed initially")
+
+	t.Logf("Created transaction with ID: %s", tx.ID().String())
+
+	// Clean up
+	err = tx.Cancel(ctx)
+	require.NoError(t, err, "Cancel should succeed")
+	assert.True(t, tx.IsClosed(), "Transaction should be closed after Cancel")
+}
+
+// TestTransaction_BeginHTTPError tests that Begin returns an error on HTTP connections.
+func TestTransaction_BeginHTTPError(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	db := testenv.MustNewHTTP("begin_http_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.Error(t, err, "Begin should fail on HTTP connection")
+	assert.ErrorIs(t, err, constants.ErrTransactionsNotSupported, "Error should be ErrTransactionsNotSupported")
+	assert.Nil(t, tx, "Transaction should be nil on error")
+}
+
+// TestTransaction_Commit tests successful transaction commit.
+func TestTransaction_Commit(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("txn_test", "commit_test", "items")
+
+	db := mustNewWS("txn_test", "commit_test", "items")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err)
+
+	// Create an item within the transaction
+	type Item struct {
+		ID    string `json:"id"`
+		Value string `json:"value"`
+	}
+
+	_, err = surrealdb.Query[[]Item](ctx, tx, "CREATE items:commit_item SET value = 'committed'", nil)
+	require.NoError(t, err)
+
+	// Commit the transaction
+	err = tx.Commit(ctx)
+	require.NoError(t, err, "Commit should succeed")
+	assert.True(t, tx.IsClosed(), "Transaction should be closed after Commit")
+
+	// Verify data persisted using the main connection (not transaction)
+	results, err := surrealdb.Query[[]Item](ctx, db, "SELECT * FROM items WHERE id = items:commit_item", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Len(t, (*results)[0].Result, 1, "Committed data should be visible")
+	assert.Equal(t, "committed", (*results)[0].Result[0].Value)
+}
+
+// TestTransaction_Cancel tests successful transaction cancellation (rollback).
+func TestTransaction_Cancel(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("txn_test", "cancel_test", "items")
+
+	db := mustNewWS("txn_test", "cancel_test", "items")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err)
+
+	type Item struct {
+		ID    string `json:"id"`
+		Value string `json:"value"`
+	}
+
+	// Create an item within the transaction
+	_, err = surrealdb.Query[[]Item](ctx, tx, "CREATE items:cancel_item SET value = 'will be rolled back'", nil)
+	require.NoError(t, err)
+
+	// Cancel the transaction
+	err = tx.Cancel(ctx)
+	require.NoError(t, err, "Cancel should succeed")
+	assert.True(t, tx.IsClosed(), "Transaction should be closed after Cancel")
+
+	// Verify data was NOT persisted
+	// Note: In SurrealDB v3, the table may not exist after cancellation, so we use IF EXISTS
+	results, err := surrealdb.Query[[]Item](ctx, db, "SELECT * FROM items WHERE id = items:cancel_item", nil)
+	// Ignore table doesn't exist error - that's expected after cancel if the table was created in the transaction
+	if err != nil && strings.Contains(err.Error(), "does not exist") {
+		// Table doesn't exist, which means the transaction was rolled back correctly
+		return
+	}
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Empty(t, (*results)[0].Result, "Cancelled transaction data should be rolled back")
+}
+
+// TestTransaction_DoubleCommit tests that committing a committed transaction returns an error.
+func TestTransaction_DoubleCommit(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	db := mustNewWS("txn_test", "double_commit_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err)
+
+	// First commit should succeed
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	// Second commit should fail
+	err = tx.Commit(ctx)
+	require.Error(t, err, "Second Commit should fail")
+	assert.ErrorIs(t, err, constants.ErrTransactionClosed, "Error should be ErrTransactionClosed")
+}
+
+// TestTransaction_DoubleCancel tests that cancelling a cancelled transaction returns an error.
+func TestTransaction_DoubleCancel(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	db := mustNewWS("txn_test", "double_cancel_test", "test_table")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err)
+
+	// First cancel should succeed
+	err = tx.Cancel(ctx)
+	require.NoError(t, err)
+
+	// Second cancel should fail
+	err = tx.Cancel(ctx)
+	require.Error(t, err, "Second Cancel should fail")
+	assert.ErrorIs(t, err, constants.ErrTransactionClosed, "Error should be ErrTransactionClosed")
+}
+
+// TestTransaction_Isolation tests that uncommitted changes are not visible to other connections.
+func TestTransaction_Isolation(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("txn_test", "isolation_test", "records")
+
+	db1 := mustNewWS("txn_test", "isolation_test", "records")
+	defer db1.Close(context.Background())
+
+	db2 := mustNewWS("txn_test", "isolation_test", "records")
+	defer db2.Close(context.Background())
+
+	ctx := context.Background()
+
+	// Start transaction on db1
+	tx, err := db1.Begin(ctx)
+	require.NoError(t, err)
+
+	type Record struct {
+		ID    string `json:"id"`
+		Value string `json:"value"`
+	}
+
+	// Create record within transaction
+	_, err = surrealdb.Query[[]Record](ctx, tx, "CREATE records:isolated SET value = 'in transaction'", nil)
+	require.NoError(t, err)
+
+	// Check from db2 - should NOT see uncommitted data
+	// Note: In SurrealDB v3, the table may not exist yet since it's only created inside the uncommitted transaction
+	results, err := surrealdb.Query[[]Record](ctx, db2, "SELECT * FROM records WHERE id = records:isolated", nil)
+	if err != nil && strings.Contains(err.Error(), "does not exist") {
+		// Table doesn't exist yet, which is correct - the transaction hasn't committed
+		t.Log("Table doesn't exist yet (uncommitted transaction) - this is expected isolation behavior")
+	} else {
+		require.NoError(t, err)
+		require.NotNil(t, results)
+		require.Len(t, *results, 1)
+		assert.Empty(t, (*results)[0].Result, "Uncommitted data should not be visible from other connection")
+	}
+
+	// Commit the transaction
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	// Now db2 should see the data
+	results, err = surrealdb.Query[[]Record](ctx, db2, "SELECT * FROM records WHERE id = records:isolated", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Len(t, (*results)[0].Result, 1, "Committed data should be visible from other connection")
+	assert.Equal(t, "in transaction", (*results)[0].Result[0].Value)
+}
+
+// TestTransaction_CRUD_Query tests Create, Select, Update, Delete operations within a transaction using Query.
+func TestTransaction_CRUD_Query(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("txn_crud", "crud_test", "products")
+
+	db := mustNewWS("txn_crud", "crud_test", "products")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err)
+	// Note: we don't defer tx.Cancel here because we want to commit
+
+	type Product struct {
+		ID    string  `json:"id"`
+		Name  string  `json:"name"`
+		Price float64 `json:"price"`
+	}
+
+	// Create - using Query for reliable behavior in transactions
+	createResults, err := surrealdb.Query[[]Product](ctx, tx, "CREATE products:txn_widget SET name = 'Transaction Widget', price = 29.99", nil)
+	require.NoError(t, err, "Create within transaction should succeed")
+	require.NotNil(t, createResults)
+	require.Len(t, *createResults, 1)
+	require.Len(t, (*createResults)[0].Result, 1)
+	assert.Equal(t, "Transaction Widget", (*createResults)[0].Result[0].Name)
+
+	// Select - using Query for reliable behavior in transactions
+	selectResults, err := surrealdb.Query[[]Product](ctx, tx, "SELECT * FROM products:txn_widget", nil)
+	require.NoError(t, err, "Select within transaction should succeed")
+	require.NotNil(t, selectResults)
+	require.Len(t, *selectResults, 1)
+	require.Len(t, (*selectResults)[0].Result, 1)
+	assert.Equal(t, "Transaction Widget", (*selectResults)[0].Result[0].Name)
+
+	// Update - using Query for reliable behavior in transactions
+	updateResults, err := surrealdb.Query[[]Product](ctx, tx, "UPDATE products:txn_widget SET name = 'Super Transaction Widget', price = 49.99", nil)
+	require.NoError(t, err, "Update within transaction should succeed")
+	require.NotNil(t, updateResults)
+	require.Len(t, *updateResults, 1)
+	require.Len(t, (*updateResults)[0].Result, 1)
+	assert.Equal(t, "Super Transaction Widget", (*updateResults)[0].Result[0].Name)
+	assert.Equal(t, 49.99, (*updateResults)[0].Result[0].Price)
+
+	// Delete - using Query for reliable behavior in transactions
+	deleteResults, err := surrealdb.Query[[]Product](ctx, tx, "DELETE products:txn_widget RETURN BEFORE", nil)
+	require.NoError(t, err, "Delete within transaction should succeed")
+	require.NotNil(t, deleteResults)
+	require.Len(t, *deleteResults, 1)
+	require.Len(t, (*deleteResults)[0].Result, 1)
+	assert.Equal(t, "Super Transaction Widget", (*deleteResults)[0].Result[0].Name)
+
+	// Commit
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	// Verify deleted after commit
+	results, err := surrealdb.Query[[]Product](ctx, db, "SELECT * FROM products WHERE id = products:txn_widget", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Empty(t, (*results)[0].Result, "Deleted product should not exist after commit")
+}
+
+// TestTransaction_CRUD_RPCs tests Create, Select, Update, Delete operations within a transaction using RPC methods.
+func TestTransaction_CRUD_RPCs(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("txn_crud_rpc", "crud_rpc_test", "products")
+
+	db := mustNewWS("txn_crud_rpc", "crud_rpc_test", "products")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err)
+	// Note: we don't defer tx.Cancel here because we want to commit
+
+	type Product struct {
+		ID    string  `json:"id"`
+		Name  string  `json:"name"`
+		Price float64 `json:"price"`
+	}
+
+	// Use RecordID for RPC methods
+	recordID := models.NewRecordID("products", "txn_rpc_widget")
+
+	// Create using surrealdb.Create
+	product, err := surrealdb.Create[Product](ctx, tx, recordID, map[string]any{
+		"name":  "Transaction RPC Widget",
+		"price": 29.99,
+	})
+	require.NoError(t, err, "Create within transaction should succeed")
+	require.NotNil(t, product)
+	assert.Equal(t, "Transaction RPC Widget", product.Name)
+	assert.Equal(t, 29.99, product.Price)
+
+	// Select using surrealdb.Select
+	selectedProduct, err := surrealdb.Select[Product](ctx, tx, recordID)
+	require.NoError(t, err, "Select within transaction should succeed")
+	require.NotNil(t, selectedProduct)
+	assert.Equal(t, "Transaction RPC Widget", selectedProduct.Name)
+
+	// Upsert using surrealdb.Upsert
+	// Note: In SurrealDB v3 transactions, the Update RPC may fail with
+	// "Expected a single result output when using the ONLY keyword" even when
+	// the record exists. Upsert works reliably in both session and transaction contexts.
+	updatedProduct, err := surrealdb.Upsert[Product](ctx, tx, recordID, map[string]any{
+		"name":  "Super Transaction RPC Widget",
+		"price": 49.99,
+	})
+	require.NoError(t, err, "Upsert within transaction should succeed")
+	require.NotNil(t, updatedProduct)
+	assert.Equal(t, "Super Transaction RPC Widget", updatedProduct.Name)
+	assert.Equal(t, 49.99, updatedProduct.Price)
+
+	// Delete using surrealdb.Delete
+	deletedProduct, err := surrealdb.Delete[Product](ctx, tx, recordID)
+	require.NoError(t, err, "Delete within transaction should succeed")
+	require.NotNil(t, deletedProduct)
+	assert.Equal(t, "Super Transaction RPC Widget", deletedProduct.Name)
+
+	// Commit
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	// Verify deleted after commit using surrealdb.Select
+	verifyProduct, err := surrealdb.Select[Product](ctx, db, recordID)
+	require.NoError(t, err, "Select of deleted record should not error")
+	assert.Nil(t, verifyProduct, "Deleted product should not exist after commit")
+}
+
+// TestTransaction_QueryWithVariables tests Query with variables within a transaction.
+func TestTransaction_QueryWithVariables(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support interactive transactions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("txn_test", "query_vars_test", "users")
+
+	db := mustNewWS("txn_test", "query_vars_test", "users")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	tx, err := db.Begin(ctx)
+	require.NoError(t, err)
+	defer tx.Cancel(ctx)
+
+	type User struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	// Create user with variables
+	results, err := surrealdb.Query[[]User](ctx, tx,
+		"CREATE users SET name = $name, age = $age",
+		map[string]any{
+			"name": "Alice",
+			"age":  30,
+		})
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Equal(t, "OK", (*results)[0].Status)
+	assert.Len(t, (*results)[0].Result, 1)
+	assert.Equal(t, "Alice", (*results)[0].Result[0].Name)
+	assert.Equal(t, 30, (*results)[0].Result[0].Age)
+}
+
+// TestTransaction_InSession tests transactions started within a session.
+func TestTransaction_InSession(t *testing.T) {
+	v := getVersion(t)
+	if !v.IsV3OrLater() {
+		t.Skipf("Skipping: SurrealDB version %s does not support sessions/transactions (requires v3+)", v)
+	}
+
+	_ = mustNewWS("txn_session", "session_txn_test", "items")
+
+	db := mustNewWS("txn_session", "session_txn_test", "items")
+	defer db.Close(context.Background())
+
+	ctx := context.Background()
+
+	// Create a session
+	session, err := db.Attach(ctx)
+	require.NoError(t, err)
+	defer session.Detach(ctx)
+
+	// Authenticate and select namespace/database
+	_, err = session.SignIn(ctx, map[string]any{"user": "root", "pass": "root"})
+	require.NoError(t, err)
+
+	err = session.Use(ctx, "txn_session", "session_txn_test")
+	require.NoError(t, err)
+
+	// Start a transaction in the session
+	tx, err := session.Begin(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tx.SessionID(), "Transaction should have SessionID when started from session")
+	assert.Equal(t, session.ID().String(), tx.SessionID().String())
+
+	type Item struct {
+		ID    string `json:"id"`
+		Value string `json:"value"`
+	}
+
+	// Create item in transaction
+	_, err = surrealdb.Query[[]Item](ctx, tx, "CREATE items:session_txn_item SET value = 'from session txn'", nil)
+	require.NoError(t, err)
+
+	// Commit
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+
+	// Verify data persisted using the session
+	results, err := surrealdb.Query[[]Item](ctx, session, "SELECT * FROM items WHERE id = items:session_txn_item", nil)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Len(t, *results, 1)
+	assert.Len(t, (*results)[0].Result, 1)
+	assert.Equal(t, "from session txn", (*results)[0].Result[0].Value)
+}


### PR DESCRIPTION
## What is the motivation?

SurrealDB v3 introduces two features via the WebSocket RPC protocol:
- **Sessions**: Allow multiple independent authentication/namespace contexts on a single WebSocket connection
- **Interactive Transactions**: Enable executing statements one at a time with conditional commit/cancel logic

This PR adds Go SDK support for these features, enabling developers to leverage the enhanced capabilities in SurrealDB v3.

## What does this change do?

Adds `surrealdb.Session` and `surrealdb.Transaction` that can be created using `(*DB).Attach` and `Begin`, which can be closed using `Detach` and `Commit|Cancel` respectively.

### Sessions
- Adds `db.Attach(ctx)` to create additional sessions on a WebSocket connection
- Each session has independent authentication, namespace/database selection, and variable scope
- Sessions support all standard operations: `SignIn`, `Authenticate`, `Use`, `Let`, `Unset`, `Query`, etc.
- Sessions can be detached with `session.Detach(ctx)`

### Interactive Transactions
- Adds `db.Begin(ctx)` and `session.Begin(ctx)` to start interactive transactions
- Transactions allow executing queries sequentially with `surrealdb.Query(ctx, tx, ...)` and similar functions
- Supports conditional commit/cancel: `tx.Commit(ctx)` or `tx.Cancel(ctx)` based on business logic
- Transaction isolation ensures uncommitted changes are not visible to other connections

## What is your testing strategy?

Session and transaction tests, along with runnable examples, have been added and verified to work locally.

