### PR TITLE
Raise timeouts in CBOR DecOptions example tests

### DIFF
--- a/example_fromconnection_fxamacker_cbor_decopts_test.go
+++ b/example_fromconnection_fxamacker_cbor_decopts_test.go
@@ -31,7 +31,7 @@ func ExampleFromConnection_cborUnmarshaler_decOptions_defaultLimit() {
 	conf.Logger = nil
 	conn := gorillaws.New(conf)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
 	defer cancel()
 
 	db, err := surrealdb.FromConnection(ctx, conn)
@@ -83,7 +83,7 @@ func ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit() {
 		conf.Logger = nil
 		conn := gws.New(conf)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
 		defer cancel()
 
 		db, err := surrealdb.FromConnection(ctx, conn)
@@ -130,7 +130,7 @@ func ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit() {
 		}
 		conn := gws.New(conf)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
 		defer cancel()
 
 		db, err := surrealdb.FromConnection(ctx, conn)
@@ -187,7 +187,7 @@ func ExampleCborUnmarshaler_DecOptions_customLargeLimit() {
 	}
 	conn := gorillaws.New(conf)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
 	defer cancel()
 
 	db, err := surrealdb.FromConnection(ctx, conn)
@@ -224,9 +224,29 @@ func ExampleCborUnmarshaler_DecOptions_customLargeLimit() {
 	// Successfully retrieved record with 20 items
 }
 
+// Timeouts used across the examples in this file.
+//
+// These are deliberately generous so that the examples do not flake on slow CI
+// runners where the initial WebSocket handshake, Use, SignIn and query round
+// trips can easily take longer than a second combined. They should still be
+// short enough to keep the example test suite fast in the happy path, since a
+// successful query resolves in milliseconds regardless of the upper bound.
+const (
+	// setupTimeout is shared across FromConnection + Use + SignIn in each example.
+	setupTimeout = 10 * time.Second
+	// queryTimeout bounds individual helper queries (DELETE/CREATE/SELECT).
+	//
+	// It must also be long enough to cover the intentionally-hung SELECT in
+	// ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit where
+	// the unmarshaler rejects the response and the request is drained via
+	// context cancellation — so making this huge directly increases the wall
+	// time of that example.
+	queryTimeout = 5 * time.Second
+)
+
 // setupTable prepares a clean table for testing by deleting any existing records
 func setupTable(db *surrealdb.DB, tableName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
 
 	// Clean up the table
@@ -236,7 +256,7 @@ func setupTable(db *surrealdb.DB, tableName string) {
 
 // createRecords creates a test record in the specified table
 func createRecords(db *surrealdb.DB, tableName string, arraySize int) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
 
 	// Create array with specified number of elements
@@ -258,7 +278,7 @@ func createRecords(db *surrealdb.DB, tableName string, arraySize int) {
 }
 
 func selectRecords(db *surrealdb.DB, tableName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
 
 	// Create test data structure


### PR DESCRIPTION
## What

The three examples in `example_fromconnection_fxamacker_cbor_decopts_test.go` each created a single 1 s context and reused it across `FromConnection`, `Use`, `SignIn` and the setup helpers. On slower CI runners the `gws` WebSocket handshake plus those round trips can easily exceed 1 s, which is why `ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit` has been panicking in CI with:

```
panic: SignIn failed: context deadline exceeded
```

The failing frame is the first-block `SignIn` (line 105 of the old file), not the small-limit `selectRecords` call. The test reports `(1.00s)` in the failure output, which is the exact context budget.

## Change

Pull the timeouts out into two named constants at the top of the file:

- `setupTimeout = 10 * time.Second` — shared across `FromConnection + Use + SignIn` in each example.
- `queryTimeout = 5 * time.Second` — used by `setupTable` / `createRecords` / `selectRecords`.

`queryTimeout` is deliberately kept modest, because it also bounds the intentionally-unresolvable SELECT in the small-limit example — where the CBOR unmarshaler rejects the server response and the pending request is drained via context cancellation. Making it large would directly inflate that example's wall time without any benefit.

## Verification

Ran the three affected examples against an in-memory `surreal start memory` instance locally:

```
--- PASS: ExampleFromConnection_cborUnmarshaler_decOptions_defaultLimit (0.04s)
--- PASS: ExampleFromConnection_cborUnmarshaler_decOptions_customSmallLimit (5.06s)
--- PASS: ExampleCborUnmarshaler_DecOptions_customLargeLimit (0.03s)
```

The 5 s in the small-limit example is the intentional `queryTimeout` wait on the unresolvable SELECT — it's the mechanism that produces the expected `Error retrieving record: context deadline exceeded` output line.

## Notes

I also audited the other short timeouts in the repo and deliberately left them alone:

- `pkg/connection/integration/rews_test.go` (10 ms) and `contrib/rews/integration_test.go` (100 ms) — part of the forced-disconnect / auto-reconnect tests; the short budget is the trigger.
- `contrib/rews/notification_router_test.go` (2 s) — bounds a concurrent-access stress test.
- `surrealcbor/example_test.go` (5 s) — only used for the deferred `db.Close`.
- `internal/fakesdb/example_test.go` (30 s) — already generous.