### PR TITLE
fix: prevent data race between Kill/CloseLiveNotifications and handleResponse

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -110,7 +110,7 @@ func (bc *Toolkit) CreateNotificationChannel(liveQueryID string) (chan Notificat
 		return nil, fmt.Errorf("%w: %v", constants.ErrIDInUse, liveQueryID)
 	}
 
-	ch := make(chan Notification)
+	ch := make(chan Notification, 16)
 	bc.NotificationChannels[liveQueryID] = ch
 
 	return ch, nil
@@ -173,4 +173,29 @@ func (bc *Toolkit) CloseLiveNotifications(liveQueryID string) error {
 	close(ch)
 	delete(bc.NotificationChannels, liveQueryID)
 	return nil
+}
+
+// SendNotification safely sends a notification to the channel identified by id.
+// It holds the read lock during the send to prevent CloseLiveNotifications from
+// closing the channel concurrently, which would cause a "send on closed channel" panic.
+// Returns true if the notification was sent, false if the channel was not found
+// or was full (dropped).
+func (bc *Toolkit) SendNotification(id string, notification Notification) bool {
+	bc.NotificationChannelsLock.RLock()
+	ch, ok := bc.NotificationChannels[id]
+	if !ok {
+		bc.NotificationChannelsLock.RUnlock()
+		return false
+	}
+
+	select {
+	case ch <- notification:
+		bc.NotificationChannelsLock.RUnlock()
+		return true
+	default:
+		// Channel is full, drop the notification to avoid blocking
+		// while holding the read lock.
+		bc.NotificationChannelsLock.RUnlock()
+		return false
+	}
 }

--- a/pkg/connection/gorillaws/connection.go
+++ b/pkg/connection/gorillaws/connection.go
@@ -537,15 +537,11 @@ func (c *Connection) handleResponse(res []byte) {
 			return
 		}
 
-		LiveNotificationChan, ok := c.GetNotificationChannel(channelID.String())
-		if !ok {
+		if !c.SendNotification(channelID.String(), notification) {
 			c.logger.Error(
 				fmt.Sprintf("unavailable ResponseChannel %+v", channelID.String()),
 				"result", fmt.Sprint(rpcRes.Result),
 			)
-			return
 		}
-
-		LiveNotificationChan <- notification
 	}
 }

--- a/pkg/connection/gws/connection.go
+++ b/pkg/connection/gws/connection.go
@@ -146,12 +146,11 @@ func (c *Connection) handleResponse(data []byte) {
 			return
 		}
 
-		notificationChan, ok := c.GetNotificationChannel(notification.ID.String())
-		if !ok {
-			return
+		if !c.SendNotification(notification.ID.String(), notification) {
+			c.logError(
+				fmt.Sprintf("unavailable NotificationChannel %+v", notification.ID.String()),
+			)
 		}
-
-		notificationChan <- notification
 	}
 }
 


### PR DESCRIPTION
## Problem

Fixes #393

There is a data race between `CloseLiveNotifications`/`Kill` and `handleResponse` in WebSocket connections. When a live query is killed while notifications are still being received:

1. `Kill()` calls `CloseLiveNotifications(id)` which acquires the write lock, closes the notification channel, and removes it from the map
2. Concurrently, `handleResponse` (running in a separate goroutine) calls `GetNotificationChannel(id)` (read lock), gets the channel, releases the lock, then sends on the channel
3. Between releasing the read lock and sending, `CloseLiveNotifications` can close the channel, causing a **"send on closed channel" panic**

The race window exists because the read lock is released before the send operation.

## Fix

This PR introduces a `SendNotification` method on `Toolkit` that holds the read lock during the channel send, preventing `CloseLiveNotifications` from acquiring the write lock and closing the channel while a notification is being sent:

```go
func (bc *Toolkit) SendNotification(id string, notification Notification) bool {
    bc.NotificationChannelsLock.RLock()
    ch, ok := bc.NotificationChannels[id]
    if !ok {
        bc.NotificationChannelsLock.RUnlock()
        return false
    }

    select {
    case ch <- notification:
        bc.NotificationChannelsLock.RUnlock()
        return true
    default:
        bc.NotificationChannelsLock.RUnlock()
        return false
    }
}
```

Key design decisions:
- **Buffered channels (16)**: Notification channels are now created with a buffer of 16 to prevent the send from blocking while holding the read lock. This allows `SendNotification` to use a non-blocking send.
- **Drop-on-full**: If the channel buffer is full, the notification is dropped rather than blocking. This is safer than deadlocking and matches the real-time nature of live query notifications.
- **Both WS implementations updated**: Both `gorillaws` and `gws` `handleResponse` methods now use `SendNotification` instead of directly accessing the channel.

## Testing

- `go build ./...` passes
- `go vet ./pkg/connection/...` passes
- All unit tests pass (integration tests require a running SurrealDB instance)

---

*This PR was created by an AI contributor. The fix has been verified with build and vet checks.*