### PR TITLE
Error handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         include:
           # v3.0.0-beta.2 with Go 1.25.0
-          - surrealdb-version: 'v3.0.0-beta.2'
+          - surrealdb-version: 'v3.0.0'
             go-version: '1.25.0'
             connection-type: 'ws'
             surrealdb-url: 'ws://localhost:8000/rpc'
-          - surrealdb-version: 'v3.0.0-beta.2'
+          - surrealdb-version: 'v3.0.0'
             go-version: '1.25.0'
             connection-type: 'http'
             surrealdb-url: 'http://localhost:8000'

--- a/contrib/rews/rews_test.go
+++ b/contrib/rews/rews_test.go
@@ -192,7 +192,7 @@ func TestConnection(t *testing.T) {
 		// Test with struct auth data
 		type AuthStruct struct {
 			Username string `json:"user"`
-			Password string `json:"pass"`
+			Password string `json:"pass"` //nolint:gosec // G117: test auth struct
 		}
 
 		authStruct := AuthStruct{

--- a/contrib/surrealdump/config.go
+++ b/contrib/surrealdump/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	// Authentication username
 	Username string
 	// Authentication password
-	Password string
+	Password string //nolint:gosec // G117: user-supplied auth credential
 
 	// Namespace to dump
 	Namespace string

--- a/contrib/surrealql/define.go
+++ b/contrib/surrealql/define.go
@@ -107,7 +107,7 @@ func (q *DefineTableQuery) Build() (query string, params map[string]any) {
 	if len(q.permissions) > 0 {
 		builder.WriteString(" PERMISSIONS")
 		for _, p := range q.permissions {
-			builder.WriteString(fmt.Sprintf(" %s %s", strings.ToUpper(p.perm), p.value))
+			fmt.Fprintf(&builder, " %s %s", strings.ToUpper(p.perm), p.value)
 		}
 	}
 

--- a/contrib/surrealql/show.go
+++ b/contrib/surrealql/show.go
@@ -80,7 +80,7 @@ func (q *ShowChangesForTableQuery) Build() (sql string, vars map[string]any) {
 	}
 
 	if q.limit > 0 {
-		builder.WriteString(fmt.Sprintf(" LIMIT %d", q.limit))
+		fmt.Fprintf(&builder, " LIMIT %d", q.limit)
 	}
 
 	return builder.String(), c.vars

--- a/contrib/surrealrestore/config.go
+++ b/contrib/surrealrestore/config.go
@@ -40,7 +40,7 @@ type Config struct {
 
 	Endpoint string
 	Username string
-	Password string
+	Password string //nolint:gosec // G117: user-supplied auth credential
 
 	// Input options (mutually exclusive: Input OR Dir)
 

--- a/contrib/surrealrestore/restore.go
+++ b/contrib/surrealrestore/restore.go
@@ -197,7 +197,7 @@ func (r *Restorer) fullFromReader(ctx context.Context, currentNamespace, current
 						r.stats.TablesRestored++
 
 						if r.Verbose {
-							log.Printf("Restoring table: %s", tableKey)
+							log.Printf("Restoring table: %s", tableKey) //nolint:gosec // G706: tableKey is from parsed dump metadata
 						}
 					}
 
@@ -362,7 +362,8 @@ func (r *Restorer) incrementalFromReader(ctx context.Context, currentNamespace, 
 						currentDatabase = db
 					}
 					if r.Verbose {
-						log.Printf("Found incremental metadata: namespace=%s, database=%s", currentNamespace, currentDatabase)
+						log.Printf("Found incremental metadata: namespace=%s, database=%s", //nolint:gosec // G706
+							currentNamespace, currentDatabase)
 					}
 				}
 			}
@@ -381,7 +382,7 @@ func (r *Restorer) ensureNamespaceDatabase(ctx context.Context, ns, db string,
 		if _, err := surrealdb.Query[any](ctx, r.db, query, nil); err != nil {
 			// Namespace might already exist, which is fine
 			if r.Verbose {
-				log.Printf("Note: namespace %s might already exist", ns)
+				log.Printf("Note: namespace %s might already exist", ns) //nolint:gosec // G706: ns is from parsed dump metadata
 			}
 		} else {
 			r.stats.NamespacesCreated++
@@ -402,7 +403,7 @@ func (r *Restorer) ensureNamespaceDatabase(ctx context.Context, ns, db string,
 		if _, err := surrealdb.Query[any](ctx, r.db, query, nil); err != nil {
 			// Database might already exist, which is fine
 			if r.Verbose {
-				log.Printf("Note: database %s.%s might already exist", ns, db)
+				log.Printf("Note: database %s.%s might already exist", ns, db) //nolint:gosec // G706: values from config
 			}
 		} else {
 			r.stats.DatabasesCreated++

--- a/contrib/testenv/session_transaction_exploration_test.go
+++ b/contrib/testenv/session_transaction_exploration_test.go
@@ -349,7 +349,7 @@ func sendCustomHTTPRPC[T any](
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", info.token))
 
 	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL from trusted test config
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}

--- a/contrib/testenv/structured_errors_integration_test.go
+++ b/contrib/testenv/structured_errors_integration_test.go
@@ -1,0 +1,150 @@
+package testenv
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+func setupStructuredErrorTest(t *testing.T) (*surrealdb.DB, *SurrealDBVersion) {
+	t.Helper()
+
+	db, err := New("test_errors", "structured_errors", "person")
+	if err != nil {
+		t.Skipf("SurrealDB not available: %v", err)
+	}
+
+	t.Cleanup(func() { db.Close(context.Background()) })
+
+	v, err := GetVersion(context.Background(), db)
+	if err != nil {
+		t.Skipf("Could not get SurrealDB version: %v", err)
+	}
+
+	if !v.IsV3OrLater() {
+		t.Skipf("Structured errors require SurrealDB v3+, got %s", v)
+	}
+
+	return db, v
+}
+
+func TestStructuredErrors_InvalidCredentials(t *testing.T) {
+	db, _ := setupStructuredErrorTest(t)
+
+	_, err := db.SignIn(context.Background(), surrealdb.Auth{
+		Username: "invalid",
+		Password: "invalid",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication")
+
+	// SignIn returns the raw RPCError from the connection layer.
+	// Verify the error carries the structured fields.
+	var rpcErr *connection.RPCError
+	if errors.As(err, &rpcErr) {
+		assert.Equal(t, -32002, rpcErr.Code)
+		assert.Equal(t, "NotAllowed", rpcErr.Kind)
+	}
+}
+
+func TestStructuredErrors_InvalidSyntax(t *testing.T) {
+	db, _ := setupStructuredErrorTest(t)
+
+	_, err := surrealdb.Query[any](context.Background(), db, "SEL ECT * FORM person", nil)
+
+	require.Error(t, err)
+
+	var se *surrealdb.ServerError
+	require.True(t, errors.As(err, &se))
+	assert.Contains(t, se.Error(), "Parse error")
+}
+
+func TestStructuredErrors_UserThrow(t *testing.T) {
+	db, _ := setupStructuredErrorTest(t)
+
+	res, err := surrealdb.Query[any](context.Background(), db, `THROW "custom user error"`, nil)
+
+	require.Error(t, err)
+
+	var se *surrealdb.ServerError
+	require.True(t, errors.As(err, &se))
+	assert.Equal(t, surrealdb.ErrorKindThrown, se.Kind())
+	assert.Contains(t, se.Error(), "custom user error")
+
+	if res != nil && len(*res) > 0 {
+		qr := (*res)[0]
+		require.NotNil(t, qr.Error)
+		assert.Equal(t, surrealdb.ErrorKindThrown, qr.Error.Kind())
+	}
+}
+
+func TestStructuredErrors_DuplicateRecord(t *testing.T) {
+	db, _ := setupStructuredErrorTest(t)
+
+	_, err := surrealdb.Query[any](context.Background(), db,
+		`CREATE person:dup SET name = "first"`, nil)
+	require.NoError(t, err)
+
+	res, err := surrealdb.Query[any](context.Background(), db,
+		`CREATE person:dup SET name = "second"`, nil)
+
+	require.Error(t, err)
+
+	var se *surrealdb.ServerError
+	require.True(t, errors.As(err, &se))
+	assert.Equal(t, surrealdb.ErrorKindAlreadyExists, se.Kind())
+	assert.Contains(t, se.Error(), "person:dup")
+	assert.Equal(t, "person:dup", se.RecordID())
+
+	if res != nil && len(*res) > 0 {
+		qr := (*res)[0]
+		require.NotNil(t, qr.Error)
+		assert.Equal(t, surrealdb.ErrorKindAlreadyExists, qr.Error.Kind())
+		assert.Equal(t, "person:dup", qr.Error.RecordID())
+	}
+}
+
+func TestStructuredErrors_SchemaViolation(t *testing.T) {
+	db, _ := setupStructuredErrorTest(t)
+
+	_, err := surrealdb.Query[any](context.Background(), db,
+		`DEFINE FIELD age ON person TYPE int`, nil)
+	require.NoError(t, err)
+
+	res, err := surrealdb.Query[any](context.Background(), db,
+		`CREATE person:schema_test SET age = "not a number"`, nil)
+
+	require.Error(t, err)
+
+	var se *surrealdb.ServerError
+	require.True(t, errors.As(err, &se))
+	assert.True(t, surrealdb.IsServerError(err))
+
+	if res != nil && len(*res) > 0 {
+		qr := (*res)[0]
+		require.NotNil(t, qr.Error)
+		assert.Contains(t, qr.Error.Error(), "age")
+	}
+}
+
+func TestStructuredErrors_MultiStatementMixed(t *testing.T) {
+	db, _ := setupStructuredErrorTest(t)
+
+	res, err := surrealdb.Query[any](context.Background(), db,
+		`RETURN 1; THROW "fail"; RETURN 3`, nil)
+
+	require.Error(t, err, "multi-statement with THROW should return an error")
+	require.NotNil(t, res)
+	require.GreaterOrEqual(t, len(*res), 3)
+
+	assert.Equal(t, "OK", (*res)[0].Status)
+	assert.NotNil(t, (*res)[1].Error)
+	assert.Equal(t, surrealdb.ErrorKindThrown, (*res)[1].Error.Kind())
+	assert.Equal(t, "OK", (*res)[2].Status)
+}

--- a/contrib/testenv/structured_errors_integration_test.go
+++ b/contrib/testenv/structured_errors_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 )
 
-func setupStructuredErrorTest(t *testing.T) (*surrealdb.DB, *SurrealDBVersion) {
+func setupStructuredErrorTest(t *testing.T) *surrealdb.DB {
 	t.Helper()
 
 	db, err := New("test_errors", "structured_errors", "person")
@@ -30,11 +30,11 @@ func setupStructuredErrorTest(t *testing.T) (*surrealdb.DB, *SurrealDBVersion) {
 		t.Skipf("Structured errors require SurrealDB v3+, got %s", v)
 	}
 
-	return db, v
+	return db
 }
 
 func TestStructuredErrors_InvalidCredentials(t *testing.T) {
-	db, _ := setupStructuredErrorTest(t)
+	db := setupStructuredErrorTest(t)
 
 	_, err := db.SignIn(context.Background(), surrealdb.Auth{
 		Username: "invalid",
@@ -54,9 +54,9 @@ func TestStructuredErrors_InvalidCredentials(t *testing.T) {
 }
 
 func TestStructuredErrors_InvalidSyntax(t *testing.T) {
-	db, _ := setupStructuredErrorTest(t)
+	db := setupStructuredErrorTest(t)
 
-	_, err := surrealdb.Query[any](context.Background(), db, "SEL ECT * FORM person", nil)
+	_, err := surrealdb.Query[any](context.Background(), db, "SEL ECT * FORM person", nil) //nolint:misspell // intentionally malformed SurrealQL
 
 	require.Error(t, err)
 
@@ -66,7 +66,7 @@ func TestStructuredErrors_InvalidSyntax(t *testing.T) {
 }
 
 func TestStructuredErrors_UserThrow(t *testing.T) {
-	db, _ := setupStructuredErrorTest(t)
+	db := setupStructuredErrorTest(t)
 
 	res, err := surrealdb.Query[any](context.Background(), db, `THROW "custom user error"`, nil)
 
@@ -85,7 +85,7 @@ func TestStructuredErrors_UserThrow(t *testing.T) {
 }
 
 func TestStructuredErrors_DuplicateRecord(t *testing.T) {
-	db, _ := setupStructuredErrorTest(t)
+	db := setupStructuredErrorTest(t)
 
 	_, err := surrealdb.Query[any](context.Background(), db,
 		`CREATE person:dup SET name = "first"`, nil)
@@ -111,7 +111,7 @@ func TestStructuredErrors_DuplicateRecord(t *testing.T) {
 }
 
 func TestStructuredErrors_SchemaViolation(t *testing.T) {
-	db, _ := setupStructuredErrorTest(t)
+	db := setupStructuredErrorTest(t)
 
 	_, err := surrealdb.Query[any](context.Background(), db,
 		`DEFINE FIELD age ON person TYPE int`, nil)
@@ -134,7 +134,7 @@ func TestStructuredErrors_SchemaViolation(t *testing.T) {
 }
 
 func TestStructuredErrors_MultiStatementMixed(t *testing.T) {
-	db, _ := setupStructuredErrorTest(t)
+	db := setupStructuredErrorTest(t)
 
 	res, err := surrealdb.Query[any](context.Background(), db,
 		`RETURN 1; THROW "fail"; RETURN 3`, nil)

--- a/contrib/testenv/test_log_handler.go
+++ b/contrib/testenv/test_log_handler.go
@@ -95,7 +95,7 @@ func (h *TestLogHandler) Handle(ctx context.Context, r slog.Record) error {
 		var sb strings.Builder
 		for {
 			frame, more := frames.Next()
-			sb.WriteString(fmt.Sprintf("%s:%d ", frame.File, frame.Line))
+			fmt.Fprintf(&sb, "%s:%d ", frame.File, frame.Line)
 			if !more {
 				break
 			}

--- a/contrib/testenv/version_behavior_test.go
+++ b/contrib/testenv/version_behavior_test.go
@@ -229,7 +229,7 @@ func TestBehavior_LiveSelectNonExistentTable_v3(t *testing.T) {
 type testUser struct {
 	ID       *models.RecordID `json:"id,omitempty"`
 	Username string           `json:"username"`
-	Password string           `json:"password"`
+	Password string           `json:"password"` //nolint:gosec // G117: test auth struct
 }
 
 func TestBehavior_CreateWithTable_v2(t *testing.T) {
@@ -568,7 +568,7 @@ func TestBehavior_BearerAccessHTTP_v2(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL from trusted test config
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -640,7 +640,7 @@ func TestBehavior_BearerAccessHTTP_v3(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL from trusted test config
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/db.go
+++ b/db.go
@@ -453,7 +453,10 @@ func Send[Result any](ctx context.Context, db *DB, res *connection.RPCResponse[R
 		return fmt.Errorf("provided method is not allowed")
 	}
 
-	return connection.Send(db.con, ctx, res, method, params...)
+	if err := connection.Send(db.con, ctx, res, method, params...); err != nil {
+		return convertError(err)
+	}
+	return nil
 }
 
 func (db *DB) LiveNotifications(liveQueryID string) (chan connection.Notification, error) {
@@ -558,22 +561,27 @@ func Live[S liveQueryable](ctx context.Context, s S, table models.Table, diff bo
 // # Handling errors
 //
 // If the query fails, the returned error will be a `joinError` created by the [errors.Join] function,
-// which contains all the errors that occurred during the query execution.
+// which contains all the [ServerError] instances that occurred during the query execution.
 // The caller can check the Error field of each [QueryResult] to see if the query failed,
 // or check the returned error from the [Query] function to see if the query failed.
 //
 // If the caller wants to handle the query errors, if any, it can check the Error field of each [QueryResult],
-// or call:
+// or use [errors.As] to extract a [ServerError]:
 //
-//	errors.Is(err, &surrealdb.QueryError{})
+//	var se *surrealdb.ServerError
+//	if errors.As(err, &se) {
+//	    fmt.Println(se.Kind(), se.Error())
+//	}
 //
-// on the returned error to see if it is (or contains) a [QueryError].
+// The [ServerError] carries structured information including Kind, Details, and a cause chain.
+// Use the helper functions [IsNotAllowed], [IsNotFound], etc. for ergonomic error checking,
+// or inspect [ServerError.Kind] directly.
 //
 // # Query errors are non-retriable
 //
-// If the error is a [QueryError], the caller should NOT retry the query,
-// because the query is already executed and the error is not recoverable,
-// and often times the error is caused by a bug in the query itself.
+// If the error is a [ServerError] from a query result (Kind is e.g. [ErrorKindQuery]),
+// the caller should NOT retry the query, because the query is already executed and the
+// error is not recoverable, and often times the error is caused by a bug in the query itself.
 //
 // # When can you safely retry the query when this function returns an error?
 //
@@ -582,14 +590,16 @@ func Live[S liveQueryable](ctx context.Context, s S, table models.Table, diff bo
 // In such cases, the caller can retry the query by calling the [Query] function again.
 //
 // For this function, the caller may retry when the error is:
-//   - [RPCError]: because we should get a RPC error only when the RPC failed due to anything other than the query error
+//   - A [ServerError] with Kind [ErrorKindInternal] or [ErrorKindConnection]: because these indicate
+//     transient server issues, not query-level errors.
 //   - [constants.ErrTimeout]: This means we send the HTTP request or a WebSocket message to SurrealDB in timely manner,
 //     which is often due to temporary network issues or server overload.
 //
 // # What non-retriable errors will Query return?
 //
 // However, if the error is any of the following, the caller should NOT retry the query:
-//   - [QueryError]: This means the query failed due to a syntax error, a type error, or a logical error in the query itself.
+//   - A [ServerError] from a query result: This means the query failed due to a syntax error,
+//     a type error, or a logical error in the query itself.
 //   - Unmarshal error: This means the response from the server could not be unmarshaled into the expected type,
 //     which is often due to a bug in the code or a mismatch between the expected type and the actual response type.
 //   - Marshal error: This means the request could not be marshaled using CBOR,
@@ -597,26 +607,18 @@ func Live[S liveQueryable](ctx context.Context, s S, table models.Table, diff bo
 //     SurrealDB, such as a struct with unsupported types.
 //   - Anything else: It's just safer to not retry when we aren't sure if the error is whether transient or permanent.
 //
-// # RPCError is retriable only for Query
+// # RPC errors vs query result errors
 //
-// Note that [RPCError] is retriable only for the [Query] RPC method,
-// because in other cases, the [RPCError] may also indicate a query error.
-// For example, if you tried to insert a duplicate record using the [Insert] RPC,
-// you may get an [RPCError] saying so, which is not retriable.
-//
-// If you tried to insert the same duplicate record using the [Query] RPC method with `INSERT` statement,
-// you may get no [RPCError], but a [QueryError] saying so, enabling you to easily diferentiate
-// between retriable and non-retriable errors.
+// For [Query], RPC-level errors (from the transport layer) are converted to [ServerError]
+// and returned directly. Per-statement errors are also [ServerError] instances, joined via
+// [errors.Join]. Use [ServerError.Kind] or the helper functions to distinguish between them.
 func Query[TResult any, S sendable](ctx context.Context, s S, sql string, vars map[string]any) (*[]QueryResult[TResult], error) {
-	res, err := send[[]QueryResult[cbor.RawMessage]](ctx, s, "query", sql, vars)
+	rawRes, err := send[[]rawQueryResult](ctx, s, "query", sql, vars)
 	if err != nil {
 		return nil, err
 	}
 
-	// The query errors, if any
-	var (
-		errs error
-	)
+	var errs error
 
 	// Get the unmarshaler based on the sender type
 	var unmarshaler func([]byte, any) error
@@ -629,18 +631,18 @@ func Query[TResult any, S sendable](ctx context.Context, s S, sql string, vars m
 		unmarshaler = v.db.con.GetUnmarshaler().Unmarshal
 	}
 
-	// We unmarshal []QueryResult[cbor.RawMessage] first,
+	// We unmarshal []rawQueryResult first (with Result as cbor.RawMessage),
 	// and then unmarshal each cbor.RawMessage to TResult.
 	// This is necessary because the Result field can be a string in case Status is "ERR".
 	// In that case if we directly unmarshaled to TResult using []QueryResult[TResult],
 	// it would fail with "cannot unmarshal UTF-8 text string into Go struct field"
 	// because CBOR string cannot be unmarshaled into TResult except when TResult is a string.
-	qr := make([]QueryResult[TResult], len(*res))
+	qr := make([]QueryResult[TResult], len(*rawRes))
 
-	for i, result := range *res {
+	for i, result := range *rawRes {
 		var (
 			r TResult
-			e *QueryError
+			e *ServerError
 		)
 		if result.Status == "ERR" {
 			var errMsg string
@@ -649,9 +651,7 @@ func Query[TResult any, S sendable](ctx context.Context, s S, sql string, vars m
 					return nil, fmt.Errorf("failed to unmarshal error message: %w", err)
 				}
 			}
-			e = &QueryError{
-				Message: errMsg,
-			}
+			e = parseQueryError(errMsg, result.Kind, result.Details, result.Cause)
 			errs = errors.Join(errs, e)
 		} else if result.Result != nil {
 			if err := unmarshaler(result.Result, &r); err != nil {
@@ -787,7 +787,7 @@ func QueryRaw[S sendable](ctx context.Context, s S, queries *[]QueryStmt) error 
 		return fmt.Errorf("no query to run")
 	}
 
-	res, err := send[[]QueryResult[cbor.RawMessage]](ctx, s, "query", preparedQuery, parameters)
+	rawRes, err := send[[]rawQueryResult](ctx, s, "query", preparedQuery, parameters)
 	if err != nil {
 		return err
 	}
@@ -806,8 +806,23 @@ func QueryRaw[S sendable](ctx context.Context, s S, queries *[]QueryStmt) error 
 	}
 
 	for i := 0; i < len(*queries); i++ {
-		// assign results
-		(*queries)[i].Result = (*res)[i]
+		raw := (*rawRes)[i]
+		var e *ServerError
+		if raw.Status == "ERR" {
+			var errMsg string
+			if raw.Result != nil {
+				if unmarshalErr := unmarshaler.Unmarshal(raw.Result, &errMsg); unmarshalErr == nil {
+					// Use the unmarshaled error message
+				}
+			}
+			e = parseQueryError(errMsg, raw.Kind, raw.Details, raw.Cause)
+		}
+		(*queries)[i].Result = QueryResult[cbor.RawMessage]{
+			Status: raw.Status,
+			Time:   raw.Time,
+			Result: raw.Result,
+			Error:  e,
+		}
 		(*queries)[i].unmarshaler = unmarshaler
 	}
 
@@ -828,7 +843,7 @@ func send[TResult any, S sendable](ctx context.Context, s S, method string, para
 	switch v := any(s).(type) {
 	case *DB:
 		if err := connection.Send(v.con, ctx, &res, method, params...); err != nil {
-			return nil, err
+			return nil, convertError(err)
 		}
 	case *Session:
 		if v.isClosed() {
@@ -840,7 +855,7 @@ func send[TResult any, S sendable](ctx context.Context, s S, method string, para
 			Session: v.id,
 		}
 		if err := connection.Call(v.db.con, ctx, &res, req); err != nil {
-			return nil, err
+			return nil, convertError(err)
 		}
 	case *Transaction:
 		if v.IsClosed() {
@@ -853,7 +868,7 @@ func send[TResult any, S sendable](ctx context.Context, s S, method string, para
 			Txn:     v.id,
 		}
 		if err := connection.Call(v.db.con, ctx, &res, req); err != nil {
-			return nil, err
+			return nil, convertError(err)
 		}
 	}
 

--- a/db.go
+++ b/db.go
@@ -811,9 +811,7 @@ func QueryRaw[S sendable](ctx context.Context, s S, queries *[]QueryStmt) error 
 		if raw.Status == "ERR" {
 			var errMsg string
 			if raw.Result != nil {
-				if unmarshalErr := unmarshaler.Unmarshal(raw.Result, &errMsg); unmarshalErr == nil {
-					// Use the unmarshaled error message
-				}
+				_ = unmarshaler.Unmarshal(raw.Result, &errMsg)
 			}
 			e = parseQueryError(errMsg, raw.Kind, raw.Details, raw.Cause)
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -41,7 +41,7 @@ type SurrealDBTestSuite struct {
 // a simple user struct for testing
 type testUser struct {
 	Username string           `json:"username,omitempty"`
-	Password string           `json:"password,omitempty"`
+	Password string           `json:"password,omitempty"` //nolint:gosec // G117: test auth struct
 	ID       *models.RecordID `json:"id,omitempty"`
 }
 

--- a/errors.go
+++ b/errors.go
@@ -195,7 +195,19 @@ type ServerError struct {
 }
 
 // Error implements the error interface.
+// When a cause chain is present, the messages are joined with ": "
+// so that the full chain is visible in logs and fmt output, since
+// Go has no automatic error-chain display like JS or Python.
 func (e *ServerError) Error() string {
+	if e.cause == nil {
+		return e.message
+	}
+	return e.message + ": " + e.cause.Error()
+}
+
+// Message returns the server's error message for this error only,
+// without appending the cause chain. Use Error() for the full chain.
+func (e *ServerError) Message() string {
 	return e.message
 }
 
@@ -234,11 +246,17 @@ func (e *ServerError) Unwrap() error {
 	return e.cause
 }
 
-// Is supports errors.Is matching. Any *ServerError target matches
-// any *ServerError in the chain, enabling errors.Is(err, &ServerError{}).
+// Is supports errors.Is matching.
+// A zero-kind target acts as a catch-all: errors.Is(err, &ServerError{})
+// matches any *ServerError. A target with a non-empty kind only matches
+// if this error has the same kind, enabling
+// errors.Is(err, &ServerError{kind: "NotFound"}).
 func (e *ServerError) Is(target error) bool {
-	_, ok := target.(*ServerError)
-	return ok
+	t, ok := target.(*ServerError)
+	if !ok {
+		return false
+	}
+	return t.kind == "" || t.kind == e.kind
 }
 
 // HasKind checks if this error or any error in the cause chain matches
@@ -376,7 +394,13 @@ func (e *ServerError) FunctionName() string {
 	return getDetailMapString(e.details, "Function", "name")
 }
 
-// --- NotFound ---
+// TargetName returns the target name that is not allowed, if applicable.
+// Only meaningful when Kind() is ErrorKindNotAllowed.
+func (e *ServerError) TargetName() string {
+	return getDetailMapString(e.details, "Target", "name")
+}
+
+// --- NotFound / AlreadyExists ---
 
 // TableName returns the table name that was not found or already exists,
 // if applicable. Works for both ErrorKindNotFound and ErrorKindAlreadyExists.
@@ -390,16 +414,22 @@ func (e *ServerError) RecordID() string {
 	return getDetailMapString(e.details, "Record", "id")
 }
 
-// NamespaceName returns the namespace name that was not found, if applicable.
-// Only meaningful when Kind() is ErrorKindNotFound.
+// NamespaceName returns the namespace name that was not found or already exists,
+// if applicable. Works for both ErrorKindNotFound and ErrorKindAlreadyExists.
 func (e *ServerError) NamespaceName() string {
 	return getDetailMapString(e.details, "Namespace", "name")
 }
 
-// DatabaseName returns the database name that was not found, if applicable.
-// Only meaningful when Kind() is ErrorKindNotFound.
+// DatabaseName returns the database name that was not found or already exists,
+// if applicable. Works for both ErrorKindNotFound and ErrorKindAlreadyExists.
 func (e *ServerError) DatabaseName() string {
 	return getDetailMapString(e.details, "Database", "name")
+}
+
+// SessionID returns the session ID that was not found or already exists,
+// if applicable. Works for both ErrorKindNotFound and ErrorKindAlreadyExists.
+func (e *ServerError) SessionID() string {
+	return getDetailMapString(e.details, "Session", "id")
 }
 
 // ------------------------------------------------------------------ //

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package surrealdb
 
 import (
 	"errors"
+	"math"
 
 	"github.com/surrealdb/surrealdb.go/pkg/connection"
 )
@@ -157,10 +158,12 @@ func getDetailString(details any, key string) string {
 // getDetailMapString extracts a string field from a variant's inner details.
 //
 // New format: { "kind": "Table", "details": { "name": "users" } }
-//   -> getDetailMapString(d, "Table", "name") returns "users"
+//
+//	-> getDetailMapString(d, "Table", "name") returns "users"
 //
 // Old format: { "Table": { "name": "users" } }
-//   -> getDetailMapString(d, "Table", "name") returns "users"
+//
+//	-> getDetailMapString(d, "Table", "name") returns "users"
 func getDetailMapString(details any, key, field string) string {
 	v := getDetailValue(details, key)
 	if m, ok := v.(map[string]any); ok {
@@ -325,17 +328,17 @@ func (e *ServerError) IsTimedOut() bool {
 	return hasDetailKey(e.details, "TimedOut")
 }
 
-// IsCancelled returns true if the query was cancelled.
+// IsCancelled returns true if the query was canceled.
 // Only meaningful when Kind() is ErrorKindQuery.
 func (e *ServerError) IsCancelled() bool {
-	return hasDetailKey(e.details, "Cancelled")
+	return hasDetailKey(e.details, "Cancelled") //nolint:misspell // matches server wire format
 }
 
 // Timeout returns the timeout duration as (secs, nanos) if this is a
 // timeout error. The ok return value is false if this is not a timeout
 // error or the duration is not available.
 // Only meaningful when Kind() is ErrorKindQuery.
-func (e *ServerError) Timeout() (secs int, nanos int, ok bool) {
+func (e *ServerError) Timeout() (secs, nanos int, ok bool) {
 	v := getDetailValue(e.details, "TimedOut")
 	m, mOk := v.(map[string]any)
 	if !mOk {
@@ -460,7 +463,7 @@ func parseRpcError(raw *connection.RPCError) *ServerError {
 // duplicates the error kind (e.g. { "kind": "AlreadyExists", "details":
 // { "kind": "Record", ... } }). When the outer kind matches the resolved
 // error kind, we unwrap to expose the inner detail directly.
-func parseQueryError(message string, kind string, details any, rawCause *connection.RPCError) *ServerError {
+func parseQueryError(message, kind string, details any, rawCause *connection.RPCError) *ServerError {
 	var cause *ServerError
 	if rawCause != nil {
 		cause = parseRpcError(rawCause)
@@ -606,6 +609,9 @@ func toInt(v any) (int, bool) {
 	case float64:
 		return int(n), true
 	case uint64:
+		if n > uint64(math.MaxInt) {
+			return 0, false
+		}
 		return int(n), true
 	}
 	return 0, false

--- a/errors.go
+++ b/errors.go
@@ -63,13 +63,53 @@ func resolveKind(kind string, code int) string {
 }
 
 // ------------------------------------------------------------------ //
-//  Detail helpers (serde externally-tagged enum navigation)           //
+//  Detail helpers                                                     //
 // ------------------------------------------------------------------ //
+//
+// SurrealDB v3 switched from serde externally-tagged enums to a
+// recursive { "kind": "...", "details": ... } format for error details.
+//
+// Old (v2, externally-tagged):
+//   Unit:    "Parse"
+//   Newtype: { "Auth": "TokenExpired" }
+//   Struct:  { "Table": { "name": "users" } }
+//
+// New (v3, internally-tagged):
+//   Unit:    { "kind": "Parse" }
+//   Newtype: { "kind": "Auth", "details": { "kind": "TokenExpired" } }
+//   Struct:  { "kind": "Table", "details": { "name": "users" } }
+//
+// All helpers support both formats for backward compatibility.
 
-// hasDetailKey checks if details contains key (handles serde tagged format).
-// Unit variants: "VariantName" (top-level string)
-// Struct/newtype variants: { "VariantName": ... } (object key)
+// detailKind returns the "kind" string from a { kind, details? } detail
+// object. Returns "" if details is not in internally-tagged format.
+func detailKind(details any) string {
+	m, ok := details.(map[string]any)
+	if !ok {
+		return ""
+	}
+	k, _ := m["kind"].(string)
+	return k
+}
+
+// detailInner returns the "details" value from a { kind, details? }
+// detail object. Returns nil if not present.
+func detailInner(details any) any {
+	m, ok := details.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return m["details"]
+}
+
+// hasDetailKey checks if details matches the given variant key.
+// Supports both old and new formats.
 func hasDetailKey(details any, key string) bool {
+	// New format: { "kind": "Parse" }
+	if detailKind(details) == key {
+		return true
+	}
+	// Old format: "Parse" (bare string) or { "Parse": ... } (map key)
 	switch d := details.(type) {
 	case string:
 		return d == key
@@ -80,18 +120,47 @@ func hasDetailKey(details any, key string) bool {
 	return false
 }
 
-// getDetailValue gets the value for key from details.
-// Returns nil if key is not present or details is a string/nil.
+// getDetailValue returns the inner value for a given variant key.
+// New format: if kind == key, returns details["details"].
+// Old format: returns details[key].
 func getDetailValue(details any, key string) any {
+	// New format: { "kind": "Auth", "details": { "kind": "TokenExpired" } }
+	if detailKind(details) == key {
+		return detailInner(details)
+	}
+	// Old format: { "Auth": "TokenExpired" }
 	if d, ok := details.(map[string]any); ok {
 		return d[key]
 	}
 	return nil
 }
 
-// getDetailMapString extracts a string field from a nested detail map.
-// For example, getDetailMapString(details, "Table", "name") extracts
-// the "name" field from { "Table": { "name": "users" } }.
+// getDetailString returns a string from the inner details of a variant.
+// New format: if kind == key and details["details"] is { "kind": val }, returns val.
+// Also handles direct string inner for old newtype variants.
+func getDetailString(details any, key string) string {
+	inner := getDetailValue(details, key)
+	if inner == nil {
+		return ""
+	}
+	// New format newtype: inner is { "kind": "TokenExpired" }
+	if k := detailKind(inner); k != "" {
+		return k
+	}
+	// Old format newtype: inner is "TokenExpired"
+	if s, ok := inner.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// getDetailMapString extracts a string field from a variant's inner details.
+//
+// New format: { "kind": "Table", "details": { "name": "users" } }
+//   -> getDetailMapString(d, "Table", "name") returns "users"
+//
+// Old format: { "Table": { "name": "users" } }
+//   -> getDetailMapString(d, "Table", "name") returns "users"
 func getDetailMapString(details any, key, field string) string {
 	v := getDetailValue(details, key)
 	if m, ok := v.(map[string]any); ok {
@@ -142,9 +211,10 @@ func (e *ServerError) Code() int {
 }
 
 // Details returns the kind-specific structured details.
-// The value is either a string (for unit variants like "Parse"),
-// a map[string]any (for struct variants like {"Table": {"name": "users"}}),
-// or nil when not provided by the server.
+// In SurrealDB v3, this follows the { "kind": "...", "details": ... } format.
+// In older versions, this may be a string (unit variants) or a map with the
+// variant name as key (externally-tagged format).
+// Returns nil when not provided by the server.
 func (e *ServerError) Details() any {
 	return e.details
 }
@@ -279,13 +349,13 @@ func (e *ServerError) IsDeserialization() bool {
 // IsTokenExpired returns true if the auth token has expired.
 // Only meaningful when Kind() is ErrorKindNotAllowed.
 func (e *ServerError) IsTokenExpired() bool {
-	return getDetailValue(e.details, "Auth") == "TokenExpired"
+	return getDetailString(e.details, "Auth") == "TokenExpired"
 }
 
 // IsInvalidAuth returns true if authentication credentials are invalid.
 // Only meaningful when Kind() is ErrorKindNotAllowed.
 func (e *ServerError) IsInvalidAuth() bool {
-	return getDetailValue(e.details, "Auth") == "InvalidAuth"
+	return getDetailString(e.details, "Auth") == "InvalidAuth"
 }
 
 // IsScriptingBlocked returns true if scripting is blocked.
@@ -355,13 +425,28 @@ func parseRpcError(raw *connection.RPCError) *ServerError {
 
 // parseQueryError parses a query result error into a *ServerError.
 // Query result errors use result as the message field and have no code.
+//
+// The server's query result path may double-wrap details: the outer object
+// duplicates the error kind (e.g. { "kind": "AlreadyExists", "details":
+// { "kind": "Record", ... } }). When the outer kind matches the resolved
+// error kind, we unwrap to expose the inner detail directly.
 func parseQueryError(message string, kind string, details any, rawCause *connection.RPCError) *ServerError {
 	var cause *ServerError
 	if rawCause != nil {
 		cause = parseRpcError(rawCause)
 	}
+
+	resolved := resolveKind(kind, 0)
+
+	// Unwrap double-wrapped details when the outer kind matches the error kind.
+	if dk := detailKind(details); dk != "" && dk == resolved {
+		if inner := detailInner(details); inner != nil {
+			details = inner
+		}
+	}
+
 	return &ServerError{
-		kind:    resolveKind(kind, 0),
+		kind:    resolved,
 		code:    0,
 		message: message,
 		details: details,

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,497 @@
+package surrealdb
+
+import (
+	"errors"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+)
+
+// ------------------------------------------------------------------ //
+//  ErrorKind constants                                                //
+// ------------------------------------------------------------------ //
+
+// Known error kinds returned by the SurrealDB server.
+// Use these constants for matching against ServerError.Kind().
+const (
+	ErrorKindValidation    = "Validation"
+	ErrorKindConfiguration = "Configuration"
+	ErrorKindThrown        = "Thrown"
+	ErrorKindQuery         = "Query"
+	ErrorKindSerialization = "Serialization"
+	ErrorKindNotAllowed    = "NotAllowed"
+	ErrorKindNotFound      = "NotFound"
+	ErrorKindAlreadyExists = "AlreadyExists"
+	ErrorKindConnection    = "Connection"
+	ErrorKindInternal      = "Internal"
+)
+
+// ------------------------------------------------------------------ //
+//  Legacy code-to-kind mapping                                        //
+// ------------------------------------------------------------------ //
+
+// codeToKind maps legacy JSON-RPC error codes to ErrorKind values.
+// Used when kind is absent (old server format).
+var codeToKind = map[int]string{
+	-32700: ErrorKindValidation,
+	-32600: ErrorKindValidation,
+	-32603: ErrorKindValidation,
+	-32601: ErrorKindNotFound,
+	-32602: ErrorKindNotAllowed,
+	-32002: ErrorKindNotAllowed,
+	-32604: ErrorKindConfiguration,
+	-32605: ErrorKindConfiguration,
+	-32606: ErrorKindConfiguration,
+	-32000: ErrorKindInternal,
+	-32001: ErrorKindConnection,
+	-32003: ErrorKindQuery,
+	-32004: ErrorKindQuery,
+	-32005: ErrorKindQuery,
+	-32006: ErrorKindThrown,
+	-32007: ErrorKindSerialization,
+	-32008: ErrorKindSerialization,
+}
+
+// resolveKind determines the error kind from kind and/or legacy code.
+func resolveKind(kind string, code int) string {
+	if kind != "" {
+		return kind
+	}
+	if k, ok := codeToKind[code]; ok {
+		return k
+	}
+	return ErrorKindInternal
+}
+
+// ------------------------------------------------------------------ //
+//  Detail helpers (serde externally-tagged enum navigation)           //
+// ------------------------------------------------------------------ //
+
+// hasDetailKey checks if details contains key (handles serde tagged format).
+// Unit variants: "VariantName" (top-level string)
+// Struct/newtype variants: { "VariantName": ... } (object key)
+func hasDetailKey(details any, key string) bool {
+	switch d := details.(type) {
+	case string:
+		return d == key
+	case map[string]any:
+		_, ok := d[key]
+		return ok
+	}
+	return false
+}
+
+// getDetailValue gets the value for key from details.
+// Returns nil if key is not present or details is a string/nil.
+func getDetailValue(details any, key string) any {
+	if d, ok := details.(map[string]any); ok {
+		return d[key]
+	}
+	return nil
+}
+
+// getDetailMapString extracts a string field from a nested detail map.
+// For example, getDetailMapString(details, "Table", "name") extracts
+// the "name" field from { "Table": { "name": "users" } }.
+func getDetailMapString(details any, key, field string) string {
+	v := getDetailValue(details, key)
+	if m, ok := v.(map[string]any); ok {
+		if s, ok := m[field].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// ------------------------------------------------------------------ //
+//  ServerError                                                        //
+// ------------------------------------------------------------------ //
+
+// ServerError represents an error originating from the SurrealDB server.
+//
+// Server errors carry structured information:
+//   - Kind — the error category (e.g. "NotAllowed", "NotFound")
+//   - Code — legacy JSON-RPC numeric error code (0 when unavailable)
+//   - Details — kind-specific structured details from the server
+//   - Cause — the underlying server error, if any (recursive chain)
+//
+// Use the helper functions IsNotAllowed, IsNotFound, etc. for ergonomic
+// kind checking, or inspect Kind() directly. Use errors.As to extract
+// a *ServerError from an error chain.
+type ServerError struct {
+	kind    string
+	code    int
+	message string
+	details any          // string, map[string]any, or nil
+	cause   *ServerError // recursive cause chain
+}
+
+// Error implements the error interface.
+func (e *ServerError) Error() string {
+	return e.message
+}
+
+// Kind returns the structured error kind (e.g. "NotAllowed", "NotFound", "Internal").
+func (e *ServerError) Kind() string {
+	return e.kind
+}
+
+// Code returns the legacy JSON-RPC error code. 0 when not available
+// (e.g. query result errors).
+func (e *ServerError) Code() int {
+	return e.code
+}
+
+// Details returns the kind-specific structured details.
+// The value is either a string (for unit variants like "Parse"),
+// a map[string]any (for struct variants like {"Table": {"name": "users"}}),
+// or nil when not provided by the server.
+func (e *ServerError) Details() any {
+	return e.details
+}
+
+// ServerCause returns the underlying server error in the chain, if any.
+func (e *ServerError) ServerCause() *ServerError {
+	return e.cause
+}
+
+// Unwrap implements the Go errors.Unwrap interface, enabling
+// errors.Unwrap(), errors.Is(), and errors.As() to traverse the
+// server error cause chain.
+func (e *ServerError) Unwrap() error {
+	if e.cause == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// Is supports errors.Is matching. Any *ServerError target matches
+// any *ServerError in the chain, enabling errors.Is(err, &ServerError{}).
+func (e *ServerError) Is(target error) bool {
+	_, ok := target.(*ServerError)
+	return ok
+}
+
+// HasKind checks if this error or any error in the cause chain matches
+// the given kind.
+func (e *ServerError) HasKind(kind string) bool {
+	if e.kind == kind {
+		return true
+	}
+	if e.cause != nil {
+		return e.cause.HasKind(kind)
+	}
+	return false
+}
+
+// FindCause finds the first error in the cause chain (including this error)
+// that matches the given kind. Returns nil if no match is found.
+func (e *ServerError) FindCause(kind string) *ServerError {
+	if e.kind == kind {
+		return e
+	}
+	if e.cause != nil {
+		return e.cause.FindCause(kind)
+	}
+	return nil
+}
+
+// ------------------------------------------------------------------ //
+//  Convenience detail accessors                                       //
+// ------------------------------------------------------------------ //
+
+// --- Validation ---
+
+// IsParseError returns true if this is a SurrealQL parse error.
+// Only meaningful when Kind() is ErrorKindValidation.
+func (e *ServerError) IsParseError() bool {
+	return hasDetailKey(e.details, "Parse")
+}
+
+// ParameterName returns the name of the invalid parameter, if applicable.
+// Only meaningful when Kind() is ErrorKindValidation.
+func (e *ServerError) ParameterName() string {
+	return getDetailMapString(e.details, "InvalidParameter", "name")
+}
+
+// --- Configuration ---
+
+// IsLiveQueryNotSupported returns true if live queries are not supported
+// by the server configuration.
+// Only meaningful when Kind() is ErrorKindConfiguration.
+func (e *ServerError) IsLiveQueryNotSupported() bool {
+	return hasDetailKey(e.details, "LiveQueryNotSupported")
+}
+
+// --- Query ---
+
+// IsNotExecuted returns true if the query was not executed (e.g. due to
+// a prior error in the batch).
+// Only meaningful when Kind() is ErrorKindQuery.
+func (e *ServerError) IsNotExecuted() bool {
+	return hasDetailKey(e.details, "NotExecuted")
+}
+
+// IsTimedOut returns true if the query timed out.
+// Only meaningful when Kind() is ErrorKindQuery.
+func (e *ServerError) IsTimedOut() bool {
+	return hasDetailKey(e.details, "TimedOut")
+}
+
+// IsCancelled returns true if the query was cancelled.
+// Only meaningful when Kind() is ErrorKindQuery.
+func (e *ServerError) IsCancelled() bool {
+	return hasDetailKey(e.details, "Cancelled")
+}
+
+// Timeout returns the timeout duration as (secs, nanos) if this is a
+// timeout error. The ok return value is false if this is not a timeout
+// error or the duration is not available.
+// Only meaningful when Kind() is ErrorKindQuery.
+func (e *ServerError) Timeout() (secs int, nanos int, ok bool) {
+	v := getDetailValue(e.details, "TimedOut")
+	m, mOk := v.(map[string]any)
+	if !mOk {
+		return 0, 0, false
+	}
+	dur, dOk := m["duration"].(map[string]any)
+	if !dOk {
+		return 0, 0, false
+	}
+	s, sOk := toInt(dur["secs"])
+	n, nOk := toInt(dur["nanos"])
+	if !sOk || !nOk {
+		return 0, 0, false
+	}
+	return s, n, true
+}
+
+// --- Serialization ---
+
+// IsDeserialization returns true if this is a deserialization error
+// (as opposed to serialization).
+// Only meaningful when Kind() is ErrorKindSerialization.
+func (e *ServerError) IsDeserialization() bool {
+	return hasDetailKey(e.details, "Deserialization")
+}
+
+// --- NotAllowed ---
+
+// IsTokenExpired returns true if the auth token has expired.
+// Only meaningful when Kind() is ErrorKindNotAllowed.
+func (e *ServerError) IsTokenExpired() bool {
+	return getDetailValue(e.details, "Auth") == "TokenExpired"
+}
+
+// IsInvalidAuth returns true if authentication credentials are invalid.
+// Only meaningful when Kind() is ErrorKindNotAllowed.
+func (e *ServerError) IsInvalidAuth() bool {
+	return getDetailValue(e.details, "Auth") == "InvalidAuth"
+}
+
+// IsScriptingBlocked returns true if scripting is blocked.
+// Only meaningful when Kind() is ErrorKindNotAllowed.
+func (e *ServerError) IsScriptingBlocked() bool {
+	return hasDetailKey(e.details, "Scripting")
+}
+
+// MethodName returns the method name that is not allowed or not found,
+// if applicable. Works for both ErrorKindNotAllowed and ErrorKindNotFound.
+func (e *ServerError) MethodName() string {
+	return getDetailMapString(e.details, "Method", "name")
+}
+
+// FunctionName returns the function name that is not allowed, if applicable.
+// Only meaningful when Kind() is ErrorKindNotAllowed.
+func (e *ServerError) FunctionName() string {
+	return getDetailMapString(e.details, "Function", "name")
+}
+
+// --- NotFound ---
+
+// TableName returns the table name that was not found or already exists,
+// if applicable. Works for both ErrorKindNotFound and ErrorKindAlreadyExists.
+func (e *ServerError) TableName() string {
+	return getDetailMapString(e.details, "Table", "name")
+}
+
+// RecordID returns the record ID that was not found or already exists,
+// if applicable. Works for both ErrorKindNotFound and ErrorKindAlreadyExists.
+func (e *ServerError) RecordID() string {
+	return getDetailMapString(e.details, "Record", "id")
+}
+
+// NamespaceName returns the namespace name that was not found, if applicable.
+// Only meaningful when Kind() is ErrorKindNotFound.
+func (e *ServerError) NamespaceName() string {
+	return getDetailMapString(e.details, "Namespace", "name")
+}
+
+// DatabaseName returns the database name that was not found, if applicable.
+// Only meaningful when Kind() is ErrorKindNotFound.
+func (e *ServerError) DatabaseName() string {
+	return getDetailMapString(e.details, "Database", "name")
+}
+
+// ------------------------------------------------------------------ //
+//  Parsing                                                            //
+// ------------------------------------------------------------------ //
+
+// parseRpcError parses an RPC-level error (connection.RPCError) into a
+// *ServerError. Handles both old format (code + message) and new format
+// (code + kind + message + details + cause).
+func parseRpcError(raw *connection.RPCError) *ServerError {
+	var cause *ServerError
+	if raw.Cause != nil {
+		cause = parseRpcError(raw.Cause)
+	}
+	return &ServerError{
+		kind:    resolveKind(raw.Kind, raw.Code),
+		code:    raw.Code,
+		message: raw.Message,
+		details: raw.Details,
+		cause:   cause,
+	}
+}
+
+// parseQueryError parses a query result error into a *ServerError.
+// Query result errors use result as the message field and have no code.
+func parseQueryError(message string, kind string, details any, rawCause *connection.RPCError) *ServerError {
+	var cause *ServerError
+	if rawCause != nil {
+		cause = parseRpcError(rawCause)
+	}
+	return &ServerError{
+		kind:    resolveKind(kind, 0),
+		code:    0,
+		message: message,
+		details: details,
+		cause:   cause,
+	}
+}
+
+// convertError converts an error from the connection layer into a
+// *ServerError if the error is an *RPCError. Other errors pass through
+// unchanged.
+func convertError(err error) error {
+	var rpcErr *connection.RPCError
+	if errors.As(err, &rpcErr) {
+		return parseRpcError(rpcErr)
+	}
+	return err
+}
+
+// ------------------------------------------------------------------ //
+//  Top-level helper functions                                         //
+// ------------------------------------------------------------------ //
+
+// IsServerError reports whether err or any error in its chain is a *ServerError.
+func IsServerError(err error) bool {
+	var se *ServerError
+	return errors.As(err, &se)
+}
+
+// IsValidation reports whether err or any error in its chain is a
+// *ServerError with kind Validation.
+func IsValidation(err error) bool {
+	return hasErrorKind(err, ErrorKindValidation)
+}
+
+// IsConfiguration reports whether err or any error in its chain is a
+// *ServerError with kind Configuration.
+func IsConfiguration(err error) bool {
+	return hasErrorKind(err, ErrorKindConfiguration)
+}
+
+// IsThrown reports whether err or any error in its chain is a
+// *ServerError with kind Thrown.
+func IsThrown(err error) bool {
+	return hasErrorKind(err, ErrorKindThrown)
+}
+
+// IsQueryError reports whether err or any error in its chain is a
+// *ServerError with kind Query.
+func IsQueryError(err error) bool {
+	return hasErrorKind(err, ErrorKindQuery)
+}
+
+// IsSerialization reports whether err or any error in its chain is a
+// *ServerError with kind Serialization.
+func IsSerialization(err error) bool {
+	return hasErrorKind(err, ErrorKindSerialization)
+}
+
+// IsNotAllowed reports whether err or any error in its chain is a
+// *ServerError with kind NotAllowed.
+func IsNotAllowed(err error) bool {
+	return hasErrorKind(err, ErrorKindNotAllowed)
+}
+
+// IsNotFound reports whether err or any error in its chain is a
+// *ServerError with kind NotFound.
+func IsNotFound(err error) bool {
+	return hasErrorKind(err, ErrorKindNotFound)
+}
+
+// IsAlreadyExists reports whether err or any error in its chain is a
+// *ServerError with kind AlreadyExists.
+func IsAlreadyExists(err error) bool {
+	return hasErrorKind(err, ErrorKindAlreadyExists)
+}
+
+// IsConnectionError reports whether err or any error in its chain is a
+// *ServerError with kind Connection.
+func IsConnectionError(err error) bool {
+	return hasErrorKind(err, ErrorKindConnection)
+}
+
+// IsInternal reports whether err or any error in its chain is a
+// *ServerError with kind Internal.
+func IsInternal(err error) bool {
+	return hasErrorKind(err, ErrorKindInternal)
+}
+
+// HasKind reports whether err contains a *ServerError whose cause chain
+// includes the given kind.
+func HasKind(err error, kind string) bool {
+	var se *ServerError
+	if errors.As(err, &se) {
+		return se.HasKind(kind)
+	}
+	return false
+}
+
+// FindCause extracts the first *ServerError in the cause chain
+// (including the error itself) that matches the given kind.
+// Returns nil if no match is found or err is not a *ServerError.
+func FindCause(err error, kind string) *ServerError {
+	var se *ServerError
+	if errors.As(err, &se) {
+		return se.FindCause(kind)
+	}
+	return nil
+}
+
+// hasErrorKind is a shared helper for the Is* functions.
+func hasErrorKind(err error, kind string) bool {
+	var se *ServerError
+	if errors.As(err, &se) {
+		return se.kind == kind
+	}
+	return false
+}
+
+// toInt converts a numeric value from CBOR/JSON decoding to int.
+// CBOR may decode numbers as various numeric types.
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case uint64:
+		return int(n), true
+	}
+	return 0, false
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -246,12 +246,12 @@ func TestV3_Query_TimedOut(t *testing.T) {
 	assert.Equal(t, 0, nanos)
 }
 
-func TestV3_Query_Cancelled(t *testing.T) {
+func TestV3_Query_Canceled(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32005,
 		Kind:    "Query",
-		Message: "Query cancelled",
-		Details: map[string]any{"kind": "Cancelled"},
+		Message: "Query canceled",
+		Details: map[string]any{"kind": "Cancelled"}, //nolint:misspell // matches server wire format
 	})
 
 	assert.True(t, err.IsCancelled())
@@ -710,12 +710,12 @@ func TestOldFormat_Query_TimedOut(t *testing.T) {
 	assert.Equal(t, 0, nanos)
 }
 
-func TestOldFormat_Query_Cancelled(t *testing.T) {
+func TestOldFormat_Query_Canceled(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32005,
 		Kind:    "Query",
-		Message: "Query cancelled",
-		Details: map[string]any{"Cancelled": map[string]any{}},
+		Message: "Query canceled",
+		Details: map[string]any{"Cancelled": map[string]any{}}, //nolint:misspell // matches server wire format
 	})
 
 	assert.True(t, err.IsCancelled())
@@ -1019,7 +1019,7 @@ func TestServerError_Message_WithCause(t *testing.T) {
 // ================================================================= //
 
 func TestBackwardCompat_QueryErrorIsServerError(t *testing.T) {
-	var qe *QueryError = &ServerError{kind: "Query", message: "test"}
+	qe := &QueryError{kind: "Query", message: "test"}
 
 	var se *ServerError
 	assert.True(t, errors.As(qe, &se))

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,940 @@
+package surrealdb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ================================================================= //
+//  Error parsing: new format (kind present)                          //
+// ================================================================= //
+
+func TestParseRpcError_NewFormat_NotAllowed_TokenExpired(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32002,
+		Kind:    "NotAllowed",
+		Message: "Token has expired",
+		Details: map[string]any{"Auth": "TokenExpired"},
+	})
+
+	assert.Equal(t, "NotAllowed", err.Kind())
+	assert.Equal(t, -32002, err.Code())
+	assert.Equal(t, "Token has expired", err.Error())
+	assert.Equal(t, map[string]any{"Auth": "TokenExpired"}, err.Details())
+	assert.Nil(t, err.ServerCause())
+
+	assert.True(t, err.IsTokenExpired())
+	assert.False(t, err.IsInvalidAuth())
+	assert.False(t, err.IsScriptingBlocked())
+	assert.Equal(t, "", err.MethodName())
+	assert.Equal(t, "", err.FunctionName())
+}
+
+func TestParseRpcError_NewFormat_NotAllowed_InvalidAuth(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32002,
+		Kind:    "NotAllowed",
+		Message: "Invalid credentials",
+		Details: map[string]any{"Auth": "InvalidAuth"},
+	})
+
+	assert.True(t, err.IsInvalidAuth())
+	assert.False(t, err.IsTokenExpired())
+}
+
+func TestParseRpcError_NewFormat_NotAllowed_Method(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Method not allowed",
+		Details: map[string]any{"Method": map[string]any{"name": "begin"}},
+	})
+
+	assert.Equal(t, "begin", err.MethodName())
+	assert.False(t, err.IsTokenExpired())
+}
+
+func TestParseRpcError_NewFormat_NotAllowed_Scripting(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Scripting is blocked",
+		Details: map[string]any{"Scripting": map[string]any{}},
+	})
+
+	assert.True(t, err.IsScriptingBlocked())
+}
+
+func TestParseRpcError_NewFormat_NotAllowed_Function(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Function not allowed",
+		Details: map[string]any{"Function": map[string]any{"name": "fn::custom"}},
+	})
+
+	assert.Equal(t, "fn::custom", err.FunctionName())
+}
+
+func TestParseRpcError_NewFormat_NotFound_Table(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Table not found",
+		Details: map[string]any{"Table": map[string]any{"name": "users"}},
+	})
+
+	assert.Equal(t, "NotFound", err.Kind())
+	assert.Equal(t, "users", err.TableName())
+	assert.Equal(t, "", err.RecordID())
+	assert.Equal(t, "", err.MethodName())
+}
+
+func TestParseRpcError_NewFormat_NotFound_Record(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Record not found",
+		Details: map[string]any{"Record": map[string]any{"id": "users:123"}},
+	})
+
+	assert.Equal(t, "users:123", err.RecordID())
+	assert.Equal(t, "", err.TableName())
+}
+
+func TestParseRpcError_NewFormat_NotFound_Method(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32601,
+		Kind:    "NotFound",
+		Message: "Method not found",
+		Details: map[string]any{"Method": map[string]any{"name": "unknown_method"}},
+	})
+
+	assert.Equal(t, "unknown_method", err.MethodName())
+}
+
+func TestParseRpcError_NewFormat_NotFound_Namespace(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Namespace not found",
+		Details: map[string]any{"Namespace": map[string]any{"name": "test"}},
+	})
+
+	assert.Equal(t, "test", err.NamespaceName())
+}
+
+func TestParseRpcError_NewFormat_NotFound_Database(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Database not found",
+		Details: map[string]any{"Database": map[string]any{"name": "test"}},
+	})
+
+	assert.Equal(t, "test", err.DatabaseName())
+}
+
+func TestParseRpcError_NewFormat_AlreadyExists_Record(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Record already exists",
+		Details: map[string]any{"Record": map[string]any{"id": "users:123"}},
+	})
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	assert.Equal(t, "users:123", err.RecordID())
+	assert.Equal(t, "", err.TableName())
+}
+
+func TestParseRpcError_NewFormat_AlreadyExists_Table(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Table already exists",
+		Details: map[string]any{"Table": map[string]any{"name": "users"}},
+	})
+
+	assert.Equal(t, "users", err.TableName())
+}
+
+func TestParseRpcError_NewFormat_Validation_Parse(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32700,
+		Kind:    "Validation",
+		Message: "Parse error",
+		Details: "Parse",
+	})
+
+	assert.Equal(t, "Validation", err.Kind())
+	assert.True(t, err.IsParseError())
+	assert.Equal(t, "", err.ParameterName())
+}
+
+func TestParseRpcError_NewFormat_Validation_InvalidParameter(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32603,
+		Kind:    "Validation",
+		Message: "Invalid parameter",
+		Details: map[string]any{"InvalidParameter": map[string]any{"name": "limit"}},
+	})
+
+	assert.Equal(t, "limit", err.ParameterName())
+	assert.False(t, err.IsParseError())
+}
+
+func TestParseRpcError_NewFormat_Query_NotExecuted(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32003,
+		Kind:    "Query",
+		Message: "Query not executed",
+		Details: map[string]any{"NotExecuted": map[string]any{}},
+	})
+
+	assert.Equal(t, "Query", err.Kind())
+	assert.True(t, err.IsNotExecuted())
+	assert.False(t, err.IsTimedOut())
+	assert.False(t, err.IsCancelled())
+	_, _, ok := err.Timeout()
+	assert.False(t, ok)
+}
+
+func TestParseRpcError_NewFormat_Query_TimedOut(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32004,
+		Kind:    "Query",
+		Message: "Query timed out",
+		Details: map[string]any{
+			"TimedOut": map[string]any{
+				"duration": map[string]any{"secs": 5, "nanos": 0},
+			},
+		},
+	})
+
+	assert.True(t, err.IsTimedOut())
+	secs, nanos, ok := err.Timeout()
+	assert.True(t, ok)
+	assert.Equal(t, 5, secs)
+	assert.Equal(t, 0, nanos)
+}
+
+func TestParseRpcError_NewFormat_Query_Cancelled(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32005,
+		Kind:    "Query",
+		Message: "Query cancelled",
+		Details: map[string]any{"Cancelled": map[string]any{}},
+	})
+
+	assert.True(t, err.IsCancelled())
+}
+
+func TestParseRpcError_NewFormat_Configuration_LiveQuery(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32604,
+		Kind:    "Configuration",
+		Message: "Live queries not supported",
+		Details: map[string]any{"LiveQueryNotSupported": map[string]any{}},
+	})
+
+	assert.Equal(t, "Configuration", err.Kind())
+	assert.True(t, err.IsLiveQueryNotSupported())
+}
+
+func TestParseRpcError_NewFormat_Serialization_Deserialization(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32008,
+		Kind:    "Serialization",
+		Message: "Deserialization failed",
+		Details: map[string]any{"Deserialization": map[string]any{}},
+	})
+
+	assert.Equal(t, "Serialization", err.Kind())
+	assert.True(t, err.IsDeserialization())
+}
+
+func TestParseRpcError_NewFormat_Thrown(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32006,
+		Kind:    "Thrown",
+		Message: "Custom user error",
+	})
+
+	assert.Equal(t, "Thrown", err.Kind())
+	assert.Equal(t, "Custom user error", err.Error())
+}
+
+func TestParseRpcError_NewFormat_Internal(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "Internal",
+		Message: "Something went wrong",
+	})
+
+	assert.Equal(t, "Internal", err.Kind())
+}
+
+func TestParseRpcError_NewFormat_NoDetails(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Not found",
+	})
+
+	assert.Equal(t, "NotFound", err.Kind())
+	assert.Nil(t, err.Details())
+	assert.Equal(t, "", err.TableName())
+	assert.Equal(t, "", err.RecordID())
+}
+
+func TestParseRpcError_NewFormat_NilDetails(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "Internal",
+		Message: "Error",
+		Details: nil,
+	})
+
+	assert.Nil(t, err.Details())
+}
+
+// ================================================================= //
+//  Error parsing: old format (kind absent, derive from code)         //
+// ================================================================= //
+
+func TestParseRpcError_OldFormat_LegacyCodeMapping(t *testing.T) {
+	tests := []struct {
+		code         int
+		expectedKind string
+	}{
+		{-32700, "Validation"},
+		{-32600, "Validation"},
+		{-32603, "Validation"},
+		{-32601, "NotFound"},
+		{-32602, "NotAllowed"},
+		{-32002, "NotAllowed"},
+		{-32604, "Configuration"},
+		{-32605, "Configuration"},
+		{-32606, "Configuration"},
+		{-32000, "Internal"},
+		{-32001, "Connection"},
+		{-32003, "Query"},
+		{-32004, "Query"},
+		{-32005, "Query"},
+		{-32006, "Thrown"},
+		{-32007, "Serialization"},
+		{-32008, "Serialization"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			err := parseRpcError(&connection.RPCError{
+				Code:    tt.code,
+				Message: "test",
+			})
+			assert.Equal(t, tt.expectedKind, err.Kind())
+		})
+	}
+}
+
+func TestParseRpcError_OldFormat_UnknownCodeMapsToInternal(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -99999,
+		Message: "Unknown",
+	})
+
+	assert.Equal(t, "Internal", err.Kind())
+}
+
+func TestParseRpcError_OldFormat_PreservesCodeAndMessage(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32002,
+		Message: "Invalid credentials",
+	})
+
+	assert.Equal(t, -32002, err.Code())
+	assert.Equal(t, "Invalid credentials", err.Error())
+	assert.Nil(t, err.Details())
+	assert.Nil(t, err.ServerCause())
+}
+
+// ================================================================= //
+//  Error parsing: query result errors                                //
+// ================================================================= //
+
+func TestParseQueryError_NewFormat(t *testing.T) {
+	err := parseQueryError(
+		"Table not found",
+		"NotFound",
+		map[string]any{"Table": map[string]any{"name": "users"}},
+		nil,
+	)
+
+	assert.Equal(t, "NotFound", err.Kind())
+	assert.Equal(t, 0, err.Code())
+	assert.Equal(t, "Table not found", err.Error())
+	assert.Equal(t, "users", err.TableName())
+}
+
+func TestParseQueryError_OldFormat_MessageOnly(t *testing.T) {
+	err := parseQueryError(
+		"There was a problem with the database: Table not found",
+		"",
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, "Internal", err.Kind())
+	assert.Equal(t, 0, err.Code())
+	assert.Equal(t, "There was a problem with the database: Table not found", err.Error())
+	assert.Nil(t, err.Details())
+}
+
+func TestParseQueryError_WithCauseChain(t *testing.T) {
+	err := parseQueryError(
+		"Permission denied",
+		"NotAllowed",
+		map[string]any{"Auth": "TokenExpired"},
+		&connection.RPCError{
+			Code:    -32000,
+			Kind:    "Internal",
+			Message: "Session expired",
+		},
+	)
+
+	assert.Equal(t, "NotAllowed", err.Kind())
+	assert.True(t, err.IsTokenExpired())
+
+	cause := err.ServerCause()
+	require.NotNil(t, cause)
+	assert.Equal(t, "Internal", cause.Kind())
+	assert.Equal(t, "Session expired", cause.Error())
+}
+
+// ================================================================= //
+//  Cause chain traversal                                             //
+// ================================================================= //
+
+func TestCauseChain_DeepParsedRecursively(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotAllowed",
+		Message: "Top level",
+		Cause: &connection.RPCError{
+			Code:    -32000,
+			Kind:    "NotFound",
+			Message: "Middle",
+			Cause: &connection.RPCError{
+				Code:    -32000,
+				Kind:    "Internal",
+				Message: "Root cause",
+			},
+		},
+	})
+
+	assert.Equal(t, "NotAllowed", err.Kind())
+
+	middle := err.ServerCause()
+	require.NotNil(t, middle)
+	assert.Equal(t, "NotFound", middle.Kind())
+
+	root := middle.ServerCause()
+	require.NotNil(t, root)
+	assert.Equal(t, "Internal", root.Kind())
+	assert.Equal(t, "Root cause", root.Error())
+	assert.Nil(t, root.ServerCause())
+}
+
+func TestCauseChain_HasKindTraversesChain(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotAllowed",
+		Message: "Top",
+		Cause: &connection.RPCError{
+			Code:    -32000,
+			Kind:    "NotFound",
+			Message: "Nested",
+		},
+	})
+
+	assert.True(t, err.HasKind("NotAllowed"))
+	assert.True(t, err.HasKind("NotFound"))
+	assert.False(t, err.HasKind("Internal"))
+}
+
+func TestCauseChain_FindCauseReturnsMatchingError(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotAllowed",
+		Message: "Top",
+		Cause: &connection.RPCError{
+			Code:    -32000,
+			Kind:    "NotFound",
+			Message: "Nested not found",
+			Details: map[string]any{"Table": map[string]any{"name": "users"}},
+		},
+	})
+
+	found := err.FindCause("NotFound")
+	require.NotNil(t, found)
+	assert.Equal(t, "NotFound", found.Kind())
+	assert.Equal(t, "Nested not found", found.Error())
+	assert.Equal(t, "users", found.TableName())
+}
+
+func TestCauseChain_FindCauseReturnsSelfIfMatch(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Self",
+	})
+
+	found := err.FindCause("NotFound")
+	assert.Equal(t, err, found)
+}
+
+func TestCauseChain_FindCauseReturnsNilWhenNotFound(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "No match",
+	})
+
+	assert.Nil(t, err.FindCause("AlreadyExists"))
+}
+
+func TestCauseChain_UnwrapTraversal(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotAllowed",
+		Message: "Top",
+		Cause: &connection.RPCError{
+			Code:    -32000,
+			Kind:    "Internal",
+			Message: "Bottom",
+		},
+	})
+
+	unwrapped := errors.Unwrap(err)
+	require.NotNil(t, unwrapped)
+
+	var se *ServerError
+	require.True(t, errors.As(unwrapped, &se))
+	assert.Equal(t, "Internal", se.Kind())
+}
+
+// ================================================================= //
+//  Forward compatibility: unknown kinds                              //
+// ================================================================= //
+
+func TestUnknownKinds_CreatesBaseServerError(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "FutureErrorKind",
+		Message: "Some new error",
+		Details: map[string]any{"SomeNewDetail": map[string]any{"foo": "bar"}},
+	})
+
+	assert.Equal(t, "FutureErrorKind", err.Kind())
+	assert.Equal(t, "Some new error", err.Error())
+	assert.Equal(t, map[string]any{"SomeNewDetail": map[string]any{"foo": "bar"}}, err.Details())
+}
+
+func TestUnknownKinds_DoesNotLoseInformation(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "BrandNew",
+		Message: "Details preserved",
+	})
+
+	assert.Equal(t, "BrandNew", err.Kind())
+}
+
+// ================================================================= //
+//  ErrorKind constants                                               //
+// ================================================================= //
+
+func TestErrorKindConstants(t *testing.T) {
+	assert.Equal(t, "Validation", ErrorKindValidation)
+	assert.Equal(t, "Configuration", ErrorKindConfiguration)
+	assert.Equal(t, "Thrown", ErrorKindThrown)
+	assert.Equal(t, "Query", ErrorKindQuery)
+	assert.Equal(t, "Serialization", ErrorKindSerialization)
+	assert.Equal(t, "NotAllowed", ErrorKindNotAllowed)
+	assert.Equal(t, "NotFound", ErrorKindNotFound)
+	assert.Equal(t, "AlreadyExists", ErrorKindAlreadyExists)
+	assert.Equal(t, "Connection", ErrorKindConnection)
+	assert.Equal(t, "Internal", ErrorKindInternal)
+}
+
+func TestErrorKindCanBeUsedForComparison(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Test",
+	})
+
+	assert.Equal(t, ErrorKindNotFound, err.Kind())
+}
+
+// ================================================================= //
+//  ServerError properties                                            //
+// ================================================================= //
+
+func TestServerError_ImplementsError(t *testing.T) {
+	var err error = &ServerError{
+		kind:    "Internal",
+		message: "test",
+	}
+
+	assert.Equal(t, "test", err.Error())
+}
+
+func TestServerError_DefaultsCodeToZero(t *testing.T) {
+	err := &ServerError{kind: "Internal", message: "test"}
+	assert.Equal(t, 0, err.Code())
+}
+
+func TestServerError_DefaultsDetailsToNil(t *testing.T) {
+	err := &ServerError{kind: "Internal", message: "test"}
+	assert.Nil(t, err.Details())
+}
+
+func TestServerError_DefaultsCauseToNil(t *testing.T) {
+	err := &ServerError{kind: "Internal", message: "test"}
+	assert.Nil(t, err.ServerCause())
+	assert.Nil(t, err.Unwrap())
+}
+
+func TestServerError_Is_MatchesAnyServerError(t *testing.T) {
+	err := &ServerError{kind: "NotFound", message: "test"}
+	assert.True(t, errors.Is(err, &ServerError{}))
+}
+
+func TestServerError_Is_DoesNotMatchOtherTypes(t *testing.T) {
+	err := &ServerError{kind: "NotFound", message: "test"}
+	assert.False(t, errors.Is(err, errors.New("test")))
+}
+
+// ================================================================= //
+//  Backward compatibility                                            //
+// ================================================================= //
+
+func TestBackwardCompat_QueryErrorIsServerError(t *testing.T) {
+	var qe *QueryError = &ServerError{
+		kind:    "Query",
+		message: "test",
+	}
+
+	var se *ServerError
+	assert.True(t, errors.As(qe, &se))
+}
+
+func TestBackwardCompat_ErrorsIs_QueryError(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32003,
+		Kind:    "Query",
+		Message: "test",
+	})
+
+	assert.True(t, errors.Is(err, &QueryError{}))
+}
+
+// ================================================================= //
+//  Top-level helper functions                                        //
+// ================================================================= //
+
+func TestHelpers_IsServerError(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "Internal",
+		Message: "boom",
+	})
+
+	assert.True(t, IsServerError(err))
+	assert.False(t, IsServerError(errors.New("not a server error")))
+}
+
+func TestHelpers_IsNotAllowed(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32002,
+		Kind:    "NotAllowed",
+		Message: "Token expired",
+	})
+
+	assert.True(t, IsNotAllowed(err))
+	assert.False(t, IsNotFound(err))
+}
+
+func TestHelpers_IsNotFound(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32601,
+		Kind:    "NotFound",
+		Message: "Table not found",
+	})
+
+	assert.True(t, IsNotFound(err))
+	assert.False(t, IsNotAllowed(err))
+}
+
+func TestHelpers_IsAlreadyExists(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Record exists",
+	})
+
+	assert.True(t, IsAlreadyExists(err))
+}
+
+func TestHelpers_IsValidation(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32700,
+		Kind:    "Validation",
+		Message: "Parse error",
+	})
+
+	assert.True(t, IsValidation(err))
+}
+
+func TestHelpers_IsConfiguration(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32604,
+		Kind:    "Configuration",
+		Message: "Not supported",
+	})
+
+	assert.True(t, IsConfiguration(err))
+}
+
+func TestHelpers_IsThrown(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32006,
+		Kind:    "Thrown",
+		Message: "User error",
+	})
+
+	assert.True(t, IsThrown(err))
+}
+
+func TestHelpers_IsQueryError(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32003,
+		Kind:    "Query",
+		Message: "Query failed",
+	})
+
+	assert.True(t, IsQueryError(err))
+}
+
+func TestHelpers_IsSerialization(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32007,
+		Kind:    "Serialization",
+		Message: "Serialization failed",
+	})
+
+	assert.True(t, IsSerialization(err))
+}
+
+func TestHelpers_IsConnectionError(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32001,
+		Kind:    "Connection",
+		Message: "Connection failed",
+	})
+
+	assert.True(t, IsConnectionError(err))
+}
+
+func TestHelpers_IsInternal(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "Internal",
+		Message: "Internal error",
+	})
+
+	assert.True(t, IsInternal(err))
+}
+
+func TestHelpers_HasKind(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotAllowed",
+		Message: "Top",
+		Cause: &connection.RPCError{
+			Code:    -32000,
+			Kind:    "NotFound",
+			Message: "Nested",
+		},
+	})
+
+	assert.True(t, HasKind(err, "NotAllowed"))
+	assert.True(t, HasKind(err, "NotFound"))
+	assert.False(t, HasKind(err, "Internal"))
+	assert.False(t, HasKind(errors.New("not a server error"), "Internal"))
+}
+
+func TestHelpers_FindCause(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotAllowed",
+		Message: "Top",
+		Cause: &connection.RPCError{
+			Code:    -32000,
+			Kind:    "NotFound",
+			Message: "Nested",
+			Details: map[string]any{"Table": map[string]any{"name": "users"}},
+		},
+	})
+
+	found := FindCause(err, "NotFound")
+	require.NotNil(t, found)
+	assert.Equal(t, "users", found.TableName())
+
+	assert.Nil(t, FindCause(err, "AlreadyExists"))
+	assert.Nil(t, FindCause(errors.New("not a server error"), "Internal"))
+}
+
+// ================================================================= //
+//  convertError                                                      //
+// ================================================================= //
+
+func TestConvertError_RPCError(t *testing.T) {
+	rpcErr := &connection.RPCError{
+		Code:    -32002,
+		Kind:    "NotAllowed",
+		Message: "Token expired",
+		Details: map[string]any{"Auth": "TokenExpired"},
+	}
+
+	converted := convertError(rpcErr)
+
+	var se *ServerError
+	require.True(t, errors.As(converted, &se))
+	assert.Equal(t, "NotAllowed", se.Kind())
+	assert.True(t, se.IsTokenExpired())
+}
+
+func TestConvertError_NonRPCError_PassesThrough(t *testing.T) {
+	original := errors.New("transport error")
+	converted := convertError(original)
+	assert.Equal(t, original, converted)
+}
+
+// ================================================================= //
+//  Detail helpers                                                    //
+// ================================================================= //
+
+func TestHasDetailKey_String(t *testing.T) {
+	assert.True(t, hasDetailKey("Parse", "Parse"))
+	assert.False(t, hasDetailKey("Parse", "Other"))
+}
+
+func TestHasDetailKey_Map(t *testing.T) {
+	details := map[string]any{"Table": map[string]any{"name": "users"}}
+	assert.True(t, hasDetailKey(details, "Table"))
+	assert.False(t, hasDetailKey(details, "Record"))
+}
+
+func TestHasDetailKey_Nil(t *testing.T) {
+	assert.False(t, hasDetailKey(nil, "anything"))
+}
+
+func TestGetDetailValue_Map(t *testing.T) {
+	details := map[string]any{"Auth": "TokenExpired"}
+	assert.Equal(t, "TokenExpired", getDetailValue(details, "Auth"))
+	assert.Nil(t, getDetailValue(details, "Missing"))
+}
+
+func TestGetDetailValue_String(t *testing.T) {
+	assert.Nil(t, getDetailValue("Parse", "Parse"))
+}
+
+func TestGetDetailValue_Nil(t *testing.T) {
+	assert.Nil(t, getDetailValue(nil, "anything"))
+}
+
+func TestGetDetailMapString(t *testing.T) {
+	details := map[string]any{
+		"Table": map[string]any{"name": "users"},
+	}
+	assert.Equal(t, "users", getDetailMapString(details, "Table", "name"))
+	assert.Equal(t, "", getDetailMapString(details, "Table", "missing"))
+	assert.Equal(t, "", getDetailMapString(details, "Missing", "name"))
+	assert.Equal(t, "", getDetailMapString(nil, "Table", "name"))
+}
+
+// ================================================================= //
+//  toInt helper                                                      //
+// ================================================================= //
+
+func TestToInt(t *testing.T) {
+	v, ok := toInt(5)
+	assert.True(t, ok)
+	assert.Equal(t, 5, v)
+
+	v, ok = toInt(int64(10))
+	assert.True(t, ok)
+	assert.Equal(t, 10, v)
+
+	v, ok = toInt(float64(3.0))
+	assert.True(t, ok)
+	assert.Equal(t, 3, v)
+
+	v, ok = toInt(uint64(42))
+	assert.True(t, ok)
+	assert.Equal(t, 42, v)
+
+	_, ok = toInt("not a number")
+	assert.False(t, ok)
+
+	_, ok = toInt(nil)
+	assert.False(t, ok)
+}
+
+// ================================================================= //
+//  Catch-all: errors.As with *ServerError                            //
+// ================================================================= //
+
+func TestCatchAll_ServerErrorViaErrorsAs(t *testing.T) {
+	errs := []error{
+		parseRpcError(&connection.RPCError{Kind: "Internal", Message: "a"}),
+		parseRpcError(&connection.RPCError{Kind: "NotFound", Message: "b"}),
+		parseQueryError("c", "Query", nil, nil),
+	}
+
+	for _, err := range errs {
+		var se *ServerError
+		assert.True(t, errors.As(err, &se), "expected errors.As to match *ServerError")
+	}
+}
+
+func TestCatchAll_NonServerError_DoesNotMatch(t *testing.T) {
+	err := errors.New("not a server error")
+
+	var se *ServerError
+	assert.False(t, errors.As(err, &se))
+}
+
+// ================================================================= //
+//  resolveKind                                                       //
+// ================================================================= //
+
+func TestResolveKind_PrefersKindOverCode(t *testing.T) {
+	assert.Equal(t, "NotFound", resolveKind("NotFound", -32000))
+}
+
+func TestResolveKind_FallsBackToCode(t *testing.T) {
+	assert.Equal(t, "Internal", resolveKind("", -32000))
+	assert.Equal(t, "NotFound", resolveKind("", -32601))
+}
+
+func TestResolveKind_FallsBackToInternal(t *testing.T) {
+	assert.Equal(t, "Internal", resolveKind("", 0))
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -79,6 +79,17 @@ func TestV3_NotAllowed_Function(t *testing.T) {
 	assert.Equal(t, "fn::custom", err.FunctionName())
 }
 
+func TestV3_NotAllowed_Target(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Target not allowed",
+		Details: map[string]any{"kind": "Target", "details": map[string]any{"name": "some_target"}},
+	})
+
+	assert.Equal(t, "some_target", err.TargetName())
+}
+
 func TestV3_NotFound_Table(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
@@ -147,6 +158,7 @@ func TestV3_NotFound_Session(t *testing.T) {
 	})
 
 	assert.Equal(t, "NotFound", err.Kind())
