### PR TITLE
Bump fxamacker/cbor/v2 v2.7.0 to v2.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/surrealdb/surrealdb.go
 go 1.23
 
 require (
-	github.com/fxamacker/cbor/v2 v2.7.0
+	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/lxzan/gws v1.8.9
 	github.com/stretchr/testify v1.8.4
@@ -13,7 +14,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dolthub/maphash v0.1.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
 github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
-github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
-github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
+github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=


### PR DESCRIPTION
## Summary

Bump `fxamacker/cbor/v2` from v2.7.0 to v2.9.0.

## Changes

Only `go.mod` and `go.sum` are modified. No source code changes required.

## What's New in v2.8.0–v2.9.0

- **v2.9.0**: Opt-in `encoding.TextMarshaler`/`TextUnmarshaler` support, opt-in `json.Marshaler`/`json.Unmarshaler` via transcoding, improved `DupMapKeyError` messages
- **v2.8.0**: Added `omitzero` struct tag option, fixed error handling in deprecated `RawTag.UnmarshalCBOR()`, `ByteString.UnmarshalCBOR()`, `SimpleValue.UnmarshalCBOR()`

## Compatibility

- No breaking API changes (semver v2.x)
- `cbor.RawMessage` type unchanged (used in `db.go` for `Query`/`QueryRaw`)
- `EncMode`, `DecMode`, `TagSet`, `TagOptions` APIs unchanged (used in `pkg/models/cbor.go` and `surrealcbor/`)
- Minimum Go version: 1.20 (repo specifies 1.23)
- `x448/float16` transitive dependency unchanged at v0.8.4

## Testing

- `make lint` passes
- `make build` compiles cleanly
- `make test` passes with default `surrealcbor` codec
- Tests pass with `SURREALDB_CBOR_IMPL=fxamackercbor` (legacy codec path)