### PR TITLE
Fix Range/RecordRangeID.String() bugs

### DIFF
--- a/pkg/models/range.go
+++ b/pkg/models/range.go
@@ -91,7 +91,7 @@ func (r *Range[T, TBeg, TEnd]) String() string {
 		beginStr = convertToString(r.Begin)
 	}
 	if r.End != nil {
-		endStr = convertToString(r.Begin)
+		endStr = convertToString(r.End)
 	}
 
 	return fmt.Sprintf("%s%s%s", beginStr, joinStr, endStr)
@@ -142,13 +142,43 @@ func (rr *RecordRangeID[T, TBeg, TEnd]) String() string {
 		beginStr = convertToString(rr.Begin)
 	}
 	if rr.End != nil {
-		endStr = convertToString(rr.Begin)
+		endStr = convertToString(rr.End)
 	}
 
 	return fmt.Sprintf("%s:%s%s%s", rr.Table, beginStr, joinStr, endStr)
 }
 
+// convertToString renders the underlying value of a range bound (a
+// *BoundIncluded[T] or *BoundExcluded[T]) as a SurrealQL-compatible string.
+//
+// String values are escaped the same way RecordID.String escapes record IDs
+// (see record_id_string.go), wrapping them in angle brackets (⟨⟩) when they
+// contain characters that would otherwise be ambiguous or invalid in a bare
+// identifier. Other value types fall back to their default string
+// representation.
 func convertToString(v any) string {
-	// todo: implement
-	return ""
+	value := reflect.ValueOf(v)
+	for value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+
+	// v is expected to be a *BoundIncluded[T] or *BoundExcluded[T], both of
+	// which have a single exported field named "Value" holding the bound.
+	field := value.FieldByName("Value")
+	if !field.IsValid() {
+		return fmt.Sprintf("%v", v)
+	}
+	inner := field.Interface()
+
+	if strVal, ok := inner.(string); ok {
+		if needsEscaping(strVal) {
+			return fmt.Sprintf("⟨%s⟩", escapeString(strVal, '⟩'))
+		}
+		return strVal
+	}
+
+	return fmt.Sprintf("%v", inner)
 }