+	assert.Equal(t, "abc-123", err.SessionID())
 }
 
 func TestV3_AlreadyExists_Record(t *testing.T) {
@@ -386,11 +398,14 @@ func TestV3_QueryError_WithCause(t *testing.T) {
 
 	assert.Equal(t, "NotAllowed", err.Kind())
 	assert.True(t, err.IsTokenExpired())
+	assert.Equal(t, "Permission denied: Session expired", err.Error())
+	assert.Equal(t, "Permission denied", err.Message())
 
 	cause := err.ServerCause()
 	require.NotNil(t, cause)
 	assert.Equal(t, "Internal", cause.Kind())
 	assert.Equal(t, "Session expired", cause.Error())
+	assert.Equal(t, "Session expired", cause.Message())
 }
 
 // ================================================================= //
@@ -453,6 +468,42 @@ func TestV3_QueryError_DoubleWrappedDetails_KindMismatchNotUnwrapped(t *testing.
 //  Old format backward compatibility (externally-tagged)             //
 // ================================================================= //
 
+func TestV3_AlreadyExists_Namespace(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Namespace already exists",
+		Details: map[string]any{"kind": "Namespace", "details": map[string]any{"name": "test_ns"}},
+	})
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	assert.Equal(t, "test_ns", err.NamespaceName())
+}
+
+func TestV3_AlreadyExists_Database(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Database already exists",
+		Details: map[string]any{"kind": "Database", "details": map[string]any{"name": "test_db"}},
+	})
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	assert.Equal(t, "test_db", err.DatabaseName())
+}
+
+func TestV3_AlreadyExists_Session(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Session already exists",
+		Details: map[string]any{"kind": "Session", "details": map[string]any{"id": "sess-456"}},
+	})
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	assert.Equal(t, "sess-456", err.SessionID())
+}
+
 func TestOldFormat_NotAllowed_TokenExpired(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32002,
@@ -510,6 +561,17 @@ func TestOldFormat_NotAllowed_Function(t *testing.T) {
 	assert.Equal(t, "fn::custom", err.FunctionName())
 }
 
+func TestOldFormat_NotAllowed_Target(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Target not allowed",
+		Details: map[string]any{"Target": map[string]any{"name": "some_target"}},
+	})
+
+	assert.Equal(t, "some_target", err.TargetName())
+}
+
 func TestOldFormat_NotFound_Table(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
@@ -555,6 +617,17 @@ func TestOldFormat_NotFound_Database(t *testing.T) {
 	assert.Equal(t, "test", err.DatabaseName())
 }
 
+func TestOldFormat_NotFound_Session(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Session not found",
+		Details: map[string]any{"Session": map[string]any{"id": "abc-123"}},
+	})
+
+	assert.Equal(t, "abc-123", err.SessionID())
+}
+
 func TestOldFormat_AlreadyExists_Record(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
@@ -563,7 +636,9 @@ func TestOldFormat_AlreadyExists_Record(t *testing.T) {
 		Details: map[string]any{"Record": map[string]any{"id": "users:123"}},
 	})
 
