### PR TITLE
Fix CBOR float-to-int decoding

### DIFF
--- a/contrib/surrealql/integration_small_int_test.go
+++ b/contrib/surrealql/integration_small_int_test.go
@@ -1,0 +1,34 @@
+package surrealql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/surrealdb/surrealdb.go"
+	"github.com/surrealdb/surrealdb.go/contrib/testenv"
+)
+
+type smallIntConfig struct {
+	MaxSteps int `json:"max_steps"`
+	Priority int `json:"priority"`
+}
+
+func TestIntegration_SmallIntsDecodeToIntFields(t *testing.T) {
+	db, cleanup := testenv.SetupVersionTest(t, "v3.0.4")
+	defer cleanup()
+
+	ctx := context.Background()
+
+	_, err := surrealdb.Query[[]smallIntConfig](ctx, db,
+		"CREATE config:smallint SET max_steps = 0, priority = 1", nil)
+	require.NoError(t, err)
+
+	results, err := surrealdb.Query[[]smallIntConfig](ctx, db, "SELECT * FROM config:smallint", nil)
+	require.NoError(t, err)
+	require.Len(t, (*results)[0].Result, 1)
+
+	cfg := (*results)[0].Result[0]
+	require.Equal(t, 0, cfg.MaxSteps)
+	require.Equal(t, 1, cfg.Priority)
+}

--- a/contrib/testenv/connection.go
+++ b/contrib/testenv/connection.go
@@ -44,6 +44,9 @@ const (
 	// EnvSurrealCBORImpl is the environment variable that specifies
 	// the SurrealDB CBOR implementation to use.
 	EnvSurrealCBORImpl = "SURREALDB_CBOR_IMPL"
+
+	defaultRootUser = "root"
+	defaultRootPass = "root"
 )
 
 // CBORImpl specifies which CBOR implementation to use
@@ -316,8 +319,8 @@ func Init(db *surrealdb.DB, namespace, database string, tables ...string) (*surr
 	}
 
 	authData := &surrealdb.Auth{
-		Username: "root",
-		Password: "root",
+		Username: defaultRootUser,
+		Password: defaultRootPass,
 	}
 	token, err := db.SignIn(context.Background(), authData)
 	if err != nil {

--- a/contrib/testenv/docker_version.go
+++ b/contrib/testenv/docker_version.go
@@ -1,0 +1,107 @@
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+)
+
+// SetupVersionTest starts a SurrealDB Docker container for the given version tag
+// and returns a connected, signed-in database handle. The container is removed
+// when cleanup is called.
+func SetupVersionTest(t *testing.T, version string) (db *surrealdb.DB, cleanup func()) {
+	t.Helper()
+	_, db, cleanup = SetupVersionTestWithHTTPURL(t, version)
+	return db, cleanup
+}
+
+// SetupVersionTestWithHTTPURL is like SetupVersionTest but also returns the WebSocket URL.
+func SetupVersionTestWithHTTPURL(t *testing.T, version string, extraArgs ...string) (wsURL string, db *surrealdb.DB, cleanup func()) {
+	t.Helper()
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("Docker not available, skipping version behavior test")
+	}
+
+	ctx := context.Background()
+
+	if err := exec.CommandContext(ctx, "docker", "info").Run(); err != nil {
+		t.Skip("Docker daemon not running, skipping version behavior test")
+	}
+
+	containerName := fmt.Sprintf("surrealdb-behavior-test-%s-%d", version, time.Now().UnixNano())
+
+	_ = exec.CommandContext(ctx, "docker", "rm", "-f", containerName).Run()
+
+	args := []string{
+		"run", "-d",
+		"--name", containerName,
+		"-p", "0:8000",
+		fmt.Sprintf("surrealdb/surrealdb:%s", version),
+		"start", "--user", "root", "--pass", "root",
+	}
+	args = append(args, extraArgs...)
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Failed to start container: %s", string(output))
+
+	containerCleanup := func() {
+		cleanupCtx := context.Background()
+		_ = exec.CommandContext(cleanupCtx, "docker", "rm", "-f", containerName).Run()
+	}
+
+	portCmd := exec.CommandContext(ctx, "docker", "port", containerName, "8000")
+	portOutput, err := portCmd.CombinedOutput()
+	if err != nil {
+		containerCleanup()
+		t.Fatalf("Failed to get container port: %v, output: %s", err, string(portOutput))
+	}
+	portStr := string(portOutput)
+	for i := len(portStr) - 1; i >= 0; i-- {
+		if portStr[i] == ':' {
+			portStr = portStr[i+1:]
+			break
+		}
+	}
+	portStr = portStr[:len(portStr)-1]
+	wsURL = fmt.Sprintf("ws://localhost:%s/rpc", portStr)
+
+	for i := 0; i < 30; i++ {
+		db, err = surrealdb.FromEndpointURLString(ctx, wsURL)
+		if err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		containerCleanup()
+		t.Fatalf("Failed to connect to SurrealDB: %v", err)
+	}
+
+	_, err = db.SignIn(ctx, surrealdb.Auth{
+		Username: "root",
+		Password: "root",
+	})
+	if err != nil {
+		containerCleanup()
+		t.Fatalf("Failed to sign in: %v", err)
+	}
+
+	err = db.Use(ctx, "test_ns", "test_db")
+	if err != nil {
+		containerCleanup()
+		t.Fatalf("Failed to use database: %v", err)
+	}
+
+	cleanup = func() {
+		db.Close(ctx)
+		containerCleanup()
+	}
+	return wsURL, db, cleanup
+}

