### PR TITLE
fix: handle timeout/network errors in WebSocket handleError to prevent panic

### DIFF
--- a/pkg/connection/gorillaws/connection.go
+++ b/pkg/connection/gorillaws/connection.go
@@ -462,6 +462,16 @@ func (c *Connection) handleError(err error) bool {
 		return true
 	}
 
+	// Handle timeout and network errors to prevent readLoop from
+	// retrying on a dead connection, which can cause panics.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		c.closeMutex.Lock()
+		c.connCloseError = err
+		c.closeMutex.Unlock()
+		return true
+	}
+
 	c.logger.Error(err.Error())
 	return false
 }


### PR DESCRIPTION
Fixes #395 (Bug 1)

## Problem

`handleError()` only recognizes `net.ErrClosed` and `IsUnexpectedCloseError`. When the connection gets a timeout (`*net.OpError`) or other network error, `handleError` returns `false`, causing `readLoop` to call `ReadMessage()` again on the dead connection. This eventually causes gorilla/websocket to panic internally.

## Fix

Add a check for `net.Error` (the interface implemented by all network errors including timeouts):

```go
var netErr net.Error
if errors.As(err, &netErr) {
    c.closeMutex.Lock()
    c.connCloseError = err
    c.closeMutex.Unlock()
    return true
}
```

This covers `*net.OpError`, `os.ErrDeadlineExceeded`, and other network-level errors, causing `readLoop` to exit cleanly instead of retrying on a dead connection.

**Note:** Bug 2 from #395 (Call() hanging when readLoop exits) is a separate issue that needs the pending calls to be notified when the connection closes. This PR addresses the panic prevention.