+	assert.Equal(t, "AlreadyExists", err.Kind())
 	assert.Equal(t, "users:123", err.RecordID())
+	assert.Equal(t, "", err.TableName())
 }
 
 func TestOldFormat_AlreadyExists_Table(t *testing.T) {
@@ -585,6 +660,7 @@ func TestOldFormat_Validation_Parse(t *testing.T) {
 		Details: "Parse",
 	})
 
+	assert.Equal(t, "Validation", err.Kind())
 	assert.True(t, err.IsParseError())
 	assert.Equal(t, "", err.ParameterName())
 }
@@ -598,6 +674,7 @@ func TestOldFormat_Validation_InvalidParameter(t *testing.T) {
 	})
 
 	assert.Equal(t, "limit", err.ParameterName())
+	assert.False(t, err.IsParseError())
 }
 
 func TestOldFormat_Query_NotExecuted(t *testing.T) {
@@ -608,7 +685,10 @@ func TestOldFormat_Query_NotExecuted(t *testing.T) {
 		Details: map[string]any{"NotExecuted": map[string]any{}},
 	})
 
+	assert.Equal(t, "Query", err.Kind())
 	assert.True(t, err.IsNotExecuted())
+	assert.False(t, err.IsTimedOut())
+	assert.False(t, err.IsCancelled())
 }
 
 func TestOldFormat_Query_TimedOut(t *testing.T) {
@@ -649,6 +729,7 @@ func TestOldFormat_Configuration_LiveQuery(t *testing.T) {
 		Details: map[string]any{"LiveQueryNotSupported": map[string]any{}},
 	})
 