--- a/contrib/testenv/docker_version.go
+++ b/contrib/testenv/docker_version.go
@@ -43,7 +43,7 @@ func SetupVersionTestWithHTTPURL(t *testing.T, version string, extraArgs ...stri
 		"--name", containerName,
 		"-p", "0:8000",
 		fmt.Sprintf("surrealdb/surrealdb:%s", version),
-		"start", "--user", "root", "--pass", "root",
+		"start", "--user", defaultRootUser, "--pass", defaultRootPass,
 	}
 	args = append(args, extraArgs...)
 
@@ -85,8 +85,8 @@ func SetupVersionTestWithHTTPURL(t *testing.T, version string, extraArgs ...stri
 	}
 
 	_, err = db.SignIn(ctx, surrealdb.Auth{
-		Username: "root",
-		Password: "root",
+		Username: defaultRootUser,
+		Password: defaultRootPass,
 	})
 	if err != nil {
 		containerCleanup()

--- a/contrib/testenv/version_behavior_test.go
+++ b/contrib/testenv/version_behavior_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -25,107 +24,17 @@ import (
 //   SURREALDB_VERSION=v3.0.0-beta.2 go test -run "TestBehavior.*_v3" ./contrib/testenv/
 
 func setupVersionTest(t *testing.T, version string) (db *surrealdb.DB, cleanup func()) {
-	_, db, cleanup = setupVersionTestWithHTTPURL(t, version)
-	return db, cleanup
+	return SetupVersionTest(t, version)
 }
 
 func setupVersionTestWithArgs(t *testing.T, version string, extraArgs ...string) (db *surrealdb.DB, cleanup func()) {
-	_, db, cleanup = setupVersionTestWithHTTPURL(t, version, extraArgs...)
+	t.Helper()
+	_, db, cleanup = SetupVersionTestWithHTTPURL(t, version, extraArgs...)
 	return db, cleanup
 }
 
 func setupVersionTestWithHTTPURL(t *testing.T, version string, extraArgs ...string) (wsURL string, db *surrealdb.DB, cleanup func()) {
-	t.Helper()
-
-	if _, err := exec.LookPath("docker"); err != nil {
-		t.Skip("Docker not available, skipping version behavior test")
-	}
-
-	ctx := context.Background()
-
-	if err := exec.CommandContext(ctx, "docker", "info").Run(); err != nil {
-		t.Skip("Docker daemon not running, skipping version behavior test")
-	}
-
-	containerName := fmt.Sprintf("surrealdb-behavior-test-%s-%d", version, time.Now().UnixNano())
-
-	// Cleanup any existing container
-	_ = exec.CommandContext(ctx, "docker", "rm", "-f", containerName).Run()
-
-	// Build command arguments
-	args := []string{
-		"run", "-d",
-		"--name", containerName,
-		"-p", "0:8000",
-		fmt.Sprintf("surrealdb/surrealdb:%s", version),
-		"start", "--user", "root", "--pass", "root",
-	}
-	args = append(args, extraArgs...)
-
-	// Start container with dynamic port allocation (port 0 lets Docker choose)
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, "Failed to start container: %s", string(output))
-
-	containerCleanup := func() {
-		cleanupCtx := context.Background()
-		_ = exec.CommandContext(cleanupCtx, "docker", "rm", "-f", containerName).Run()
-	}
-
-	// Get the dynamically allocated port
-	portCmd := exec.CommandContext(ctx, "docker", "port", containerName, "8000")
-	portOutput, err := portCmd.CombinedOutput()
-	if err != nil {
-		containerCleanup()
-		t.Fatalf("Failed to get container port: %v, output: %s", err, string(portOutput))
-	}
-	// Output format: "0.0.0.0:12345\n" - extract port number
-	portStr := string(portOutput)
-	// Find the last colon and extract port
-	for i := len(portStr) - 1; i >= 0; i-- {
-		if portStr[i] == ':' {
-			portStr = portStr[i+1:]
-			break
-		}
-	}
-	portStr = portStr[:len(portStr)-1] // Remove trailing newline
-	wsURL = fmt.Sprintf("ws://localhost:%s/rpc", portStr)
-
-	// Wait for container to be ready
-	for i := 0; i < 30; i++ {
-		db, err = surrealdb.FromEndpointURLString(ctx, wsURL)
-		if err == nil {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-	if err != nil {
-		containerCleanup()
-		t.Fatalf("Failed to connect to SurrealDB: %v", err)
-	}
-
-	// Sign in as root
-	_, err = db.SignIn(ctx, surrealdb.Auth{
-		Username: "root",
-		Password: "root",
-	})
-	if err != nil {
-		containerCleanup()
-		t.Fatalf("Failed to sign in: %v", err)
-	}
-
-	// Use a test namespace/database
-	err = db.Use(ctx, "test_ns", "test_db")
-	if err != nil {
-		containerCleanup()
-		t.Fatalf("Failed to use database: %v", err)
-	}
-
-	cleanup = func() {
-		db.Close(ctx)
-		containerCleanup()
-	}
-	return wsURL, db, cleanup
+	return SetupVersionTestWithHTTPURL(t, version, extraArgs...)
 }
 
 // =============================================================================

--- a/surrealcbor/decode_float_to_int_test.go
+++ b/surrealcbor/decode_float_to_int_test.go
@@ -1,0 +1,86 @@
+package surrealcbor
+
+import (
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type config391 struct {
+	MaxSteps int `json:"max_steps"`
+	Priority int `json:"priority"`
+}
+
+// TestCBORFloat16ToInt reproduces issue #391: SurrealDB v3.0.4 encodes small
+// integers as CBOR float16 in RPC responses.
+func TestCBORFloat16ToInt(t *testing.T) {
+	// map{"max_steps": float16(0.0)}
+	data := []byte{0xA1, 0x69, 0x6D, 0x61, 0x78, 0x5F, 0x73, 0x74, 0x65, 0x70, 0x73, 0xF9, 0x00, 0x00}
+	var cfg config391
+	err := Unmarshal(data, &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cfg.MaxSteps)
+}
+
+func TestCBORFloat32ToInt(t *testing.T) {
+	// map{"max_steps": float32(42.0)}
+	data := []byte{0xA1, 0x69, 0x6D, 0x61, 0x78, 0x5F, 0x73, 0x74, 0x65, 0x70, 0x73, 0xFA, 0x42, 0x28, 0x00, 0x00}
+	var cfg config391
+	err := Unmarshal(data, &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 42, cfg.MaxSteps)
+}
+
+func TestCBORFloatExactIntegers(t *testing.T) {
+	t.Run("float16 one", func(t *testing.T) {
+		data := []byte{0xF9, 0x3C, 0x00}
+		var i int
+		err := Unmarshal(data, &i)
+		require.NoError(t, err)
+		assert.Equal(t, 1, i)
+	})
+
+	t.Run("float16 two", func(t *testing.T) {
+		data := []byte{0xF9, 0x40, 0x00}
+		var i int
+		err := Unmarshal(data, &i)
+		require.NoError(t, err)
+		assert.Equal(t, 2, i)
+	})
+
+	t.Run("float64 exact zero", func(t *testing.T) {
+		enc, err := cbor.Marshal(float64(0))
+		require.NoError(t, err)
+		var i int
+		err = Unmarshal(enc, &i)
+		require.NoError(t, err)
+		assert.Equal(t, 0, i)
+	})
+
+	t.Run("float64 non-integer errors", func(t *testing.T) {
+		enc, err := cbor.Marshal(123.456)
+		require.NoError(t, err)
+		var i int64
+		err = Unmarshal(enc, &i)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot unmarshal CBOR float64 into Go value of type int64")
+	})
+
+	t.Run("float16 NaN to int errors", func(t *testing.T) {
+		data := []byte{0xF9, 0x7E, 0x00}
+		var i int
+		err := Unmarshal(data, &i)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot unmarshal CBOR float16 into Go value of type int")
+	})
+
+	t.Run("negative exact float to uint errors", func(t *testing.T) {
+		data := []byte{0xF9, 0xBC, 0x00} // float16(-1.0)
+		var u uint
+		err := Unmarshal(data, &u)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot unmarshal CBOR float16 into Go value of type uint")
+	})
+}

--- a/surrealcbor/decode_simple.go
+++ b/surrealcbor/decode_simple.go
@@ -57,15 +57,11 @@ func (d *decoder) decodeFloat16(v reflect.Value) error {
 	bits := uint16(d.data[d.pos])<<8 | uint16(d.data[d.pos+1])
 	d.pos += 2
 	f := float16ToFloat32(bits)
-	if v.Kind() == reflect.Float32 || v.Kind() == reflect.Float64 {
-		v.SetFloat(float64(f))
-	} else if v.Kind() == reflect.Interface {
+	if v.Kind() == reflect.Interface {
 		v.Set(reflect.ValueOf(f))
-	} else if v.CanSet() {
-		// Return error for type mismatch instead of silently ignoring
-		return fmt.Errorf("cannot unmarshal CBOR float16 into Go value of type %v", v.Type())
+		return nil
 	}
-	return nil
+	return setFloatValue(v, float64(f), "float16")
 }
 
 func float16ToFloat32(bits uint16) float32 {
@@ -108,15 +104,11 @@ func (d *decoder) decodeFloat32(v reflect.Value) error {
 	bits := binary.BigEndian.Uint32(d.data[d.pos : d.pos+4])
 	d.pos += 4
 	f := math.Float32frombits(bits)
-	if v.Kind() == reflect.Float32 || v.Kind() == reflect.Float64 {
-		v.SetFloat(float64(f))
-	} else if v.Kind() == reflect.Interface {
+	if v.Kind() == reflect.Interface {
 		v.Set(reflect.ValueOf(f))
-	} else if v.CanSet() {
-		// Return error for type mismatch instead of silently ignoring
-		return fmt.Errorf("cannot unmarshal CBOR float32 into Go value of type %v", v.Type())
+		return nil
 	}
-	return nil
+	return setFloatValue(v, float64(f), "float32")
 }
 
 func (d *decoder) decodeFloat64(v reflect.Value) error {
@@ -127,14 +119,79 @@ func (d *decoder) decodeFloat64(v reflect.Value) error {
 	bits := binary.BigEndian.Uint64(d.data[d.pos : d.pos+8])
 	d.pos += 8
 	f := math.Float64frombits(bits)
-	if v.Kind() == reflect.Float32 || v.Kind() == reflect.Float64 {
-		v.SetFloat(f)
-	} else if v.Kind() == reflect.Interface {
+	if v.Kind() == reflect.Interface {
 		v.Set(reflect.ValueOf(f))
-	} else if v.CanSet() {
-		// Return error for type mismatch instead of silently ignoring
-		return fmt.Errorf("cannot unmarshal CBOR float64 into Go value of type %v", v.Type())
+		return nil
 	}
+	return setFloatValue(v, f, "float64")
+}
+
+func setFloatValue(v reflect.Value, f float64, floatKind string) error {
+	switch v.Kind() {
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(f)
+		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return setFloatToInt(v, f, floatKind)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return setFloatToUint(v, f, floatKind)
+	default:
+		if v.CanSet() {
+			return fmt.Errorf("cannot unmarshal CBOR %s into Go value of type %v", floatKind, v.Type())
+		}
+		return nil
+	}
+}
+
+func setFloatToInt(v reflect.Value, f float64, floatKind string) error {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) {
+		return fmt.Errorf("cannot unmarshal CBOR %s into Go value of type %v", floatKind, v.Type())
+	}
+	i := int64(f)
+	if float64(i) != f {
+		return fmt.Errorf("cannot unmarshal CBOR %s into Go value of type %v", floatKind, v.Type())
+	}
+	switch v.Kind() {
+	case reflect.Int8:
+		if i < math.MinInt8 || i > math.MaxInt8 {
+			return fmt.Errorf("value %d overflows int8", i)
+		}
+	case reflect.Int16:
+		if i < math.MinInt16 || i > math.MaxInt16 {
+			return fmt.Errorf("value %d overflows int16", i)
+		}
+	case reflect.Int32:
+		if i < math.MinInt32 || i > math.MaxInt32 {
+			return fmt.Errorf("value %d overflows int32", i)
+		}
+	}
+	v.SetInt(i)
+	return nil
+}
+
+func setFloatToUint(v reflect.Value, f float64, floatKind string) error {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) || f < 0 {
+		return fmt.Errorf("cannot unmarshal CBOR %s into Go value of type %v", floatKind, v.Type())
+	}
+	u := uint64(f)
+	if float64(u) != f {
+		return fmt.Errorf("cannot unmarshal CBOR %s into Go value of type %v", floatKind, v.Type())
+	}
+	switch v.Kind() {
+	case reflect.Uint8:
+		if u > math.MaxUint8 {
+			return fmt.Errorf("value %d overflows uint8", u)
+		}
+	case reflect.Uint16:
+		if u > math.MaxUint16 {
+			return fmt.Errorf("value %d overflows uint16", u)
+		}
+	case reflect.Uint32:
+		if u > math.MaxUint32 {
+			return fmt.Errorf("value %d overflows uint32", u)
+		}
+	}
+	v.SetUint(u)
 	return nil
 }
 

--- a/surrealcbor/decode_simple_test.go
+++ b/surrealcbor/decode_simple_test.go
@@ -189,6 +189,16 @@ func TestDecode_floatToInterfaceWithExistingValue(t *testing.T) {
 		assert.Contains(t, err.Error(), "cannot unmarshal CBOR float64 into Go value of type int64")
 	})
 
+	t.Run("decode float64 exact integer to int64", func(t *testing.T) {
+		enc, err := cbor.Marshal(float64(42))
+		require.NoError(t, err)
+
+		var i int64
+		err = Unmarshal(enc, &i)
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), i)
+	})
+
 	t.Run("decode float32 to string directly should error", func(t *testing.T) {
 		floatVal := float32(45.67)
 		enc, err := cbor.Marshal(floatVal)


### PR DESCRIPTION
SurrealDB encodes small integers as CBOR floats in RPC responses, which caused unmarshaling into Go `int` struct fields to fail.

Fixes #391