### PR TITLE
Add ServerError kind constants and Is* helper functions

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,40 @@
+package surrealdb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	surrealdb "github.com/surrealdb/surrealdb.go"
+)
+
+// TestErrorKindHelpers_ReExports is a pure unit test (no live server needed)
+// confirming that the top-level surrealdb package re-exports the
+// pkg/connection Kind* constants and Is* helper functions, and that they
+// behave identically when used through the surrealdb package alias.
+func TestErrorKindHelpers_ReExports(t *testing.T) {
+	notFoundErr := &surrealdb.ServerError{Kind: surrealdb.KindNotFound, Message: "no such table"}
+	notAllowedErr := &surrealdb.ServerError{Kind: surrealdb.KindNotAllowed, Message: "denied"}
+	conflictErr := &surrealdb.ServerError{
+		Kind:    surrealdb.KindQuery,
+		Details: map[string]any{"kind": "TransactionConflict"},
+	}
+	tokenExpiredErr := &surrealdb.ServerError{
+		Kind:    surrealdb.KindNotAllowed,
+		Details: map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}},
+	}
+
+	assert.True(t, surrealdb.IsNotFound(notFoundErr))
+	assert.False(t, surrealdb.IsNotFound(notAllowedErr))
+
+	assert.True(t, surrealdb.IsNotAllowed(notAllowedErr))
+	assert.False(t, surrealdb.IsNotAllowed(notFoundErr))
+
+	assert.True(t, surrealdb.IsTransactionConflict(conflictErr))
+	assert.False(t, surrealdb.IsTransactionConflict(notFoundErr))
+
+	assert.True(t, surrealdb.IsTokenExpired(tokenExpiredErr))
+	assert.False(t, surrealdb.IsInvalidAuth(tokenExpiredErr))
+
+	assert.False(t, surrealdb.IsNotFound(nil))
+	assert.False(t, surrealdb.IsNotFound(assert.AnError))
+}

--- a/pkg/connection/server_error.go
+++ b/pkg/connection/server_error.go
@@ -11,8 +11,9 @@ package connection
 //	}
 //
 // ServerError carries structured information including Kind, Details, and a cause chain.