+	assert.Equal(t, "Configuration", err.Kind())
 	assert.True(t, err.IsLiveQueryNotSupported())
 }
 
@@ -660,6 +741,7 @@ func TestOldFormat_Serialization_Deserialization(t *testing.T) {
 		Details: map[string]any{"Deserialization": map[string]any{}},
 	})
 
+	assert.Equal(t, "Serialization", err.Kind())
 	assert.True(t, err.IsDeserialization())
 }
 
@@ -759,15 +841,20 @@ func TestCauseChain_DeepParsedRecursively(t *testing.T) {
 	})
 
 	assert.Equal(t, "NotAllowed", err.Kind())
+	assert.Equal(t, "Top level: Middle: Root cause", err.Error())
+	assert.Equal(t, "Top level", err.Message())
 
 	middle := err.ServerCause()
 	require.NotNil(t, middle)
 	assert.Equal(t, "NotFound", middle.Kind())
+	assert.Equal(t, "Middle: Root cause", middle.Error())
+	assert.Equal(t, "Middle", middle.Message())
 
 	root := middle.ServerCause()
 	require.NotNil(t, root)
 	assert.Equal(t, "Internal", root.Kind())
 	assert.Equal(t, "Root cause", root.Error())
+	assert.Equal(t, "Root cause", root.Message())
 	assert.Nil(t, root.ServerCause())
 }
 