--- a/pkg/models/range_test.go
+++ b/pkg/models/range_test.go
@@ -1,0 +1,170 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRange_String covers Range[T, TBeg, TEnd].String() for the four
+// inclusive/exclusive bound combinations.
+//
+// Prior to the fix, convertToString was a stub that always returned "",
+// so every case below would have produced just the join string (e.g. "..",
+// "..=", ">..", ">..="). In addition, the end bound was rendered by calling
+// convertToString(r.Begin) instead of convertToString(r.End), so even with
+// convertToString implemented, the end value would have echoed the begin
+// value instead of the real end value whenever begin != end.
+func TestRange_String(t *testing.T) {
+	t.Run("begin included, end included", func(t *testing.T) {
+		r := Range[int, BoundIncluded[int], BoundIncluded[int]]{
+			Begin: &BoundIncluded[int]{1},
+			End:   &BoundIncluded[int]{10},
+		}
+		assert.Equal(t, "1..=10", r.String())
+	})
+
+	t.Run("begin included, end excluded", func(t *testing.T) {
+		r := Range[int, BoundIncluded[int], BoundExcluded[int]]{
+			Begin: &BoundIncluded[int]{1},
+			End:   &BoundExcluded[int]{10},
+		}
+		assert.Equal(t, "1..10", r.String())
+	})
+
+	t.Run("begin excluded, end included", func(t *testing.T) {
+		r := Range[int, BoundExcluded[int], BoundIncluded[int]]{
+			Begin: &BoundExcluded[int]{1},
+			End:   &BoundIncluded[int]{10},
+		}
+		assert.Equal(t, "1>..=10", r.String())
+	})
+
+	t.Run("begin excluded, end excluded", func(t *testing.T) {
+		r := Range[int, BoundExcluded[int], BoundExcluded[int]]{
+			Begin: &BoundExcluded[int]{1},
+			End:   &BoundExcluded[int]{10},
+		}
+		assert.Equal(t, "1>..10", r.String())
+	})
+
+	t.Run("begin and end differ, end must not echo begin", func(t *testing.T) {
+		// Regression test for the Begin/End field-name swap bug: the old
+		// code called convertToString(r.Begin) for both bounds, so the end
+		// bound rendered as "5" (the begin value) instead of "99".
+		r := Range[int, BoundIncluded[int], BoundIncluded[int]]{
+			Begin: &BoundIncluded[int]{5},
+			End:   &BoundIncluded[int]{99},
+		}
+		result := r.String()
+		assert.Equal(t, "5..=99", result)
+		assert.NotEqual(t, "5..=5", result)
+	})
+
+	t.Run("string bounds are escaped like RecordID IDs", func(t *testing.T) {
+		r := Range[string, BoundIncluded[string], BoundExcluded[string]]{
+			Begin: &BoundIncluded[string]{"a-b"},
+			End:   &BoundExcluded[string]{"c-d"},
+		}
+		assert.Equal(t, "⟨a-b⟩..⟨c-d⟩", r.String())
+	})
+}
+
+// TestRecordRangeID_String covers RecordRangeID[T, TBeg, TEnd].String(),
+// which prefixes the range with "<table>:".
+//
+// Same rationale as TestRange_String: pre-fix, the stubbed convertToString
+// meant the bounds rendered as empty strings, and the Begin/End swap meant
+// the end bound (when non-empty) would have echoed the begin value.
+func TestRecordRangeID_String(t *testing.T) {
+	t.Run("begin included, end included", func(t *testing.T) {
+		rr := RecordRangeID[int, BoundIncluded[int], BoundIncluded[int]]{
+			Range: Range[int, BoundIncluded[int], BoundIncluded[int]]{
+				Begin: &BoundIncluded[int]{1},
+				End:   &BoundIncluded[int]{10},
+			},
+			Table: Table("foo"),
+		}
+		assert.Equal(t, "foo:1..=10", rr.String())
+	})
+
+	t.Run("begin excluded, end excluded", func(t *testing.T) {
+		rr := RecordRangeID[int, BoundExcluded[int], BoundExcluded[int]]{
+			Range: Range[int, BoundExcluded[int], BoundExcluded[int]]{
+				Begin: &BoundExcluded[int]{1},
+				End:   &BoundExcluded[int]{10},
+			},
+			Table: Table("foo"),
+		}
+		assert.Equal(t, "foo:1>..10", rr.String())
+	})
+
+	t.Run("begin excluded, end included", func(t *testing.T) {
+		rr := RecordRangeID[int, BoundExcluded[int], BoundIncluded[int]]{
+			Range: Range[int, BoundExcluded[int], BoundIncluded[int]]{
+				Begin: &BoundExcluded[int]{1},
+				End:   &BoundIncluded[int]{10},
+			},
+			Table: Table("foo"),
+		}
+		assert.Equal(t, "foo:1>..=10", rr.String())
+	})
+
+	t.Run("end bound must reflect End, not Begin", func(t *testing.T) {
+		rr := RecordRangeID[int, BoundIncluded[int], BoundIncluded[int]]{
+			Range: Range[int, BoundIncluded[int], BoundIncluded[int]]{
+				Begin: &BoundIncluded[int]{5},
+				End:   &BoundIncluded[int]{99},
+			},
+			Table: Table("foo"),
+		}
+		result := rr.String()
+		assert.Equal(t, "foo:5..=99", result)
+		assert.NotEqual(t, "foo:5..=5", result)
+	})
+}
+
+// TestConvertToString exercises the convertToString helper directly to make
+// sure it no longer returns the empty-string stub, and that it applies the
+// same escaping rules RecordID.String uses for string IDs.
+func TestConvertToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		bound    any
+		expected string
+	}{
+		{
+			name:     "included int",
+			bound:    &BoundIncluded[int]{42},
+			expected: "42",
+		},
+		{
+			name:     "excluded int",
+			bound:    &BoundExcluded[int]{42},
+			expected: "42",
+		},
+		{
+			name:     "included plain string",
+			bound:    &BoundIncluded[string]{"abc"},
+			expected: "abc",
+		},
+		{
+			name:     "included string needing escaping",
+			bound:    &BoundIncluded[string]{"a-b"},
+			expected: "⟨a-b⟩",
+		},
+		{
+			name:     "excluded numeric-looking string needs escaping",
+			bound:    &BoundExcluded[string]{"123"},
+			expected: "⟨123⟩",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertToString(tt.bound)
+			assert.NotEmpty(t, result)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Root cause

`pkg/models/range.go` had two provable bugs affecting the string rendering of `Range` and `RecordRangeID` values:

1. **Unimplemented stub.** `convertToString(v any) string` was a stub (`// todo: implement`) that always returned `""`. As a result, `Range.String()` and `RecordRangeID.String()` only ever rendered the bare join operator (e.g. `..`, `..=`, `>..`, `>..=`) — the actual bound values never appeared in the output.

2. **Begin/End copy-paste bug.** In both `Range.String()` (line ~94) and `RecordRangeID.String()` (line ~145), the end-bound string was computed by calling `convertToString(r.Begin)` / `convertToString(rr.Begin)` instead of passing the `End` field. So even once the stub is fixed, the rendered end bound would echo the begin value instead of the real end value whenever `Begin != End`.

## Fix

- Implemented `convertToString` to unwrap a `*BoundIncluded[T]`/`*BoundExcluded[T]` via reflection and stringify its `Value` field. String values are escaped the same way `RecordID.String()` escapes record IDs (reusing `needsEscaping`/`escapeString` from `record_id_string.go`), wrapping ambiguous values in angle brackets (e.g. `a-b` -> `⟨a-b⟩`). Other value types fall back to their default string form (`%v`).
- Fixed the `Begin`/`End` swap so the end bound is derived from the `End` field in both `String()` implementations.

The inclusive/exclusive join syntax (`..`, `..=`, `>..`, `>..=`) produced by `GetJoinString()` was already correct and was cross-checked against the golden reference `surrealdb.js` (`packages/sqon/src/internal/range.ts`'s `getRangeJoin` and `packages/sqon/src/utils/escape.ts`'s `escapeRangeBound`), which implement identical bound semantics.

## Tests

Added `pkg/models/range_test.go` covering:
- `Range.String()` and `RecordRangeID.String()` for all four inclusive/exclusive bound combinations (`..`, `..=`, `>..`, `>..=`)
- String bound escaping matching `RecordID.String()` conventions
- A regression case asserting the end bound reflects `End` and is not an echo of `Begin`
- `convertToString` directly, confirming it no longer returns `""`

I verified these tests fail against the pre-fix code (by stashing the `range.go` fix and re-running): `TestConvertToString` fails with empty-string results, confirming the stub was previously live and the new tests exercise the actual bug.

## Verification commands run

- `go build ./...` — passes
- `golangci-lint run ./...` — `0 issues.`
- `go test -v -run 'TestRange|TestRecordRangeID|TestConvertToString' ./pkg/models/...` — all pass
- `go test ./pkg/models/...` — `ok`

All tests are pure unit tests with no live SurrealDB server dependency.

## Scope / follow-up

This PR is narrowly scoped to the string-rendering correctness bugs above. It intentionally does **not** wire `RecordRangeID` into the `TableOrRecord` generic constraint so that ranges work end-to-end through `Select`/`Update`/`Delete`/`Upsert` — that CRUD-integration work is a separate, larger feature and is deferred to a follow-up PR.

No existing GitHub issue tracks this bug, so per this repo's `CONTRIBUTING.md` convention the branch name omits an issue-number prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)