### PR TITLE
test: make live query example output order-independent

### DIFF
--- a/example_livequery_test.go
+++ b/example_livequery_test.go
@@ -149,6 +149,20 @@ func ExampleLive() {
 	received := make(chan struct{})
 	done := make(chan bool)
 	go func() {
+		// Live query notifications are delivered asynchronously and are NOT
+		// guaranteed to arrive in operation order, so buffer them and emit in a
+		// canonical CREATE/UPDATE/DELETE order for deterministic example output.
+		type event struct {
+			action  connection.Action
+			record  string
+			message string
+		}
+		var events []event
+		actionRank := map[connection.Action]int{
+			connection.CreateAction: 0,
+			connection.UpdateAction: 1,
+			connection.DeleteAction: 2,
+		}
 		for notification := range notifications {
 			// KILLED is sent by the server when Kill() is called; the channel
 			// will be closed immediately after. Skip it — no result to process.
@@ -162,15 +176,26 @@ func ExampleLive() {
 				panic(fmt.Sprintf("Expected map[string]any, got %T", notification.Result))
 			}
 
-			fmt.Printf("Received notification - Action: %s, Result: %s\n", notification.Action, formatRecordResult(record))
-
+			var message string
 			switch notification.Action {
 			case connection.CreateAction:
-				fmt.Println("New user created")
+				message = "New user created"
 			case connection.UpdateAction:
-				fmt.Println("User updated")
+				message = "User updated"
 			case connection.DeleteAction:
-				fmt.Println("User deleted")
+				message = "User deleted"
+			}
+
+			events = append(events, event{notification.Action, formatRecordResult(record), message})
+
+			if len(events) >= 3 {
+				sort.SliceStable(events, func(a, b int) bool {
+					return actionRank[events[a].action] < actionRank[events[b].action]
+				})
+				for _, e := range events {
+					fmt.Printf("Received notification - Action: %s, Result: %s\n", e.action, e.record)
+					fmt.Println(e.message)
+				}
 				close(received)
 			}
 		}
@@ -415,7 +440,19 @@ func ExampleLive_withDiff() {
 	received := make(chan struct{})
 	done := make(chan bool)
 	go func() {
-		var i int
+		// Live query notifications are delivered asynchronously and are NOT
+		// guaranteed to arrive in operation order, so buffer them and emit in a
+		// canonical CREATE/UPDATE/DELETE order for deterministic example output.
+		type event struct {
+			action connection.Action
+			result string
+		}
+		var events []event
+		actionRank := map[connection.Action]int{
+			connection.CreateAction: 0,
+			connection.UpdateAction: 1,
+			connection.DeleteAction: 2,
+		}
 		for notification := range notifications {
 			var resultStr string
 
@@ -476,11 +513,15 @@ func ExampleLive_withDiff() {
 				panic(fmt.Sprintf("Unexpected result type %T for action %s", notification.Result, notification.Action))
 			}
 
-			i++
+			events = append(events, event{notification.Action, resultStr})
 
-			fmt.Printf("Action: %s, Result: %s\n", notification.Action, resultStr)
-
-			if i >= 3 {
+			if len(events) >= 3 {
+				sort.SliceStable(events, func(a, b int) bool {
+					return actionRank[events[a].action] < actionRank[events[b].action]
+				})
+				for _, e := range events {
+					fmt.Printf("Action: %s, Result: %s\n", e.action, e.result)
+				}
 				close(received)
 			}
 		}


### PR DESCRIPTION
## Problem

`ExampleLive` and `ExampleLive_withDiff` in `example_livequery_test.go` are Go **example tests** — the testing framework compares their stdout **exactly and in order** against the `// Output:` block. Both printed each live-query notification *as it arrived* and hard-coded the order `CREATE → UPDATE → DELETE`.

Live query notifications are delivered **asynchronously and are not guaranteed to arrive in operation order**. When the `UPDATE` notification lands after the `DELETE`, the output becomes `CREATE → DELETE → UPDATE` and the example fails with an output mismatch:

```
got:
 Action: CREATE, ...
 Action: DELETE, Result: {deleted}
 Action: UPDATE, ...
want:
 Action: CREATE, ...
 Action: UPDATE, ...
 Action: DELETE, Result: {deleted}
```

This was flaking the **`SDK - Golang (1.23, ws)`** CI leg. `ExampleLive` has the same latent race; it just hadn't surfaced yet.

## Fix

Buffer the three notifications and emit them in a canonical `CREATE/UPDATE/DELETE` order before comparing against `// Output:`, making the example output deterministic regardless of delivery order. No `// Output:` blocks change — sorted order already matches them.

## Testing

- `go vet ./...` clean, `gofmt` clean.
- Ran both examples 15× against a local SurrealDB 3.1.3 in-memory server (`ws`): 15/15 pass.