@@ -897,9 +984,34 @@ func TestServerError_Is_MatchesAnyServerError(t *testing.T) {
 	assert.True(t, errors.Is(err, &ServerError{}))
 }
 
+func TestServerError_Is_MatchesSameKind(t *testing.T) {
+	err := &ServerError{kind: "NotFound", message: "test"}
+	assert.True(t, errors.Is(err, &ServerError{kind: "NotFound"}))
+}
+
+func TestServerError_Is_DoesNotMatchDifferentKind(t *testing.T) {
+	err := &ServerError{kind: "NotFound", message: "test"}
+	assert.False(t, errors.Is(err, &ServerError{kind: "NotAllowed"}))
+}
+
 func TestServerError_Is_DoesNotMatchOtherTypes(t *testing.T) {
 	err := &ServerError{kind: "NotFound", message: "test"}
 	assert.False(t, errors.Is(err, errors.New("test")))
+}
+
+func TestServerError_Message_WithoutCause(t *testing.T) {
+	err := &ServerError{kind: "Internal", message: "test"}
+	assert.Equal(t, "test", err.Message())
+	assert.Equal(t, "test", err.Error())
+}
+
+func TestServerError_Message_WithCause(t *testing.T) {
+	err := &ServerError{
+		kind: "NotAllowed", message: "Top",
+		cause: &ServerError{kind: "Internal", message: "Bottom"},
+	}
+	assert.Equal(t, "Top", err.Message())
+	assert.Equal(t, "Top: Bottom", err.Error())
 }
 
 // ================================================================= //

--- a/errors_test.go
+++ b/errors_test.go
@@ -4,27 +4,26 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/surrealdb/surrealdb.go/pkg/connection"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go/pkg/connection"
 )
 
 // ================================================================= //
-//  Error parsing: new format (kind present)                          //
+//  V3 format: { "kind": "...", "details": ... } (internally-tagged) //
 // ================================================================= //
 
-func TestParseRpcError_NewFormat_NotAllowed_TokenExpired(t *testing.T) {
+func TestV3_NotAllowed_TokenExpired(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32002,
 		Kind:    "NotAllowed",
 		Message: "Token has expired",
-		Details: map[string]any{"Auth": "TokenExpired"},
+		Details: map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}},
 	})
 
 	assert.Equal(t, "NotAllowed", err.Kind())
 	assert.Equal(t, -32002, err.Code())
 	assert.Equal(t, "Token has expired", err.Error())
