### PR TITLE
fix: check for nil Result in Info() to prevent panic

### DIFF
--- a/db.go
+++ b/db.go
@@ -149,6 +149,9 @@ func (db *DB) Use(ctx context.Context, ns, database string) error {
 func (db *DB) Info(ctx context.Context) (map[string]any, error) {
 	var info connection.RPCResponse[map[string]any]
 	err := connection.Send(db.con, ctx, &info, "info")
+	if info.Result == nil {
+		return nil, err
+	}
 	return *info.Result, err
 }
 


### PR DESCRIPTION
Fixes #389

## Problem

`DB.Info()` panics with a nil pointer dereference when signed in as root user:

```go
db.SignIn(ctx, &surrealdb.Auth{Username: "root", Password: "root"})
info, err := db.Info(ctx) // PANIC: nil pointer dereference
```

The SurrealDB `info` RPC returns `null` for root users. `RPCResponse[T].Result` is `*T`, so it becomes `nil`. The code dereferences it unconditionally with `*info.Result`.

## Fix

Add a nil check before dereferencing:

```go
if info.Result == nil {
    return nil, err
}
return *info.Result, err
```