-// Use the helper functions in the surrealdb package (IsNotAllowed, IsNotFound, etc.)
-// for ergonomic kind checking, or inspect Kind directly.
+// Use the Is* helper functions in this package (IsNotAllowed, IsNotFound, etc. -- also
+// re-exported from the top-level surrealdb package) for ergonomic kind checking, or
+// compare Kind directly against the Kind* constants (e.g. KindNotFound).
 type ServerError struct {
 	// Code is the JSON-RPC numeric error code.
 	Code int
@@ -21,6 +22,7 @@ type ServerError struct {
 	Message string
 
 	// Kind is the structured error kind (e.g. "NotFound", "NotAllowed").
+	// See the Kind* constants (e.g. KindNotFound) for the known values.
 	Kind string
 
 	// Details contains kind-specific structured error details.

--- a/pkg/connection/server_error_kind.go
+++ b/pkg/connection/server_error_kind.go
@@ -1,0 +1,212 @@
+package connection
+
+import "errors"
+
+// Known values for ServerError.Kind, matching the top-level error kinds
+// returned by SurrealDB v3's structured error wire format ({ "kind": "...",
+// "details": ... }).
+//
+// These mirror the ErrorKind map in surrealdb.js (packages/sdk/src/errors.ts)
+// and the ErrorDetails variants in the server's surrealdb/types/src/error.rs
+// (see ErrorDetails::kind_str). Servers may introduce new kinds over time;
+// unknown kinds should be treated the same as KindInternal by callers.
+const (
+	KindValidation    = "Validation"
+	KindConfiguration = "Configuration"
+	KindThrown        = "Thrown"
+	KindQuery         = "Query"
+	KindSerialization = "Serialization"
+	KindNotAllowed    = "NotAllowed"
+	KindNotFound      = "NotFound"
+	KindAlreadyExists = "AlreadyExists"
+	KindConnection    = "Connection"
+	KindInternal      = "Internal"
+)
+
+// Nested detail-kind values used to further discriminate within a top-level
+// Kind. On SurrealDB v3, ServerError.Details typically decodes to
+// map[string]any{"kind": "<detailKind>", "details": ...} (or, for
+// double-nested details such as auth failures, another map of the same
+// shape). These are unexported because, unlike the top-level Kind values,
+// they are only meaningful in combination with a specific top-level Kind --
+// callers should use the Is* helpers below rather than comparing directly.
+const (
+	detailKindAuth         = "Auth"
+	detailKindTokenExpired = "TokenExpired"
+	detailKindInvalidAuth  = "InvalidAuth"
+	detailKindScripting    = "Scripting"
+	detailKindParse        = "Parse"
+	detailKindNotExecuted  = "NotExecuted"
+	// detailKindCancelled matches the server's wire value verbatim (a
+	// British-spelling variant name shared by the Rust and JS sources) --
+	// not a typo.
+	detailKindCancelled             = "Cancelled" //nolint:misspell
+	detailKindTransactionConflict   = "TransactionConflict"
+	detailKindTimedOut              = "TimedOut"
+	detailKindDeserialization       = "Deserialization"
+	detailKindLiveQueryNotSupported = "LiveQueryNotSupported"
+)
+
+// hasKind reports whether err unwraps (via errors.As) to a *ServerError with
+// the given top-level Kind. Returns false for nil, for errors that aren't
+// (or don't wrap) a *ServerError, and for a *ServerError with a different
+// Kind.
+func hasKind(err error, kind string) bool {
+	var se *ServerError
+	if !errors.As(err, &se) {
+		return false
+	}
+	return se.Kind == kind
+}
+
+// detailKind extracts the "kind" string from a details value shaped like
+// map[string]any{"kind": "...", "details": ...} -- the shape ServerError.Details
+// takes on SurrealDB v3 after CBOR/JSON decoding. ok is false if details is
+// nil, isn't a map, or has no string "kind" entry.
+func detailKind(details any) (kind string, ok bool) {
+	m, isMap := details.(map[string]any)
+	if !isMap {
+		return "", false
+	}
+	kind, ok = m["kind"].(string)
+	return kind, ok
+}
+
+// nestedDetails returns the "details" entry nested inside a details map, e.g.
+// the AuthErrorDetail nested inside a NotAllowedErrorDetail's
+// { "kind": "Auth", "details": { "kind": "TokenExpired" } } shape. Returns
+// nil if details isn't shaped that way.
+func nestedDetails(details any) any {
+	m, ok := details.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return m["details"]
+}
+
+// hasDetailKind reports whether err is a *ServerError whose top-level Kind is
+// kind and whose Details map has the nested "kind" equal to detailKind.
+func hasDetailKind(err error, kind, wantDetailKind string) bool {
+	var se *ServerError
+	if !errors.As(err, &se) {
+		return false
+	}
+	if se.Kind != kind {
+		return false
+	}
+	got, ok := detailKind(se.Details)
+	return ok && got == wantDetailKind
+}
+
+// hasAuthDetailKind reports whether err is a *ServerError with Kind
+// "NotAllowed" whose Details is shaped like
+// { "kind": "Auth", "details": { "kind": wantAuthKind } }, i.e. an IAM/auth
+// failure of the given sub-kind.
+func hasAuthDetailKind(err error, wantAuthKind string) bool {
+	var se *ServerError
+	if !errors.As(err, &se) {
+		return false
+	}
+	if se.Kind != KindNotAllowed {
+		return false
+	}
+	dk, ok := detailKind(se.Details)
+	if !ok || dk != detailKindAuth {
+		return false
+	}
+	inner, ok := detailKind(nestedDetails(se.Details))
+	return ok && inner == wantAuthKind
+}
+
+// IsNotFound reports whether err is (or wraps) a *ServerError whose Kind is
+// "NotFound" -- a missing table, record, namespace, database, session, RPC
+// method, or transaction. Returns false for nil, for errors that aren't a
+// *ServerError, and for a *ServerError with a different Kind.
+func IsNotFound(err error) bool {
+	return hasKind(err, KindNotFound)
+}
+
+// IsNotAllowed reports whether err is (or wraps) a *ServerError whose Kind is
+// "NotAllowed" -- a permission failure, disallowed method/function/net
+// target, blocked scripting, or authentication failure. Returns false for
+// nil, for errors that aren't a *ServerError, and for a *ServerError with a
+// different Kind.
+func IsNotAllowed(err error) bool {
+	return hasKind(err, KindNotAllowed)
+}
+
+// IsTransactionConflict reports whether err is a *ServerError representing a
+// Query/TransactionConflict failure -- a concurrent transaction wrote to the
+// same data. Such errors are safe to retry. Mirrors
+// QueryError.isTransactionConflict in surrealdb.js's errors.ts.
+func IsTransactionConflict(err error) bool {
+	return hasDetailKind(err, KindQuery, detailKindTransactionConflict)
+}
+
+// IsTimedOut reports whether err is a *ServerError representing a
+// Query/TimedOut failure -- the query exceeded its configured timeout.
+// Mirrors QueryError.isTimedOut in surrealdb.js's errors.ts.
+func IsTimedOut(err error) bool {
+	return hasDetailKind(err, KindQuery, detailKindTimedOut)
+}
+
+// IsNotExecuted reports whether err is a *ServerError representing a
+// Query/NotExecuted failure -- the query was never run, typically because an
+// earlier statement in the same batch/transaction failed. Mirrors
+// QueryError.isNotExecuted in surrealdb.js's errors.ts.
+func IsNotExecuted(err error) bool {
+	return hasDetailKind(err, KindQuery, detailKindNotExecuted)
+}
+
+// IsCancelled reports whether err is a *ServerError representing a canceled
+// Query (see detailKindCancelled for the server's exact wire spelling).
+// Mirrors QueryError.isCancelled in surrealdb.js's errors.ts.
+func IsCancelled(err error) bool {
+	return hasDetailKind(err, KindQuery, detailKindCancelled)
+}
+
+// IsParseError reports whether err is a *ServerError representing a
+// Validation/Parse failure -- a SurrealQL parse error. Mirrors
+// ValidationError.isParseError in surrealdb.js's errors.ts.
+func IsParseError(err error) bool {
+	return hasDetailKind(err, KindValidation, detailKindParse)
+}
+
+// IsDeserialization reports whether err is a *ServerError representing a
+// Serialization/Deserialization failure, as opposed to a serialization
+// failure. Mirrors SerializationError.isDeserialization in surrealdb.js's
+// errors.ts.
+func IsDeserialization(err error) bool {
+	return hasDetailKind(err, KindSerialization, detailKindDeserialization)
+}
+
+// IsLiveQueryNotSupported reports whether err is a *ServerError representing
+// a Configuration/LiveQueryNotSupported failure -- live queries are not
+// supported by the server configuration. Mirrors
+// ConfigurationError.isLiveQueryNotSupported in surrealdb.js's errors.ts.
+func IsLiveQueryNotSupported(err error) bool {
+	return hasDetailKind(err, KindConfiguration, detailKindLiveQueryNotSupported)
+}
+
+// IsScriptingBlocked reports whether err is a *ServerError representing a
+// NotAllowed/Scripting failure -- server-side scripting is blocked. Mirrors
+// NotAllowedError.isScriptingBlocked in surrealdb.js's errors.ts.
+func IsScriptingBlocked(err error) bool {
+	return hasDetailKind(err, KindNotAllowed, detailKindScripting)
+}
+
+// IsTokenExpired reports whether err is a *ServerError representing a
+// NotAllowed/Auth/TokenExpired failure -- the auth token used for the
+// request has expired. Mirrors NotAllowedError.isTokenExpired in
+// surrealdb.js's errors.ts.
+func IsTokenExpired(err error) bool {
+	return hasAuthDetailKind(err, detailKindTokenExpired)
+}
+
+// IsInvalidAuth reports whether err is a *ServerError representing a
+// NotAllowed/Auth/InvalidAuth failure -- the supplied credentials were
+// invalid. Mirrors NotAllowedError.isInvalidAuth in surrealdb.js's
+// errors.ts.
+func IsInvalidAuth(err error) bool {
+	return hasAuthDetailKind(err, detailKindInvalidAuth)
+}

--- a/pkg/connection/server_error_kind_test.go
+++ b/pkg/connection/server_error_kind_test.go
@@ -1,0 +1,234 @@
+package connection
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestKindHelpers_TopLevelKind exercises the Is* helpers that only check the
+// top-level ServerError.Kind (IsNotFound, IsNotAllowed), across a matching
+// error, a same-family-but-different-detail error (to prove the helper isn't
+// a tautology that always returns true for any *ServerError), a
+// non-ServerError error, and nil.
+func TestKindHelpers_TopLevelKind(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(error) bool
+		kind string
+	}{
+		{"IsNotFound", IsNotFound, KindNotFound},
+		{"IsNotAllowed", IsNotAllowed, KindNotAllowed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("matching kind", func(t *testing.T) {
+				err := &ServerError{Kind: tt.kind, Message: "boom"}
+				assert.True(t, tt.fn(err))
+			})
+
+			t.Run("different kind", func(t *testing.T) {
+				err := &ServerError{Kind: KindInternal, Message: "boom"}
+				if tt.kind == KindInternal {
+					err.Kind = KindThrown
+				}
+				assert.False(t, tt.fn(err))
+			})
+
+			t.Run("wrapped matching kind", func(t *testing.T) {
+				inner := &ServerError{Kind: tt.kind, Message: "boom"}
+				wrapped := &wrapError{err: inner}
+				assert.True(t, tt.fn(wrapped))
+			})
+
+			t.Run("non-ServerError", func(t *testing.T) {
+				assert.False(t, tt.fn(errors.New("boom")))
+			})
+
+			t.Run("nil", func(t *testing.T) {
+				assert.False(t, tt.fn(nil))
+			})
+		})
+	}
+}
+
+// wrapError wraps an error the same way callers commonly would (e.g. with
+// fmt.Errorf("%w", err) or a custom error implementing Unwrap), to confirm
+// the helpers unwrap via errors.As rather than requiring an exact
+// *ServerError at the top of the chain.
+type wrapError struct{ err error }
+
+func (w *wrapError) Error() string { return "wrapped: " + w.err.Error() }
+func (w *wrapError) Unwrap() error { return w.err }
+
+// TestKindHelpers_NestedDetailKind exercises the Is* helpers that check a
+// nested Details.kind alongside the top-level Kind (e.g. Query +
+// TransactionConflict). For each helper we verify: true for a ServerError
+// with the exact Kind+Details shape, false when the Kind matches but the
+// nested detail kind doesn't (proving the helper actually inspects Details,
+// not just Kind), false when the Kind doesn't match at all, false for a
+// non-ServerError error, and false for nil.
+func TestKindHelpers_NestedDetailKind(t *testing.T) {
+	tests := []struct {
+		name           string
+		fn             func(error) bool
+		kind           string
+		matchingDetail any
+		otherDetail    any
+	}{
+		{
+			name:           "IsTransactionConflict",
+			fn:             IsTransactionConflict,
+			kind:           KindQuery,
+			matchingDetail: map[string]any{"kind": "TransactionConflict"},
+			otherDetail:    map[string]any{"kind": "TimedOut"},
+		},
+		{
+			name:           "IsTimedOut",
+			fn:             IsTimedOut,
+			kind:           KindQuery,
+			matchingDetail: map[string]any{"kind": "TimedOut"},
+			otherDetail:    map[string]any{"kind": detailKindCancelled},
+		},
+		{
+			name:           "IsNotExecuted",
+			fn:             IsNotExecuted,
+			kind:           KindQuery,
+			matchingDetail: map[string]any{"kind": "NotExecuted"},
+			otherDetail:    map[string]any{"kind": detailKindCancelled},
+		},
+		{
+			name:           "IsCancelled",
+			fn:             IsCancelled,
+			kind:           KindQuery,
+			matchingDetail: map[string]any{"kind": detailKindCancelled},
+			otherDetail:    map[string]any{"kind": "NotExecuted"},
+		},
+		{
+			name:           "IsParseError",
+			fn:             IsParseError,
+			kind:           KindValidation,
+			matchingDetail: map[string]any{"kind": "Parse"},
+			otherDetail:    map[string]any{"kind": "InvalidParams"},
+		},
+		{
+			name:           "IsDeserialization",
+			fn:             IsDeserialization,
+			kind:           KindSerialization,
+			matchingDetail: map[string]any{"kind": "Deserialization"},
+			otherDetail:    map[string]any{"kind": "Serialization"},
+		},
+		{
+			name:           "IsLiveQueryNotSupported",
+			fn:             IsLiveQueryNotSupported,
+			kind:           KindConfiguration,
+			matchingDetail: map[string]any{"kind": "LiveQueryNotSupported"},
+			otherDetail:    map[string]any{"kind": "BadGraphqlConfig"},
+		},
+		{
+			name:           "IsScriptingBlocked",
+			fn:             IsScriptingBlocked,
+			kind:           KindNotAllowed,
+			matchingDetail: map[string]any{"kind": "Scripting"},
+			otherDetail:    map[string]any{"kind": "Method", "details": map[string]any{"name": "foo"}},
+		},
+		{
+			name: "IsTokenExpired",
+			fn:   IsTokenExpired,
+			kind: KindNotAllowed,
+			matchingDetail: map[string]any{
+				"kind":    "Auth",
+				"details": map[string]any{"kind": "TokenExpired"},
+			},
+			otherDetail: map[string]any{
+				"kind":    "Auth",
+				"details": map[string]any{"kind": "InvalidAuth"},
+			},
+		},
+		{
+			name: "IsInvalidAuth",
+			fn:   IsInvalidAuth,
+			kind: KindNotAllowed,
+			matchingDetail: map[string]any{
+				"kind":    "Auth",
+				"details": map[string]any{"kind": "InvalidAuth"},
+			},
+			otherDetail: map[string]any{
+				"kind":    "Auth",
+				"details": map[string]any{"kind": "TokenExpired"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("matching kind and detail", func(t *testing.T) {
+				err := &ServerError{Kind: tt.kind, Details: tt.matchingDetail}
+				assert.True(t, tt.fn(err), "expected true for matching Kind+Details")
+			})
+
+			t.Run("matching kind, different detail", func(t *testing.T) {
+				err := &ServerError{Kind: tt.kind, Details: tt.otherDetail}
+				assert.False(t, tt.fn(err), "expected false when Details doesn't match")
+			})
+
+			t.Run("different kind entirely", func(t *testing.T) {
+				otherKind := KindInternal
+				if tt.kind == KindInternal {
+					otherKind = KindThrown
+				}
+				err := &ServerError{Kind: otherKind, Details: tt.matchingDetail}
+				assert.False(t, tt.fn(err), "expected false when top-level Kind doesn't match")
+			})
+
+			t.Run("non-ServerError", func(t *testing.T) {
+				assert.False(t, tt.fn(errors.New("boom")))
+			})
+
+			t.Run("nil", func(t *testing.T) {
+				assert.False(t, tt.fn(nil))
+			})
+		})
+	}
+}
+
+// TestIsTokenExpired_and_IsInvalidAuth_AreDistinct proves the two auth
+// helpers actually discriminate on the nested Auth sub-kind, rather than
+// both simply matching any NotAllowed/Auth error indiscriminately.
+func TestIsTokenExpired_and_IsInvalidAuth_AreDistinct(t *testing.T) {
+	tokenExpired := &ServerError{
+		Kind:    KindNotAllowed,
+		Details: map[string]any{"kind": "Auth", "details": map[string]any{"kind": "TokenExpired"}},
+	}
+	invalidAuth := &ServerError{
+		Kind:    KindNotAllowed,
+		Details: map[string]any{"kind": "Auth", "details": map[string]any{"kind": "InvalidAuth"}},
+	}
+
+	assert.True(t, IsTokenExpired(tokenExpired))
+	assert.False(t, IsInvalidAuth(tokenExpired))
+
+	assert.True(t, IsInvalidAuth(invalidAuth))
+	assert.False(t, IsTokenExpired(invalidAuth))
+}
+
+// TestKindHelpers_ServerErrorValue confirms the helpers also work when the
+// *ServerError is reached indirectly (e.g. as the Cause of an outer
+// ServerError), matching the cause-chain traversal already exercised in
+// wire_error_test.go.
+func TestKindHelpers_ServerErrorValue(t *testing.T) {
+	outer := &ServerError{
+		Kind:    KindInternal,
+		Message: "outer",
+		Cause: &ServerError{
+			Kind:    KindQuery,
+			Message: "inner",
+			Details: map[string]any{"kind": "TransactionConflict"},
+		},
+	}
+
+	assert.False(t, IsTransactionConflict(outer), "outer error itself is Internal, not Query")
+	assert.True(t, IsTransactionConflict(errors.Unwrap(outer)), "unwrapped cause is the TransactionConflict")
+}

--- a/types.go
+++ b/types.go
@@ -23,7 +23,76 @@ type RPCError = connection.RPCError
 //	if errors.As(err, &se) {
 //	    fmt.Println(se.Kind, se.Details)
 //	}
+//
+// For ergonomic kind checking without extracting a *ServerError yourself,
+// use the Is* helpers below (e.g. [IsNotFound], [IsNotAllowed]) or compare
+// se.Kind directly against the Kind* constants (e.g. [KindNotFound]).
 type ServerError = connection.ServerError
+
+// Known values for ServerError.Kind. See [connection.KindNotFound] and its
+// siblings for the full list and provenance.
+const (
+	KindValidation    = connection.KindValidation
+	KindConfiguration = connection.KindConfiguration
+	KindThrown        = connection.KindThrown
+	KindQuery         = connection.KindQuery
+	KindSerialization = connection.KindSerialization
+	KindNotAllowed    = connection.KindNotAllowed
+	KindNotFound      = connection.KindNotFound
+	KindAlreadyExists = connection.KindAlreadyExists
+	KindConnection    = connection.KindConnection
+	KindInternal      = connection.KindInternal
+)
+
+// IsNotFound reports whether err is (or wraps) a *ServerError whose Kind is
+// "NotFound". See [connection.IsNotFound].
+var IsNotFound = connection.IsNotFound
+
+// IsNotAllowed reports whether err is (or wraps) a *ServerError whose Kind is
+// "NotAllowed". See [connection.IsNotAllowed].
+var IsNotAllowed = connection.IsNotAllowed
+
+// IsTransactionConflict reports whether err is a *ServerError representing a
+// Query/TransactionConflict failure, safe to retry. See
+// [connection.IsTransactionConflict].
+var IsTransactionConflict = connection.IsTransactionConflict
+
+// IsTimedOut reports whether err is a *ServerError representing a
+// Query/TimedOut failure. See [connection.IsTimedOut].
+var IsTimedOut = connection.IsTimedOut
+
+// IsNotExecuted reports whether err is a *ServerError representing a
+// Query/NotExecuted failure. See [connection.IsNotExecuted].
+var IsNotExecuted = connection.IsNotExecuted
+
+// IsCancelled reports whether err is a *ServerError representing a canceled
+// query. See [connection.IsCancelled].
+var IsCancelled = connection.IsCancelled
+
+// IsParseError reports whether err is a *ServerError representing a
+// Validation/Parse failure. See [connection.IsParseError].
+var IsParseError = connection.IsParseError
+
+// IsDeserialization reports whether err is a *ServerError representing a
+// Serialization/Deserialization failure. See [connection.IsDeserialization].
+var IsDeserialization = connection.IsDeserialization
+
+// IsLiveQueryNotSupported reports whether err is a *ServerError representing
+// a Configuration/LiveQueryNotSupported failure. See
+// [connection.IsLiveQueryNotSupported].
+var IsLiveQueryNotSupported = connection.IsLiveQueryNotSupported
+
+// IsScriptingBlocked reports whether err is a *ServerError representing a
+// NotAllowed/Scripting failure. See [connection.IsScriptingBlocked].
+var IsScriptingBlocked = connection.IsScriptingBlocked
+
+// IsTokenExpired reports whether err is a *ServerError representing a
+// NotAllowed/Auth/TokenExpired failure. See [connection.IsTokenExpired].
+var IsTokenExpired = connection.IsTokenExpired
+
+// IsInvalidAuth reports whether err is a *ServerError representing a
+// NotAllowed/Auth/InvalidAuth failure. See [connection.IsInvalidAuth].
+var IsInvalidAuth = connection.IsInvalidAuth
 
 // Patch represents a patch object set to MODIFY a record
 type PatchData struct {


### PR DESCRIPTION
## Root cause

`pkg/connection/server_error.go`'s doc comment for `ServerError` promised:

> Use the helper functions in the surrealdb package (`IsNotAllowed`, `IsNotFound`, etc.) for ergonomic kind checking, or inspect Kind directly.

...but no such functions existed anywhere in the repo (`grep -rn '^func Is' --include='*.go'` returns nothing before this PR), and `ServerError.Kind` was a bare `string` with no exported constants to compare against. Callers were forced to hardcode magic strings like `se.Kind == "NotFound"`.

## Fix

- **`pkg/connection/server_error_kind.go`** (new): `Kind*` constants for the 10 top-level error kinds (`KindNotFound`, `KindNotAllowed`, `KindQuery`, `KindValidation`, `KindConfiguration`, `KindThrown`, `KindSerialization`, `KindAlreadyExists`, `KindConnection`, `KindInternal`), plus `Is*` helper functions that use `errors.As` to extract a `*ServerError` and check `Kind` (and, where needed, the nested `Details` map) against the real wire values:
  - Top-level: `IsNotFound`, `IsNotAllowed`
  - `Query` sub-kinds: `IsTransactionConflict`, `IsTimedOut`, `IsNotExecuted`, `IsCancelled`
  - `Validation` sub-kind: `IsParseError`
  - `Serialization` sub-kind: `IsDeserialization`
  - `Configuration` sub-kind: `IsLiveQueryNotSupported`
  - `NotAllowed` sub-kinds: `IsScriptingBlocked`, `IsTokenExpired`, `IsInvalidAuth`

  `IsTokenExpired`/`IsInvalidAuth` discriminate on the nested `{ kind: "Auth", details: { kind: "TokenExpired" | "InvalidAuth" } }` shape, not just the top-level `NotAllowed` kind, since both those failures share the same top-level `Kind`.

- **`types.go`**: re-exports the same constants/functions from the top-level `surrealdb` package (e.g. `surrealdb.IsNotFound`), matching the existing convention of aliasing `ServerError`/`RPCError`/`Tokens` there, and matching what the doc comment literally promised ("helper functions in the surrealdb package").

- **`pkg/connection/server_error_kind_test.go`** and **`errors_test.go`**: unit tests for every helper covering: matching kind/detail → `true`; same kind family but different detail (e.g. `Query`+`TimedOut` vs `Query`+`TransactionConflict`) → `false` (proves the checks aren't tautological); a completely different top-level `Kind` → `false`; a non-`ServerError` error → `false`; `nil` → `false`. Also covers unwrapping through a wrapping error (`Unwrap() error`) and through a `ServerError.Cause` chain.

## Verification

Wire values were cross-checked against both the JS SDK (`surrealdb.js/packages/sdk/src/errors.ts`, `ErrorKind` map and the `ServerError` subclass getters like `NotAllowedError.isTokenExpired`) and the server's Rust source (`surrealdb/types/src/error.rs`, `ErrorDetails::kind_str` and the `AuthError`/`QueryError`/etc. detail enums), not guessed.

Commands run in this worktree, all passing:

```
$ go build ./...
(no output, success)

$ golangci-lint run ./...
0 issues.

$ go test -v -run "TestKindHelpers|TestIsTokenExpired_and_IsInvalidAuth|TestWireError" ./pkg/connection/...
--- PASS: TestKindHelpers_TopLevelKind
--- PASS: TestKindHelpers_NestedDetailKind
--- PASS: TestIsTokenExpired_and_IsInvalidAuth_AreDistinct
--- PASS: TestKindHelpers_ServerErrorValue
--- PASS: TestWireError_As_RPCError_And_ServerError   (pre-existing, unaffected)
--- PASS: TestWireError_As_ZeroValueCause             (pre-existing, unaffected)
ok  	github.com/surrealdb/surrealdb.go/pkg/connection

$ go test -v -run TestErrorKindHelpers_ReExports ./...
--- PASS: TestErrorKindHelpers_ReExports
ok  	github.com/surrealdb/surrealdb.go
```

These are pure error-matching unit tests with no network calls, so no live SurrealDB server was needed.

## Notes

No related GitHub issue exists (verified no open/closed issue references this doc-comment gap), so per `CONTRIBUTING.md` the branch name omits the issue-number prefix.

Opened as a draft: further JS-parity detail getters exist (e.g. `tableName`/`recordId`/`methodName` string accessors on JS's `NotFoundError`/`AlreadyExistsError`) that were intentionally left out of this PR's scope since they return values rather than booleans and would be a separate, larger API surface decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)