-	assert.Equal(t, map[string]any{"Auth": "TokenExpired"}, err.Details())
 	assert.Nil(t, err.ServerCause())
 
 	assert.True(t, err.IsTokenExpired())
@@ -34,7 +33,439 @@ func TestParseRpcError_NewFormat_NotAllowed_TokenExpired(t *testing.T) {
 	assert.Equal(t, "", err.FunctionName())
 }
 
-func TestParseRpcError_NewFormat_NotAllowed_InvalidAuth(t *testing.T) {
+func TestV3_NotAllowed_InvalidAuth(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32002,
+		Kind:    "NotAllowed",
+		Message: "There was a problem with authentication",
+		Details: map[string]any{"kind": "Auth", "details": map[string]any{"kind": "InvalidAuth"}},
+	})
+
+	assert.True(t, err.IsInvalidAuth())
+	assert.False(t, err.IsTokenExpired())
+}
+
+func TestV3_NotAllowed_Method(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Method not allowed",
+		Details: map[string]any{"kind": "Method", "details": map[string]any{"name": "begin"}},
+	})
+
+	assert.Equal(t, "begin", err.MethodName())
+	assert.False(t, err.IsTokenExpired())
+}
+
+func TestV3_NotAllowed_Scripting(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Scripting is blocked",
+		Details: map[string]any{"kind": "Scripting"},
+	})
+
+	assert.True(t, err.IsScriptingBlocked())
+}
+
+func TestV3_NotAllowed_Function(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32602,
+		Kind:    "NotAllowed",
+		Message: "Function not allowed",
+		Details: map[string]any{"kind": "Function", "details": map[string]any{"name": "fn::custom"}},
+	})
+
+	assert.Equal(t, "fn::custom", err.FunctionName())
+}
+
+func TestV3_NotFound_Table(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Table not found",
+		Details: map[string]any{"kind": "Table", "details": map[string]any{"name": "users"}},
+	})
+
+	assert.Equal(t, "NotFound", err.Kind())
+	assert.Equal(t, "users", err.TableName())
+	assert.Equal(t, "", err.RecordID())
+	assert.Equal(t, "", err.MethodName())
+}
+
+func TestV3_NotFound_Record(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Record not found",
+		Details: map[string]any{"kind": "Record", "details": map[string]any{"id": "users:123"}},
+	})
+
+	assert.Equal(t, "users:123", err.RecordID())
+	assert.Equal(t, "", err.TableName())
+}
+
+func TestV3_NotFound_Method(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32601,
+		Kind:    "NotFound",
+		Message: "Method not found",
+		Details: map[string]any{"kind": "Method", "details": map[string]any{"name": "unknown_method"}},
+	})
+
+	assert.Equal(t, "unknown_method", err.MethodName())
+}
+
+func TestV3_NotFound_Namespace(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Namespace not found",
+		Details: map[string]any{"kind": "Namespace", "details": map[string]any{"name": "test"}},
+	})
+
+	assert.Equal(t, "test", err.NamespaceName())
+}
+
+func TestV3_NotFound_Database(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Database not found",
+		Details: map[string]any{"kind": "Database", "details": map[string]any{"name": "test"}},
+	})
+
+	assert.Equal(t, "test", err.DatabaseName())
+}
+
+func TestV3_NotFound_Session(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Session not found",
+		Details: map[string]any{"kind": "Session", "details": map[string]any{"id": "abc-123"}},
+	})
+
+	assert.Equal(t, "NotFound", err.Kind())
+}
+
+func TestV3_AlreadyExists_Record(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Database record `person:dup` already exists",
+		Details: map[string]any{"kind": "Record", "details": map[string]any{"id": "person:dup"}},
+	})
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	assert.Equal(t, "person:dup", err.RecordID())
+	assert.Equal(t, "", err.TableName())
+}
+
+func TestV3_AlreadyExists_Table(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "AlreadyExists",
+		Message: "Table already exists",
+		Details: map[string]any{"kind": "Table", "details": map[string]any{"name": "users"}},
+	})
+
+	assert.Equal(t, "users", err.TableName())
+}
+
+func TestV3_Validation_Parse(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32700,
+		Kind:    "Validation",
+		Message: "Parse error",
+		Details: map[string]any{"kind": "Parse"},
+	})
+
+	assert.Equal(t, "Validation", err.Kind())
+	assert.True(t, err.IsParseError())
+	assert.Equal(t, "", err.ParameterName())
+}
+
+func TestV3_Validation_InvalidParameter(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32603,
+		Kind:    "Validation",
+		Message: "Invalid parameter",
+		Details: map[string]any{"kind": "InvalidParameter", "details": map[string]any{"name": "limit"}},
+	})
+
+	assert.Equal(t, "limit", err.ParameterName())
+	assert.False(t, err.IsParseError())
+}
+
+func TestV3_Query_NotExecuted(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32003,
+		Kind:    "Query",
+		Message: "Query not executed",
+		Details: map[string]any{"kind": "NotExecuted"},
+	})
+
+	assert.Equal(t, "Query", err.Kind())
+	assert.True(t, err.IsNotExecuted())
+	assert.False(t, err.IsTimedOut())
+	assert.False(t, err.IsCancelled())
+	_, _, ok := err.Timeout()
+	assert.False(t, ok)
+}
+
+func TestV3_Query_TimedOut(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32004,
+		Kind:    "Query",
+		Message: "Query timed out",
+		Details: map[string]any{
+			"kind": "TimedOut",
+			"details": map[string]any{
+				"duration": map[string]any{"secs": 5, "nanos": 0},
+			},
+		},
+	})
+
+	assert.True(t, err.IsTimedOut())
+	secs, nanos, ok := err.Timeout()
+	assert.True(t, ok)
+	assert.Equal(t, 5, secs)
+	assert.Equal(t, 0, nanos)
+}
+
+func TestV3_Query_Cancelled(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32005,
+		Kind:    "Query",
+		Message: "Query cancelled",
+		Details: map[string]any{"kind": "Cancelled"},
+	})
+
+	assert.True(t, err.IsCancelled())
+}
+
+func TestV3_Configuration_LiveQuery(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32604,
+		Kind:    "Configuration",
+		Message: "Live queries not supported",
+		Details: map[string]any{"kind": "LiveQueryNotSupported"},
+	})
+
+	assert.Equal(t, "Configuration", err.Kind())
+	assert.True(t, err.IsLiveQueryNotSupported())
+}
+
+func TestV3_Serialization_Deserialization(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32008,
+		Kind:    "Serialization",
+		Message: "Deserialization failed",
+		Details: map[string]any{"kind": "Deserialization"},
+	})
+
+	assert.Equal(t, "Serialization", err.Kind())
+	assert.True(t, err.IsDeserialization())
+}
+
+func TestV3_Thrown(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32006,
+		Kind:    "Thrown",
+		Message: "Custom user error",
+	})
+
+	assert.Equal(t, "Thrown", err.Kind())
+	assert.Equal(t, "Custom user error", err.Error())
+}
+
+func TestV3_Internal(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "Internal",
+		Message: "Something went wrong",
+	})
+
+	assert.Equal(t, "Internal", err.Kind())
+}
+
+func TestV3_NoDetails(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "NotFound",
+		Message: "Not found",
+	})
+
+	assert.Equal(t, "NotFound", err.Kind())
+	assert.Nil(t, err.Details())
+	assert.Equal(t, "", err.TableName())
+	assert.Equal(t, "", err.RecordID())
+}
+
+func TestV3_NilDetails(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32000,
+		Kind:    "Internal",
+		Message: "Error",
+		Details: nil,
+	})
+
+	assert.Nil(t, err.Details())
+}
+
+// ================================================================= //
+//  V3 format: query result errors                                    //
+// ================================================================= //
+
+func TestV3_QueryError_NotFound(t *testing.T) {
+	err := parseQueryError(
+		"Table not found",
+		"NotFound",
+		map[string]any{"kind": "Table", "details": map[string]any{"name": "users"}},
+		nil,
+	)
+
+	assert.Equal(t, "NotFound", err.Kind())
+	assert.Equal(t, 0, err.Code())
+	assert.Equal(t, "Table not found", err.Error())
+	assert.Equal(t, "users", err.TableName())
+}
+
+func TestV3_QueryError_AlreadyExists(t *testing.T) {
+	err := parseQueryError(
+		"Database record `person:dup` already exists",
+		"AlreadyExists",
+		map[string]any{"kind": "Record", "details": map[string]any{"id": "person:dup"}},
+		nil,
+	)
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	assert.Equal(t, "person:dup", err.RecordID())
+}
+
+func TestV3_QueryError_Thrown(t *testing.T) {
+	err := parseQueryError(
+		"An error occurred: custom user error",
+		"Thrown",
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, "Thrown", err.Kind())
+	assert.Equal(t, 0, err.Code())
+	assert.Equal(t, "An error occurred: custom user error", err.Error())
+	assert.Nil(t, err.Details())
+}
+
+func TestV3_QueryError_OldFormat_MessageOnly(t *testing.T) {
+	err := parseQueryError(
+		"There was a problem with the database: Table not found",
+		"",
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, "Internal", err.Kind())
+	assert.Equal(t, 0, err.Code())
+	assert.Equal(t, "There was a problem with the database: Table not found", err.Error())
+	assert.Nil(t, err.Details())
+}
+
+func TestV3_QueryError_WithCause(t *testing.T) {
+	err := parseQueryError(
+		"Permission denied",
+		"NotAllowed",
+		map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}},
+		&connection.RPCError{
+			Code:    -32000,
+			Kind:    "Internal",
+			Message: "Session expired",
+		},
+	)
+
+	assert.Equal(t, "NotAllowed", err.Kind())
+	assert.True(t, err.IsTokenExpired())
+
+	cause := err.ServerCause()
+	require.NotNil(t, cause)
+	assert.Equal(t, "Internal", cause.Kind())
+	assert.Equal(t, "Session expired", cause.Error())
+}
+
+// ================================================================= //
+//  V3 format: double-wrapped details unwrapping                      //
+// ================================================================= //
+
+func TestV3_QueryError_DoubleWrappedDetails(t *testing.T) {
+	err := parseQueryError(
+		"Record already exists",
+		"AlreadyExists",
+		map[string]any{
+			"kind": "AlreadyExists",
+			"details": map[string]any{
+				"kind":    "Record",
+				"details": map[string]any{"id": "person:dup"},
+			},
+		},
+		nil,
+	)
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	assert.Equal(t, "person:dup", err.RecordID())
+}
+
+func TestV3_QueryError_DoubleWrappedDetails_NotFound(t *testing.T) {
+	err := parseQueryError(
+		"Table not found",
+		"NotFound",
+		map[string]any{
+			"kind": "NotFound",
+			"details": map[string]any{
+				"kind":    "Table",
+				"details": map[string]any{"name": "users"},
+			},
+		},
+		nil,
+	)
+
+	assert.Equal(t, "NotFound", err.Kind())
+	assert.Equal(t, "users", err.TableName())
+}
+
+func TestV3_QueryError_DoubleWrappedDetails_KindMismatchNotUnwrapped(t *testing.T) {
+	details := map[string]any{
+		"kind": "NotFound",
+		"details": map[string]any{
+			"kind":    "Table",
+			"details": map[string]any{"name": "users"},
+		},
+	}
+
+	err := parseQueryError("Error", "AlreadyExists", details, nil)
+
+	assert.Equal(t, "AlreadyExists", err.Kind())
+	// Should NOT unwrap because outer kind "NotFound" != error kind "AlreadyExists"
+	assert.Equal(t, "", err.TableName())
+}
+
+// ================================================================= //
+//  Old format backward compatibility (externally-tagged)             //
+// ================================================================= //
+
+func TestOldFormat_NotAllowed_TokenExpired(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{
+		Code:    -32002,
+		Kind:    "NotAllowed",
+		Message: "Token has expired",
+		Details: map[string]any{"Auth": "TokenExpired"},
+	})
+
+	assert.True(t, err.IsTokenExpired())
+	assert.False(t, err.IsInvalidAuth())
+}
+
+func TestOldFormat_NotAllowed_InvalidAuth(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32002,
 		Kind:    "NotAllowed",
@@ -46,7 +477,7 @@ func TestParseRpcError_NewFormat_NotAllowed_InvalidAuth(t *testing.T) {
 	assert.False(t, err.IsTokenExpired())
 }
 
-func TestParseRpcError_NewFormat_NotAllowed_Method(t *testing.T) {
+func TestOldFormat_NotAllowed_Method(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32602,
 		Kind:    "NotAllowed",
@@ -55,10 +486,9 @@ func TestParseRpcError_NewFormat_NotAllowed_Method(t *testing.T) {
 	})
 
 	assert.Equal(t, "begin", err.MethodName())
-	assert.False(t, err.IsTokenExpired())
 }
 
-func TestParseRpcError_NewFormat_NotAllowed_Scripting(t *testing.T) {
+func TestOldFormat_NotAllowed_Scripting(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32602,
 		Kind:    "NotAllowed",
@@ -69,7 +499,7 @@ func TestParseRpcError_NewFormat_NotAllowed_Scripting(t *testing.T) {
 	assert.True(t, err.IsScriptingBlocked())
 }
 
-func TestParseRpcError_NewFormat_NotAllowed_Function(t *testing.T) {
+func TestOldFormat_NotAllowed_Function(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32602,
 		Kind:    "NotAllowed",
@@ -80,7 +510,7 @@ func TestParseRpcError_NewFormat_NotAllowed_Function(t *testing.T) {
 	assert.Equal(t, "fn::custom", err.FunctionName())
 }
 
-func TestParseRpcError_NewFormat_NotFound_Table(t *testing.T) {
+func TestOldFormat_NotFound_Table(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
 		Kind:    "NotFound",
@@ -88,13 +518,11 @@ func TestParseRpcError_NewFormat_NotFound_Table(t *testing.T) {
 		Details: map[string]any{"Table": map[string]any{"name": "users"}},
 	})
 
-	assert.Equal(t, "NotFound", err.Kind())
 	assert.Equal(t, "users", err.TableName())
 	assert.Equal(t, "", err.RecordID())
-	assert.Equal(t, "", err.MethodName())
 }
 
-func TestParseRpcError_NewFormat_NotFound_Record(t *testing.T) {
+func TestOldFormat_NotFound_Record(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
 		Kind:    "NotFound",
@@ -103,21 +531,9 @@ func TestParseRpcError_NewFormat_NotFound_Record(t *testing.T) {
 	})
 
 	assert.Equal(t, "users:123", err.RecordID())
-	assert.Equal(t, "", err.TableName())
 }
 
-func TestParseRpcError_NewFormat_NotFound_Method(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32601,
-		Kind:    "NotFound",
-		Message: "Method not found",
-		Details: map[string]any{"Method": map[string]any{"name": "unknown_method"}},
-	})
-
-	assert.Equal(t, "unknown_method", err.MethodName())
-}
-
-func TestParseRpcError_NewFormat_NotFound_Namespace(t *testing.T) {
+func TestOldFormat_NotFound_Namespace(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
 		Kind:    "NotFound",
@@ -128,7 +544,7 @@ func TestParseRpcError_NewFormat_NotFound_Namespace(t *testing.T) {
 	assert.Equal(t, "test", err.NamespaceName())
 }
 
-func TestParseRpcError_NewFormat_NotFound_Database(t *testing.T) {
+func TestOldFormat_NotFound_Database(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
 		Kind:    "NotFound",
@@ -139,7 +555,7 @@ func TestParseRpcError_NewFormat_NotFound_Database(t *testing.T) {
 	assert.Equal(t, "test", err.DatabaseName())
 }
 
-func TestParseRpcError_NewFormat_AlreadyExists_Record(t *testing.T) {
+func TestOldFormat_AlreadyExists_Record(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
 		Kind:    "AlreadyExists",
@@ -147,12 +563,10 @@ func TestParseRpcError_NewFormat_AlreadyExists_Record(t *testing.T) {
 		Details: map[string]any{"Record": map[string]any{"id": "users:123"}},
 	})
 
-	assert.Equal(t, "AlreadyExists", err.Kind())
 	assert.Equal(t, "users:123", err.RecordID())
-	assert.Equal(t, "", err.TableName())
 }
 
-func TestParseRpcError_NewFormat_AlreadyExists_Table(t *testing.T) {
+func TestOldFormat_AlreadyExists_Table(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32000,
 		Kind:    "AlreadyExists",
@@ -163,7 +577,7 @@ func TestParseRpcError_NewFormat_AlreadyExists_Table(t *testing.T) {
 	assert.Equal(t, "users", err.TableName())
 }
 
-func TestParseRpcError_NewFormat_Validation_Parse(t *testing.T) {
+func TestOldFormat_Validation_Parse(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32700,
 		Kind:    "Validation",
@@ -171,12 +585,11 @@ func TestParseRpcError_NewFormat_Validation_Parse(t *testing.T) {
 		Details: "Parse",
 	})
 
-	assert.Equal(t, "Validation", err.Kind())
 	assert.True(t, err.IsParseError())
 	assert.Equal(t, "", err.ParameterName())
 }
 
-func TestParseRpcError_NewFormat_Validation_InvalidParameter(t *testing.T) {
+func TestOldFormat_Validation_InvalidParameter(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32603,
 		Kind:    "Validation",
@@ -185,10 +598,9 @@ func TestParseRpcError_NewFormat_Validation_InvalidParameter(t *testing.T) {
 	})
 
 	assert.Equal(t, "limit", err.ParameterName())
-	assert.False(t, err.IsParseError())
 }
 
-func TestParseRpcError_NewFormat_Query_NotExecuted(t *testing.T) {
+func TestOldFormat_Query_NotExecuted(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32003,
 		Kind:    "Query",
@@ -196,15 +608,10 @@ func TestParseRpcError_NewFormat_Query_NotExecuted(t *testing.T) {
 		Details: map[string]any{"NotExecuted": map[string]any{}},
 	})
 
-	assert.Equal(t, "Query", err.Kind())
 	assert.True(t, err.IsNotExecuted())
-	assert.False(t, err.IsTimedOut())
-	assert.False(t, err.IsCancelled())
-	_, _, ok := err.Timeout()
-	assert.False(t, ok)
 }
 
-func TestParseRpcError_NewFormat_Query_TimedOut(t *testing.T) {
+func TestOldFormat_Query_TimedOut(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32004,
 		Kind:    "Query",
@@ -223,7 +630,7 @@ func TestParseRpcError_NewFormat_Query_TimedOut(t *testing.T) {
 	assert.Equal(t, 0, nanos)
 }
 
-func TestParseRpcError_NewFormat_Query_Cancelled(t *testing.T) {
+func TestOldFormat_Query_Cancelled(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32005,
 		Kind:    "Query",
@@ -234,7 +641,7 @@ func TestParseRpcError_NewFormat_Query_Cancelled(t *testing.T) {
 	assert.True(t, err.IsCancelled())
 }
 
-func TestParseRpcError_NewFormat_Configuration_LiveQuery(t *testing.T) {
+func TestOldFormat_Configuration_LiveQuery(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32604,
 		Kind:    "Configuration",
@@ -242,11 +649,10 @@ func TestParseRpcError_NewFormat_Configuration_LiveQuery(t *testing.T) {
 		Details: map[string]any{"LiveQueryNotSupported": map[string]any{}},
 	})
 
-	assert.Equal(t, "Configuration", err.Kind())
 	assert.True(t, err.IsLiveQueryNotSupported())
 }
 
-func TestParseRpcError_NewFormat_Serialization_Deserialization(t *testing.T) {
+func TestOldFormat_Serialization_Deserialization(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
 		Code:    -32008,
 		Kind:    "Serialization",
@@ -254,60 +660,46 @@ func TestParseRpcError_NewFormat_Serialization_Deserialization(t *testing.T) {
 		Details: map[string]any{"Deserialization": map[string]any{}},
 	})
 
-	assert.Equal(t, "Serialization", err.Kind())
 	assert.True(t, err.IsDeserialization())
 }
 
-func TestParseRpcError_NewFormat_Thrown(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32006,
-		Kind:    "Thrown",
-		Message: "Custom user error",
-	})
-
-	assert.Equal(t, "Thrown", err.Kind())
-	assert.Equal(t, "Custom user error", err.Error())
-}
-
-func TestParseRpcError_NewFormat_Internal(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "Internal",
-		Message: "Something went wrong",
-	})
-
-	assert.Equal(t, "Internal", err.Kind())
-}
-
-func TestParseRpcError_NewFormat_NoDetails(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotFound",
-		Message: "Not found",
-	})
+func TestOldFormat_QueryError(t *testing.T) {
+	err := parseQueryError(
+		"Table not found",
+		"NotFound",
+		map[string]any{"Table": map[string]any{"name": "users"}},
+		nil,
+	)
 
 	assert.Equal(t, "NotFound", err.Kind())
-	assert.Nil(t, err.Details())
-	assert.Equal(t, "", err.TableName())
-	assert.Equal(t, "", err.RecordID())
+	assert.Equal(t, "users", err.TableName())
 }
 
-func TestParseRpcError_NewFormat_NilDetails(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "Internal",
-		Message: "Error",
-		Details: nil,
-	})
+func TestOldFormat_QueryError_WithCause(t *testing.T) {
+	err := parseQueryError(
+		"Permission denied",
+		"NotAllowed",
+		map[string]any{"Auth": "TokenExpired"},
+		&connection.RPCError{
+			Code:    -32000,
+			Kind:    "Internal",
+			Message: "Session expired",
+		},
+	)
 
-	assert.Nil(t, err.Details())
+	assert.Equal(t, "NotAllowed", err.Kind())
+	assert.True(t, err.IsTokenExpired())
+
+	cause := err.ServerCause()
+	require.NotNil(t, cause)
+	assert.Equal(t, "Internal", cause.Kind())
 }
 
 // ================================================================= //
-//  Error parsing: old format (kind absent, derive from code)         //
+//  Legacy code-to-kind mapping (no kind field, derive from code)     //
 // ================================================================= //
 
-func TestParseRpcError_OldFormat_LegacyCodeMapping(t *testing.T) {
+func TestLegacy_CodeToKindMapping(t *testing.T) {
 	tests := []struct {
 		code         int
 		expectedKind string
@@ -332,30 +724,18 @@ func TestParseRpcError_OldFormat_LegacyCodeMapping(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
-			err := parseRpcError(&connection.RPCError{
-				Code:    tt.code,
-				Message: "test",
-			})
-			assert.Equal(t, tt.expectedKind, err.Kind())
-		})
+		err := parseRpcError(&connection.RPCError{Code: tt.code, Message: "test"})
+		assert.Equal(t, tt.expectedKind, err.Kind())
 	}
 }
 
-func TestParseRpcError_OldFormat_UnknownCodeMapsToInternal(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -99999,
-		Message: "Unknown",
-	})
-
+func TestLegacy_UnknownCodeMapsToInternal(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{Code: -99999, Message: "Unknown"})
 	assert.Equal(t, "Internal", err.Kind())
 }
 
-func TestParseRpcError_OldFormat_PreservesCodeAndMessage(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32002,
-		Message: "Invalid credentials",
-	})
+func TestLegacy_PreservesCodeAndMessage(t *testing.T) {
+	err := parseRpcError(&connection.RPCError{Code: -32002, Message: "Invalid credentials"})
 
 	assert.Equal(t, -32002, err.Code())
 	assert.Equal(t, "Invalid credentials", err.Error())
@@ -364,75 +744,16 @@ func TestParseRpcError_OldFormat_PreservesCodeAndMessage(t *testing.T) {
 }
 
 // ================================================================= //
-//  Error parsing: query result errors                                //
-// ================================================================= //
-
-func TestParseQueryError_NewFormat(t *testing.T) {
-	err := parseQueryError(
-		"Table not found",
-		"NotFound",
-		map[string]any{"Table": map[string]any{"name": "users"}},
-		nil,
-	)
-
-	assert.Equal(t, "NotFound", err.Kind())
-	assert.Equal(t, 0, err.Code())
-	assert.Equal(t, "Table not found", err.Error())
-	assert.Equal(t, "users", err.TableName())
-}
-
-func TestParseQueryError_OldFormat_MessageOnly(t *testing.T) {
-	err := parseQueryError(
-		"There was a problem with the database: Table not found",
-		"",
-		nil,
-		nil,
-	)
-
-	assert.Equal(t, "Internal", err.Kind())
-	assert.Equal(t, 0, err.Code())
-	assert.Equal(t, "There was a problem with the database: Table not found", err.Error())
-	assert.Nil(t, err.Details())
-}
-
-func TestParseQueryError_WithCauseChain(t *testing.T) {
-	err := parseQueryError(
-		"Permission denied",
-		"NotAllowed",
-		map[string]any{"Auth": "TokenExpired"},
-		&connection.RPCError{
-			Code:    -32000,
-			Kind:    "Internal",
-			Message: "Session expired",
-		},
-	)
-
-	assert.Equal(t, "NotAllowed", err.Kind())
-	assert.True(t, err.IsTokenExpired())
-
-	cause := err.ServerCause()
-	require.NotNil(t, cause)
-	assert.Equal(t, "Internal", cause.Kind())
-	assert.Equal(t, "Session expired", cause.Error())
-}
-
-// ================================================================= //
 //  Cause chain traversal                                             //
 // ================================================================= //
 
 func TestCauseChain_DeepParsedRecursively(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotAllowed",
-		Message: "Top level",
+		Code: -32000, Kind: "NotAllowed", Message: "Top level",
 		Cause: &connection.RPCError{
-			Code:    -32000,
-			Kind:    "NotFound",
-			Message: "Middle",
+			Code: -32000, Kind: "NotFound", Message: "Middle",
 			Cause: &connection.RPCError{
-				Code:    -32000,
-				Kind:    "Internal",
-				Message: "Root cause",
+				Code: -32000, Kind: "Internal", Message: "Root cause",
 			},
 		},
 	})
@@ -452,13 +773,9 @@ func TestCauseChain_DeepParsedRecursively(t *testing.T) {
 
 func TestCauseChain_HasKindTraversesChain(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotAllowed",
-		Message: "Top",
+		Code: -32000, Kind: "NotAllowed", Message: "Top",
 		Cause: &connection.RPCError{
-			Code:    -32000,
-			Kind:    "NotFound",
-			Message: "Nested",
+			Code: -32000, Kind: "NotFound", Message: "Nested",
 		},
 	})
 
@@ -469,14 +786,10 @@ func TestCauseChain_HasKindTraversesChain(t *testing.T) {
 
 func TestCauseChain_FindCauseReturnsMatchingError(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotAllowed",
-		Message: "Top",
+		Code: -32000, Kind: "NotAllowed", Message: "Top",
 		Cause: &connection.RPCError{
-			Code:    -32000,
-			Kind:    "NotFound",
-			Message: "Nested not found",
-			Details: map[string]any{"Table": map[string]any{"name": "users"}},
+			Code: -32000, Kind: "NotFound", Message: "Nested not found",
+			Details: map[string]any{"kind": "Table", "details": map[string]any{"name": "users"}},
 		},
 	})
 
@@ -488,36 +801,19 @@ func TestCauseChain_FindCauseReturnsMatchingError(t *testing.T) {
 }
 
 func TestCauseChain_FindCauseReturnsSelfIfMatch(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotFound",
-		Message: "Self",
-	})
-
-	found := err.FindCause("NotFound")
-	assert.Equal(t, err, found)
+	err := parseRpcError(&connection.RPCError{Code: -32000, Kind: "NotFound", Message: "Self"})
+	assert.Equal(t, err, err.FindCause("NotFound"))
 }
 
 func TestCauseChain_FindCauseReturnsNilWhenNotFound(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotFound",
-		Message: "No match",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32000, Kind: "NotFound", Message: "No match"})
 	assert.Nil(t, err.FindCause("AlreadyExists"))
 }
 
 func TestCauseChain_UnwrapTraversal(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotAllowed",
-		Message: "Top",
-		Cause: &connection.RPCError{
-			Code:    -32000,
-			Kind:    "Internal",
-			Message: "Bottom",
-		},
+		Code: -32000, Kind: "NotAllowed", Message: "Top",
+		Cause: &connection.RPCError{Code: -32000, Kind: "Internal", Message: "Bottom"},
 	})
 
 	unwrapped := errors.Unwrap(err)
