### PR TITLE
release: surrealdb@v1.6.0

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
   "name": "surrealdb",
-  "version": "1.0.0",
+  "version": "1.6.0",
   "signGitTag": false
 }


### PR DESCRIPTION
## Summary
Version bump covering the two changes merged to `main` since the last release (v1.5.1) that haven't been tagged/released yet:

- #413 — Add `ServerError` kind constants and `Is*` helper functions (additive, non-breaking) → **minor**
- #412 — Fix `Range`/`RecordRangeID.String()` bugs (bug fix) → **patch**

Net effect: **v1.5.1 → v1.6.0** (minor bump, since the window includes a non-breaking feature addition).

## Changes
- `project.json`: `version` `1.0.0` → `1.6.0` (this file hadn't been kept in sync with the actual tag-based releases since v1.0.0; bringing it back in line with reality)

## Test plan
- [x] No functional code changes; version metadata only
- [ ] Maintainer to cut the `v1.6.0` git tag / GitHub Release after merge, per the existing release process

🤖 Generated with [Claude Code](https://claude.com/claude-code)