### PR TITLE
test(fakesdb): fix flaky Token_expiration in CI

### DIFF
--- a/internal/fakesdb/server_test.go
+++ b/internal/fakesdb/server_test.go
@@ -166,8 +166,10 @@ func TestAuthenticationFlow(t *testing.T) {
 			}
 		}()
 
-		// Generate token with short expiration
-		token, err := server.GenerateTokenWithExpiration("testuser", "mytoken", 100*time.Millisecond)
+		// Long enough for connect + Use + Authenticate + first query on a loaded CI
+		// runner; a very short TTL can expire before the first select runs.
+		const tokenTTL = 1 * time.Second
+		token, err := server.GenerateTokenWithExpiration("testuser", "mytoken", tokenTTL)
 		require.NoError(t, err)
 		require.Equal(t, "mytoken", token)
 
@@ -186,8 +188,8 @@ func TestAuthenticationFlow(t *testing.T) {
 		_, err = surrealdb.Select[map[string]any, string](ctx, db, "test:1")
 		assert.NoError(t, err)
 
-		// Wait for token to expire
-		time.Sleep(150 * time.Millisecond)
+		// Wait until after expiry (slightly past TTL for timer resolution)
+		time.Sleep(tokenTTL + 200*time.Millisecond)
 
 		// Query should fail with expired token
 		_, err = surrealdb.Select[map[string]any, string](ctx, db, "test:2")


### PR DESCRIPTION
### What is the motivation?

The `TestAuthenticationFlow/Token_expiration` subtest was intermittently failing in CI: the first `Select` after `Authenticate` sometimes returned an `Expired` authentication error.

### What does this change do?

The fake server test used a **100ms** token lifetime. On a loaded CI runner, the time between issuing the session and the first `Select` (connect, `Use`, `Authenticate`, request) can exceed 100ms, so the token was already expired when the test expected it to be valid.

The test now issues a **1s** token so the first query is reliably still within the session, then waits `tokenTTL + 200ms` before the second `Select` that should observe expiry.

### What is your testing strategy?

`go test ./internal/fakesdb/...` (run locally; repeated runs of the subtest pass).

### Security Considerations

Test-only change; no security impact.

### Is this related to any issues?

No related issues.

### Have you read the Contributing Guidelines?

- [x] Yes