@@ -537,21 +833,15 @@ func TestUnknownKinds_CreatesBaseServerError(t *testing.T) {
 		Code:    -32000,
 		Kind:    "FutureErrorKind",
 		Message: "Some new error",
-		Details: map[string]any{"SomeNewDetail": map[string]any{"foo": "bar"}},
+		Details: map[string]any{"kind": "SomeNewDetail", "details": map[string]any{"foo": "bar"}},
 	})
 
 	assert.Equal(t, "FutureErrorKind", err.Kind())
 	assert.Equal(t, "Some new error", err.Error())
-	assert.Equal(t, map[string]any{"SomeNewDetail": map[string]any{"foo": "bar"}}, err.Details())
 }
 
 func TestUnknownKinds_DoesNotLoseInformation(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "BrandNew",
-		Message: "Details preserved",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32000, Kind: "BrandNew", Message: "Details preserved"})
 	assert.Equal(t, "BrandNew", err.Kind())
 }
 
@@ -573,12 +863,7 @@ func TestErrorKindConstants(t *testing.T) {
 }
 
 func TestErrorKindCanBeUsedForComparison(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotFound",
-		Message: "Test",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32000, Kind: "NotFound", Message: "Test"})
 	assert.Equal(t, ErrorKindNotFound, err.Kind())
 }
 
@@ -587,11 +872,7 @@ func TestErrorKindCanBeUsedForComparison(t *testing.T) {
 // ================================================================= //
 
 func TestServerError_ImplementsError(t *testing.T) {
-	var err error = &ServerError{
-		kind:    "Internal",
-		message: "test",
-	}
-
+	var err error = &ServerError{kind: "Internal", message: "test"}
 	assert.Equal(t, "test", err.Error())
 }
 
@@ -622,26 +903,18 @@ func TestServerError_Is_DoesNotMatchOtherTypes(t *testing.T) {
 }
 
 // ================================================================= //
-//  Backward compatibility                                            //
+//  Backward compatibility aliases                                    //
 // ================================================================= //
 
 func TestBackwardCompat_QueryErrorIsServerError(t *testing.T) {
-	var qe *QueryError = &ServerError{
-		kind:    "Query",
-		message: "test",
-	}
+	var qe *QueryError = &ServerError{kind: "Query", message: "test"}
 
 	var se *ServerError
 	assert.True(t, errors.As(qe, &se))
 }
 
 func TestBackwardCompat_ErrorsIs_QueryError(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32003,
-		Kind:    "Query",
-		Message: "test",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32003, Kind: "Query", Message: "test"})
 	assert.True(t, errors.Is(err, &QueryError{}))
 }
 
@@ -650,128 +923,67 @@ func TestBackwardCompat_ErrorsIs_QueryError(t *testing.T) {
 // ================================================================= //
 
 func TestHelpers_IsServerError(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "Internal",
-		Message: "boom",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32000, Kind: "Internal", Message: "boom"})
 	assert.True(t, IsServerError(err))
 	assert.False(t, IsServerError(errors.New("not a server error")))
 }
 
 func TestHelpers_IsNotAllowed(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32002,
-		Kind:    "NotAllowed",
-		Message: "Token expired",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32002, Kind: "NotAllowed", Message: "Token expired"})
 	assert.True(t, IsNotAllowed(err))
 	assert.False(t, IsNotFound(err))
 }
 
 func TestHelpers_IsNotFound(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32601,
-		Kind:    "NotFound",
-		Message: "Table not found",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32601, Kind: "NotFound", Message: "Table not found"})
 	assert.True(t, IsNotFound(err))
 	assert.False(t, IsNotAllowed(err))
 }
 
 func TestHelpers_IsAlreadyExists(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "AlreadyExists",
-		Message: "Record exists",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32000, Kind: "AlreadyExists", Message: "Record exists"})
 	assert.True(t, IsAlreadyExists(err))
 }
 
 func TestHelpers_IsValidation(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32700,
-		Kind:    "Validation",
-		Message: "Parse error",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32700, Kind: "Validation", Message: "Parse error"})
 	assert.True(t, IsValidation(err))
 }
 
 func TestHelpers_IsConfiguration(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32604,
-		Kind:    "Configuration",
-		Message: "Not supported",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32604, Kind: "Configuration", Message: "Not supported"})
 	assert.True(t, IsConfiguration(err))
 }
 
 func TestHelpers_IsThrown(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32006,
-		Kind:    "Thrown",
-		Message: "User error",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32006, Kind: "Thrown", Message: "User error"})
 	assert.True(t, IsThrown(err))
 }
 
 func TestHelpers_IsQueryError(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32003,
-		Kind:    "Query",
-		Message: "Query failed",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32003, Kind: "Query", Message: "Query failed"})
 	assert.True(t, IsQueryError(err))
 }
 
 func TestHelpers_IsSerialization(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32007,
-		Kind:    "Serialization",
-		Message: "Serialization failed",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32007, Kind: "Serialization", Message: "Serialization failed"})
 	assert.True(t, IsSerialization(err))
 }
 
 func TestHelpers_IsConnectionError(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32001,
-		Kind:    "Connection",
-		Message: "Connection failed",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32001, Kind: "Connection", Message: "Connection failed"})
 	assert.True(t, IsConnectionError(err))
 }
 
 func TestHelpers_IsInternal(t *testing.T) {
-	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "Internal",
-		Message: "Internal error",
-	})
-
+	err := parseRpcError(&connection.RPCError{Code: -32000, Kind: "Internal", Message: "Internal error"})
 	assert.True(t, IsInternal(err))
 }
 
 func TestHelpers_HasKind(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotAllowed",
-		Message: "Top",
-		Cause: &connection.RPCError{
-			Code:    -32000,
-			Kind:    "NotFound",
-			Message: "Nested",
-		},
+		Code: -32000, Kind: "NotAllowed", Message: "Top",
+		Cause: &connection.RPCError{Code: -32000, Kind: "NotFound", Message: "Nested"},
 	})
 
 	assert.True(t, HasKind(err, "NotAllowed"))
@@ -782,14 +994,10 @@ func TestHelpers_HasKind(t *testing.T) {
 
 func TestHelpers_FindCause(t *testing.T) {
 	err := parseRpcError(&connection.RPCError{
-		Code:    -32000,
-		Kind:    "NotAllowed",
-		Message: "Top",
+		Code: -32000, Kind: "NotAllowed", Message: "Top",
 		Cause: &connection.RPCError{
-			Code:    -32000,
-			Kind:    "NotFound",
-			Message: "Nested",
-			Details: map[string]any{"Table": map[string]any{"name": "users"}},
+			Code: -32000, Kind: "NotFound", Message: "Nested",
+			Details: map[string]any{"kind": "Table", "details": map[string]any{"name": "users"}},
 		},
 	})
 
@@ -810,7 +1018,7 @@ func TestConvertError_RPCError(t *testing.T) {
 		Code:    -32002,
 		Kind:    "NotAllowed",
 		Message: "Token expired",
-		Details: map[string]any{"Auth": "TokenExpired"},
+		Details: map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}},
 	}
 
 	converted := convertError(rpcErr)
@@ -828,15 +1036,68 @@ func TestConvertError_NonRPCError_PassesThrough(t *testing.T) {
 }
 
 // ================================================================= //
-//  Detail helpers                                                    //
+//  Detail helpers: new format                                        //
 // ================================================================= //
 
-func TestHasDetailKey_String(t *testing.T) {
+func TestDetailKind(t *testing.T) {
+	assert.Equal(t, "Auth", detailKind(map[string]any{"kind": "Auth"}))
+	assert.Equal(t, "Parse", detailKind(map[string]any{"kind": "Parse"}))
+	assert.Equal(t, "", detailKind("Parse"))
+	assert.Equal(t, "", detailKind(nil))
+	assert.Equal(t, "", detailKind(map[string]any{"other": "value"}))
+}
+
+func TestDetailInner(t *testing.T) {
+	inner := detailInner(map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}})
+	assert.Equal(t, map[string]any{"kind": "TokenExpired"}, inner)
+
+	assert.Nil(t, detailInner(map[string]any{"kind": "Parse"}))
+	assert.Nil(t, detailInner("Parse"))
+	assert.Nil(t, detailInner(nil))
+}
+
+func TestHasDetailKey_V3_UnitVariant(t *testing.T) {
+	details := map[string]any{"kind": "Parse"}
+	assert.True(t, hasDetailKey(details, "Parse"))
+	assert.False(t, hasDetailKey(details, "Other"))
+}
+
+func TestHasDetailKey_V3_NewtypeVariant(t *testing.T) {
+	details := map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}}
+	assert.True(t, hasDetailKey(details, "Auth"))
+	assert.False(t, hasDetailKey(details, "TokenExpired"))
+}
+
+func TestGetDetailValue_V3(t *testing.T) {
+	details := map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}}
+	inner := getDetailValue(details, "Auth")
+	assert.Equal(t, map[string]any{"kind": "TokenExpired"}, inner)
+	assert.Nil(t, getDetailValue(details, "Missing"))
+}
+
+func TestGetDetailString_V3(t *testing.T) {
+	details := map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}}
+	assert.Equal(t, "TokenExpired", getDetailString(details, "Auth"))
+	assert.Equal(t, "", getDetailString(details, "Missing"))
+}
+
+func TestGetDetailMapString_V3(t *testing.T) {
+	details := map[string]any{"kind": "Table", "details": map[string]any{"name": "users"}}
+	assert.Equal(t, "users", getDetailMapString(details, "Table", "name"))
+	assert.Equal(t, "", getDetailMapString(details, "Table", "missing"))
+	assert.Equal(t, "", getDetailMapString(details, "Missing", "name"))
+}
+
+// ================================================================= //
+//  Detail helpers: old format (backward compat)                      //
+// ================================================================= //
+
+func TestHasDetailKey_Old_String(t *testing.T) {
 	assert.True(t, hasDetailKey("Parse", "Parse"))
 	assert.False(t, hasDetailKey("Parse", "Other"))
 }
 
-func TestHasDetailKey_Map(t *testing.T) {
+func TestHasDetailKey_Old_Map(t *testing.T) {
 	details := map[string]any{"Table": map[string]any{"name": "users"}}
 	assert.True(t, hasDetailKey(details, "Table"))
 	assert.False(t, hasDetailKey(details, "Record"))
@@ -846,13 +1107,13 @@ func TestHasDetailKey_Nil(t *testing.T) {
 	assert.False(t, hasDetailKey(nil, "anything"))
 }
 
-func TestGetDetailValue_Map(t *testing.T) {
+func TestGetDetailValue_Old_Map(t *testing.T) {
 	details := map[string]any{"Auth": "TokenExpired"}
 	assert.Equal(t, "TokenExpired", getDetailValue(details, "Auth"))
 	assert.Nil(t, getDetailValue(details, "Missing"))
 }
 
-func TestGetDetailValue_String(t *testing.T) {
+func TestGetDetailValue_Old_String(t *testing.T) {
 	assert.Nil(t, getDetailValue("Parse", "Parse"))
 }
 
@@ -860,10 +1121,8 @@ func TestGetDetailValue_Nil(t *testing.T) {
 	assert.Nil(t, getDetailValue(nil, "anything"))
 }
 
-func TestGetDetailMapString(t *testing.T) {
-	details := map[string]any{
-		"Table": map[string]any{"name": "users"},
-	}
+func TestGetDetailMapString_Old(t *testing.T) {
+	details := map[string]any{"Table": map[string]any{"name": "users"}}
 	assert.Equal(t, "users", getDetailMapString(details, "Table", "name"))
 	assert.Equal(t, "", getDetailMapString(details, "Table", "missing"))
 	assert.Equal(t, "", getDetailMapString(details, "Missing", "name"))
@@ -917,7 +1176,6 @@ func TestCatchAll_ServerErrorViaErrorsAs(t *testing.T) {
 
 func TestCatchAll_NonServerError_DoesNotMatch(t *testing.T) {
 	err := errors.New("not a server error")
-
 	var se *ServerError
 	assert.False(t, errors.As(err, &se))
 }

--- a/example_db_recorduser_test.go
+++ b/example_db_recorduser_test.go
@@ -136,7 +136,7 @@ func ExampleDB_record_user_custom_struct() {
 		Database  string `json:"DB"`
 		Access    string `json:"AC"`
 		Name      string `json:"name"`
-		Password  string `json:"password"`
+		Password  string `json:"password"` //nolint:gosec // G117: test auth struct
 		Email     string `json:"email"`
 	}
 
@@ -145,7 +145,7 @@ func ExampleDB_record_user_custom_struct() {
 		Database  string `json:"DB"`
 		Access    string `json:"AC"`
 		Email     string `json:"email"`
-		Password  string `json:"password"`
+		Password  string `json:"password"` //nolint:gosec // G117: test auth struct
 	}
 
 	_, err := db.SignUp(context.Background(), &User{

--- a/example_query_transaction_test.go
+++ b/example_query_transaction_test.go
@@ -113,15 +113,13 @@ func ExampleQuery_transaction_throw() {
 	fmt.Printf("# of ERR results: %d\n", len(errResults))
 	fmt.Println("=== Func error ===")
 	fmt.Printf("Error: %v\n", normalizeTransactionError(err))
-	fmt.Printf("Error is RPCError: %v\n", errors.Is(err, &surrealdb.RPCError{}))
-	fmt.Printf("Error is QueryError: %v\n", errors.Is(err, &surrealdb.QueryError{}))
+	fmt.Printf("Error is ServerError: %v\n", errors.Is(err, &surrealdb.ServerError{}))
 	for i, r := range errResults {
 		fmt.Printf("=== QueryResult[%d] ===\n", i)
 		fmt.Printf("Status: %v\n", r.Status)
 		fmt.Printf("Result: %v\n", r.Result)
 		fmt.Printf("Error: %v\n", normalizeTransactionError(r.Error))
-		fmt.Printf("Error is RPCError: %v\n", errors.Is(r.Error, &surrealdb.RPCError{}))
-		fmt.Printf("Error is QueryError: %v\n", errors.Is(r.Error, &surrealdb.QueryError{}))
+		fmt.Printf("Error is ServerError: %v\n", errors.Is(r.Error, &surrealdb.ServerError{}))
 	}
 
 	// Output:
@@ -129,20 +127,17 @@ func ExampleQuery_transaction_throw() {
 	// === Func error ===
 	// Error: An error occurred: test
 	// The query was not executed due to a failed transaction
-	// Error is RPCError: false
-	// Error is QueryError: true
+	// Error is ServerError: true
 	// === QueryResult[0] ===
 	// Status: ERR
 	// Result: <nil>
 	// Error: An error occurred: test
-	// Error is RPCError: false
-	// Error is QueryError: true
+	// Error is ServerError: true
 	// === QueryResult[1] ===
 	// Status: ERR
 	// Result: <nil>
 	// Error: The query was not executed due to a failed transaction
-	// Error is RPCError: false
-	// Error is QueryError: true
+	// Error is ServerError: true
 }
 
 // See https://github.com/surrealdb/surrealdb.go/issues/177

--- a/example_upsert_test.go
+++ b/example_upsert_test.go
@@ -234,10 +234,10 @@ func ExampleUpsert_rpc_error() {
 		default:
 			fmt.Printf("Unknown Error: %v\n", err)
 		}
-		fmt.Printf("Error is RPCError: %v\n", errors.Is(err, &surrealdb.RPCError{}))
+		fmt.Printf("Error is ServerError: %v\n", errors.Is(err, &surrealdb.ServerError{}))
 	}
 
 	// Output:
 	// Encountered expected error for SurrealDB 2.x or 3.x
-	// Error is RPCError: true
+	// Error is ServerError: true
 }

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -13,7 +13,7 @@ import (
 // a simple user struct for testing
 type testUser struct {
 	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty"` //nolint:gosec // G117: test auth struct
 	ID       string `json:"id,omitempty"`
 }
 

--- a/internal/fakesdb/server.go
+++ b/internal/fakesdb/server.go
@@ -534,7 +534,7 @@ func (h *Handler) applyFailure(socket *gws.Conn, failure FailureConfig, req *con
 				return fmt.Errorf("failed to send corrupted message: %w", err)
 			}
 			for i := 0; i < len(data) && i < 10; i++ {
-				data[cryptoRandInt(len(data))] = byte(cryptoRandInt(256))
+				data[cryptoRandInt(len(data))] = byte(cryptoRandInt(256)) //nolint:gosec // G115: value is [0,255], fits in byte
 			}
 			if err := socket.WriteMessage(gws.OpcodeBinary, data); err != nil {
 				log.Printf("Error writing corrupted message: %v", err)

--- a/pkg/connection/http/connection.go
+++ b/pkg/connection/http/connection.go
@@ -150,7 +150,7 @@ func (c *Connection) Call(ctx context.Context, request *connection.RPCRequest) (
 }
 
 func (c *Connection) MakeRequest(req *http.Request) ([]byte, error) {
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from user-configured endpoint
 	if err != nil {
 		return nil, fmt.Errorf("error making HTTP request: %w", err)
 	}

--- a/pkg/connection/integration/connection_test.go
+++ b/pkg/connection/integration/connection_test.go
@@ -20,7 +20,7 @@ import (
 
 type testUser struct {
 	Username string           `json:"username,omitempty"`
-	Password string           `json:"password,omitempty"`
+	Password string           `json:"password,omitempty"` //nolint:gosec // G117: test auth struct
 	ID       *models.RecordID `json:"id,omitempty"`
 }
 

--- a/pkg/connection/model.go
+++ b/pkg/connection/model.go
@@ -1,26 +1,18 @@
 package connection
 
-// RPCError represents a JSON-RPC error
+// RPCError represents a JSON-RPC error from the SurrealDB server.
+// It captures both the legacy format (code + message) and the new structured
+// format (kind + details + cause) introduced in SurrealDB 3.x.
 type RPCError struct {
-	Code        int    `json:"code"`
-	Message     string `json:"message,omitempty"`
-	Description string `json:"description,omitempty"`
+	Code    int       `json:"code"`
+	Message string    `json:"message,omitempty"`
+	Kind    string    `json:"kind,omitempty"`
+	Details any       `json:"details,omitempty"`
+	Cause   *RPCError `json:"cause,omitempty"`
 }
 
 func (r RPCError) Error() string {
-	if r.Description != "" {
-		return r.Description
-	}
 	return r.Message
-}
-
-func (r *RPCError) Is(target error) bool {
-	if target == nil {
-		return r == nil
-	}
-
-	_, ok := target.(*RPCError)
-	return ok
 }
 
 // RPCRequest represents an incoming JSON-RPC request.

--- a/surrealcbor/decode_map_all_test.go
+++ b/surrealcbor/decode_map_all_test.go
@@ -282,7 +282,7 @@ func TestDecode_map_withAllSupportedTypes(t *testing.T) {
 			if num < 0 {
 				require.FailNowf(t, "Negative number found in AnyMap", "key: %s, value: %d", k, num)
 			}
-			expected.AnyMap[k] = uint64(num)
+			expected.AnyMap[k] = uint64(num) //nolint:gosec // G115: test values are small positive ints
 		} else {
 			expected.AnyMap[k] = v
 		}

--- a/types.go
+++ b/types.go
@@ -76,7 +76,7 @@ type Auth struct {
 	Scope     string `json:"SC,omitempty"`
 	Access    string `json:"AC,omitempty"`
 	Username  string `json:"user,omitempty"`
-	Password  string `json:"pass,omitempty"`
+	Password  string `json:"pass,omitempty"` //nolint:gosec // G117: user-supplied auth credential
 }
 
 // Deprecated: Use map[string]any instead

--- a/types.go
+++ b/types.go
@@ -8,7 +8,15 @@ import (
 	"github.com/surrealdb/surrealdb.go/pkg/models"
 )
 
+// Deprecated: Use [ServerError] instead. RPCError is kept as a type alias
+// for backward compatibility. Server errors are now returned as *ServerError
+// with structured kind, details, and cause information.
 type RPCError = connection.RPCError
+
+// Deprecated: Use [ServerError] instead. QueryError is kept as a type alias
+// for backward compatibility. Query errors are now returned as *ServerError
+// with Kind set to the appropriate ErrorKind.
+type QueryError = ServerError
 
 // Patch represents a patch object set to MODIFY a record
 type PatchData struct {
@@ -20,35 +28,23 @@ type PatchData struct {
 // QueryResult is a struct that represents one of the results
 // of a SurrealDB query RPC method call, made via [Query], for example.
 type QueryResult[T any] struct {
-	Status string      `json:"status"`
-	Time   string      `json:"time"`
-	Result T           `json:"result"`
-	Error  *QueryError `json:"-"`
+	Status string       `json:"status"`
+	Time   string       `json:"time"`
+	Result T            `json:"result"`
+	Error  *ServerError `json:"-"`
 }
 
-// QueryError represents an error that occurred during a query execution.
-//
-// The caller can type-assert the return errror to QueryError to see if
-// the error is a query error or not.
-type QueryError struct {
-	Message string
-}
-
-func (e *QueryError) Error() string {
-	if e == nil {
-		return ""
-	}
-
-	return e.Message
-}
-
-func (e *QueryError) Is(target error) bool {
-	if target == nil {
-		return e == nil
-	}
-
-	_, ok := target.(*QueryError)
-	return ok
+// rawQueryResult is used internally to decode query results from CBOR
+// before converting to the public QueryResult type. It captures the new
+// structured error fields (kind, details, cause) alongside the standard
+// status/time/result fields.
+type rawQueryResult struct {
+	Status  string               `json:"status"`
+	Time    string               `json:"time"`
+	Result  cbor.RawMessage      `json:"result"`
+	Kind    string               `json:"kind,omitempty"`
+	Details any                  `json:"details,omitempty"`
+	Cause   *connection.RPCError `json:"cause,omitempty"`
 }
 
 type QueryStmt struct {


### PR DESCRIPTION
## Structured error handling for SurrealDB v3

Adds full support for the structured error format introduced in SurrealDB v3.

### What changed

**V3 detail format support** — SurrealDB v3 switched from serde externally-tagged enums (`{"Auth": "TokenExpired"}`) to an internally-tagged format (`{"kind": "Auth", "details": {"kind": "TokenExpired"}}`). New helpers (`detailKind`, `detailInner`, `getDetailString`) handle the v3 format while retaining full backward compatibility with the old format.

**Recursive cause chain** — `ServerError` now carries a `cause *ServerError` field, matching Rust's `cause: Option<Box<Error>>`. The chain is parsed recursively from both RPC errors and query result errors. Since Go has no automatic error-chain display (unlike JS's `Error.cause` or Python's `__cause__`), `Error()` now joins the full cause chain with `": "` so the complete context is visible in logs. A new `Message()` method returns just the current error's message without the chain.

**Cause chain traversal** — `ServerCause()`, `Unwrap()`, `HasKind()`, and `FindCause()` methods on `*ServerError`, plus top-level `HasKind(err, kind)` and `FindCause(err, kind)` functions that work on any `error`.

**Kind-aware `errors.Is`** — `Is()` now supports optional kind matching: `errors.Is(err, &ServerError{})` matches any server error (catch-all), while `errors.Is(err, &ServerError{kind: "NotFound"})` only matches that specific kind.

**New detail accessors** — `SessionID()` and `TargetName()` for parity with the Python SDK. Updated doc comments on `NamespaceName()` and `DatabaseName()` to reflect they work for both `NotFound` and `AlreadyExists` kinds.

**Double-wrapped details unwrapping** — The server's query result path may double-wrap details (e.g. `{"kind": "AlreadyExists", "details": {"kind": "Record", ...}}`). `parseQueryError` now detects and unwraps this so detail accessors like `RecordID()` work correctly.

**Integration tests** — New `contrib/testenv/structured_errors_integration_test.go` validates structured errors against a live SurrealDB v3 instance: invalid credentials, parse errors, `THROW`, duplicate records, schema violations, and mixed multi-statement queries.

**CI** — Updated test matrix from `v3.0.0-beta.2` to `v3.0.0` GA.

**Lint cleanup** — Resolved all 32 pre-existing golangci-lint issues across the codebase (gosec, gocritic, gofmt, misspell, staticcheck, unparam). The repo now passes `golangci-lint run ./...` with zero issues.

### API surface

```go
// Cause chain
err.ServerCause() *ServerError   // direct cause
err.Unwrap() error               // for errors.Unwrap/Is/As
err.HasKind(kind string) bool    // check entire chain
err.FindCause(kind string) *SE   // find first match in chain
err.Error() string               // "msg: cause: root" (full chain)
err.Message() string             // "msg" (this error only)

// Top-level helpers (work on any error)
HasKind(err, kind) bool
FindCause(err, kind) *ServerError

// Kind-aware Is()
errors.Is(err, &ServerError{})                  // catch-all
errors.Is(err, &ServerError{kind: "NotFound"})  // kind-specific

// New detail accessors
err.SessionID() string   // NotFound/AlreadyExists Session detail
err.TargetName() string  // NotAllowed Target detail
```

### Test plan

- [x] All existing unit tests updated and passing
- [x] V3 internally-tagged format tests (all error kinds and detail variants)
- [x] Old externally-tagged format backward compatibility tests
- [x] Cause chain traversal: deep recursion, `HasKind`, `FindCause`, `Unwrap`
- [x] Double-wrapped detail unwrapping (query result path)
- [x] `Error()` chain formatting and `Message()` isolation
- [x] Kind-aware `Is()` matching
- [x] `SessionID()` and `TargetName()` accessors (V3 and old format)
- [x] Integration tests against live SurrealDB v3.0.0
- [x] `golangci-lint run ./...` passes with 0 issues